### PR TITLE
Add click-out closing for popups/panels

### DIFF
--- a/js/elite-add.js
+++ b/js/elite-add.js
@@ -30,6 +30,7 @@
       box.innerHTML='';
       add.removeEventListener('click',onAdd);
       cls.removeEventListener('click',onCancel);
+      pop.removeEventListener('click',onOutside);
       sels.forEach(s=>s.removeEventListener('change',check));
     }
     function onAdd(){
@@ -40,6 +41,12 @@
       cb(levels);
     }
     function onCancel(){ close(); cb(null); }
+    function onOutside(e){
+      if(!pop.querySelector('.popup-inner').contains(e.target)){
+        close();
+        cb(null);
+      }
+    }
     function check(){
       for(let i=0;i<groups.length;i++){
         const sgs=box.querySelectorAll(`select[data-group="${i}"]`);
@@ -52,6 +59,7 @@
     check();
     add.addEventListener('click',onAdd);
     cls.addEventListener('click',onCancel);
+    pop.addEventListener('click',onOutside);
   }
 
   function splitComma(str){

--- a/js/exceptionellt.js
+++ b/js/exceptionellt.js
@@ -22,6 +22,7 @@
       box.innerHTML='';
       box.removeEventListener('click',onClick);
       cls.removeEventListener('click',onCancel);
+      pop.removeEventListener('click',onOutside);
     }
     function onClick(e){
       const b=e.target.closest('button[data-i]');
@@ -31,8 +32,15 @@
       cb(options[idx]);
     }
     function onCancel(){ close(); cb(null); }
+    function onOutside(e){
+      if(!pop.querySelector('.popup-inner').contains(e.target)){
+        close();
+        cb(null);
+      }
+    }
     box.addEventListener('click',onClick);
     cls.addEventListener('click',onCancel);
+    pop.addEventListener('click',onOutside);
   }
 
   function pickTrait(used, cb){

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -69,6 +69,7 @@
       pop.classList.remove('open');
       box.removeEventListener('click', onBtn);
       cls.removeEventListener('click', close);
+      pop.removeEventListener('click', onOutside);
       box.innerHTML = '';                      // rensa bort gamla knappar
     };
     const onBtn = e => {
@@ -78,9 +79,16 @@
       close();
       callback(idx);
     };
+    const onOutside = e => {
+      if(!pop.querySelector('.popup-inner').contains(e.target)){
+        close();
+        callback(null);
+      }
+    };
 
     box.addEventListener('click', onBtn);
     cls.addEventListener('click', close);
+    pop.addEventListener('click', onOutside);
   }
 
   function openCustomPopup(callback) {
@@ -102,6 +110,7 @@
       pop.classList.remove('open');
       add.removeEventListener('click', onAdd);
       cancel.removeEventListener('click', onCancel);
+      pop.removeEventListener('click', onOutside);
       name.value = '';
       dIn.value = sIn.value = oIn.value = '';
       desc.value = '';
@@ -121,9 +130,16 @@
       callback(entry);
     };
     const onCancel = () => { close(); callback(null); };
+    const onOutside = e => {
+      if(!pop.querySelector('.popup-inner').contains(e.target)){
+        close();
+        callback(null);
+      }
+    };
 
     add.addEventListener('click', onAdd);
     cancel.addEventListener('click', onCancel);
+    pop.addEventListener('click', onOutside);
   }
 
   function calcRowCost(row, hasForge, hasAlchemy, hasArtefacter) {

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -17,6 +17,8 @@ class SharedToolbar extends HTMLElement {
     this.render();
     this.cache();
     this.shadowRoot.addEventListener('click', e => this.handleClick(e));
+    this._outsideHandler = e => this.handleOutsideClick(e);
+    document.addEventListener('click', this._outsideHandler);
     this.initSwitchLink();
   }
 
@@ -183,6 +185,16 @@ class SharedToolbar extends HTMLElement {
     if (btn.id === 'filterToggle') return this.toggle('filterPanel');
     /* stäng */
     if (btn.dataset.close) return this.close(btn.dataset.close);
+  }
+
+  handleOutsideClick(e) {
+    const path = e.composedPath();
+    const toggles = ['invToggle','traitsToggle','filterToggle'];
+    if (path.some(el => toggles.includes(el.id))) return;
+    const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));
+    if (openPanel && !path.includes(openPanel)) {
+      openPanel.classList.remove('open');
+    }
   }
 
   toggle(id) {

--- a/js/yrke-panel.js
+++ b/js/yrke-panel.js
@@ -1,4 +1,5 @@
 (function(window){
+  let outsideHandler = null;
   function create() {
     if (document.getElementById('yrkePanel')) return;
     const panel = document.createElement('aside');
@@ -18,12 +19,23 @@
     create();
     document.getElementById('yrkeTitle').textContent = title || '';
     document.getElementById('yrkeContent').innerHTML = html || '';
-    document.getElementById('yrkePanel').classList.add('open');
+    const panel = document.getElementById('yrkePanel');
+    panel.classList.add('open');
+    outsideHandler = e => {
+      if(!panel.contains(e.target)){
+        close();
+      }
+    };
+    setTimeout(()=>document.addEventListener('click', outsideHandler));
   }
 
   function close(){
     const p = document.getElementById('yrkePanel');
     if(p) p.classList.remove('open');
+    if(outsideHandler){
+      document.removeEventListener('click', outsideHandler);
+      outsideHandler = null;
+    }
   }
 
   window.yrkePanel = { open, close };


### PR DESCRIPTION
## Summary
- allow closing popups when clicking outside
- close off-canvas panels on outside click
- add global outside-click handler for yrke panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68766cfa8fd48323814b929afb8743b5