### PR TITLE
Support multiple advantages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -171,6 +171,15 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
 }
 .inv-controls button { align-self: initial; }
 
+.count-badge {
+  margin-left: .3rem;
+  background: var(--border);
+  color: var(--txt);
+  padding: 0 .4rem;
+  border-radius: .5rem;
+  font-size: .85rem;
+}
+
 /* ---------- Fast verktygsrad ---------- */
 .toolbar {
   position: fixed;

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -52,8 +52,20 @@ function initCharacter() {
       .sort(sortByType);
 
   const renderSkills = arr=>{
-    dom.valda.innerHTML = arr.length ? '' : '<li class="card">Inga träffar.</li>';
+    const groups = [];
     arr.forEach(p=>{
+      const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel') && !p.trait;
+      if(multi){
+        const g = groups.find(x=>x.entry.namn===p.namn);
+        if(g) { g.count++; return; }
+        groups.push({entry:p, count:1});
+      } else {
+        groups.push({entry:p, count:1});
+      }
+    });
+    dom.valda.innerHTML = groups.length ? '' : '<li class="card">Inga träffar.</li>';
+    groups.forEach(g=>{
+      const p = g.entry;
       const lvlSel=p.nivåer?`<select class="level" data-name="${p.namn}"${p.trait?` data-trait="${p.trait}"`:''}>
         ${LVL.filter(l=>p.nivåer[l]).map(l=>`<option${l===p.nivå?' selected':''}>${l}</option>`).join('')}
       </select>`:'';
@@ -80,8 +92,9 @@ function initCharacter() {
       const li=document.createElement('li');li.className='card';li.dataset.name=p.namn;
       if(p.trait) li.dataset.trait=p.trait;
       if(p.trait) li.dataset.trait=p.trait;
+      const badge = g.count>1 ? ` <span class="count-badge">×${g.count}</span>` : '';
       const traitInfo = p.trait ? `<br><strong>Karaktärsdrag:</strong> ${p.trait}` : '';
-      li.innerHTML = `<div class="card-title">${p.namn}</div>${lvlSel}
+      li.innerHTML = `<div class="card-title">${p.namn}${badge}</div>${lvlSel}
         <div class="card-desc">${desc}${traitInfo}</div>
         ${info}<button class="char-btn danger icon" data-act="rem">🗑</button>`;
       dom.valda.appendChild(li);
@@ -131,7 +144,21 @@ function initCharacter() {
     const name = liEl.dataset.name;
     const tr = liEl.dataset.trait || null;
     const before = storeHelper.getCurrentList(store);
-    const list = before.filter(x => !(x.namn===name && (tr?x.trait===tr:!x.trait)));
+    const p = DB.find(x=>x.namn===name) || before.find(x=>x.namn===name);
+    let list;
+    const multi = p && p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel') && !tr;
+    if(multi){
+      let removed=false;
+      list=[];
+      for(const it of before){
+        if(!removed && it.namn===name && !it.trait){
+          removed=true; continue;
+        }
+        list.push(it);
+      }
+    }else{
+      list = before.filter(x => !(x.namn===name && (tr?x.trait===tr:!x.trait)));
+    }
     if(eliteReq.canChange(before) && !eliteReq.canChange(list)){
       if(!confirm('Förmågan krävs för ett valt elityrke. Ta bort ändå?'))
         return;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -77,15 +77,25 @@ function initIndex() {
       } else if (isYrke(p) || isElityrke(p)) {
         info = `<button class="char-btn" data-yrke="${p.namn}">Arketyp</button>`;
       }
-      const btn  = inChar
-        ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
-        : `<button data-act="add" class="char-btn" data-name="${p.namn}">Lägg till</button>`;
+      const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel');
+      const count = charList.filter(c => c.namn===p.namn && !c.trait).length;
+      const badge = multi && count>0 ? ` <span class="count-badge">×${count}</span>` : '';
+      let btn = '';
+      if(multi){
+        const addBtn = count<3 ? `<button data-act="add" class="char-btn" data-name="${p.namn}">+</button>` : '';
+        const remBtn = count>0 ? `<button data-act="rem" class="char-btn danger" data-name="${p.namn}">−</button>` : '';
+        btn = `<div class="inv-controls">${addBtn}${remBtn}</div>`;
+      }else{
+        btn = inChar
+          ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
+          : `<button data-act="add" class="char-btn" data-name="${p.namn}">Lägg till</button>`;
+      }
       const eliteBtn = isElityrke(p)
         ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
         : '';
       const li=document.createElement('li'); li.className='card';
       li.innerHTML = `
-        <div class="card-title">${p.namn}</div>
+        <div class="card-title">${p.namn}${badge}</div>
         ${(p.taggar.typ||[])
           .concat(explodeTags(p.taggar.ark_trad), p.taggar.test||[])
           .map(t=>`<span class="tag">${t}</span>`).join(' ')}
@@ -243,6 +253,16 @@ function initIndex() {
           });
           return;
         }
+        const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel');
+        if(multi){
+          const cnt = list.filter(x=>x.namn===p.namn && !x.trait).length;
+          if(cnt >= 3){
+            alert('Denna fördel kan bara tas tre gånger.');
+            return;
+          }
+        }else if(list.some(x=>x.namn===p.namn && !x.trait)){
+          return;
+        }
         list.push({ ...p, nivå: lvl });
         storeHelper.setCurrentList(store, list); updateXP();
       }
@@ -258,7 +278,21 @@ function initIndex() {
       } else {
         const tr = btn.closest('li').dataset.trait || null;
         const before = storeHelper.getCurrentList(store);
-        const list = before.filter(x => !(x.namn===p.namn && (tr?x.trait===tr:!x.trait)));
+        let list;
+        const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel');
+        if(multi){
+          let removed=false;
+          list = [];
+          for(const it of before){
+            if(!removed && it.namn===p.namn && (tr?it.trait===tr:!it.trait)){
+              removed=true;
+              continue;
+            }
+            list.push(it);
+          }
+        }else{
+          list = before.filter(x => !(x.namn===p.namn && (tr?x.trait===tr:!x.trait)));
+        }
         if(eliteReq.canChange(before) && !eliteReq.canChange(list)) {
           if(!confirm('Förmågan krävs för ett valt elityrke. Ta bort ändå?'))
             return;


### PR DESCRIPTION
## Summary
- show a badge for how many times an advantage is taken
- allow adding the same advantage up to three times
- display counts in character view and remove one at a time

## Testing
- `node --check js/index-view.js`
- `node --check js/character-view.js`


------
https://chatgpt.com/codex/tasks/task_e_6876aa1b08408323970f49b44e8b3970