### PR TITLE
Add compact index entry view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -147,6 +147,7 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
 }
 .card-title { font-size: 1.34rem; font-weight: 600; }
 .card-desc  { font-size: 1.15rem; }
+.card.compact .card-desc { display: none; }
 
 .card button {
   align-self: flex-end;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -4,6 +4,8 @@ function initIndex() {
   let sTemp = '';
   let union = storeHelper.getFilterUnion(store);
   dom.filterUnion.classList.toggle('active', union);
+  let compact = storeHelper.getCompactEntries(store);
+  dom.entryViewToggle.classList.toggle('active', compact);
 
   /* fyll dropdowns */
   (()=>{
@@ -51,6 +53,7 @@ function initIndex() {
   const renderList = arr=>{
     dom.lista.innerHTML = arr.length ? '' : '<li class="card">Inga träffar.</li>';
     const charList = storeHelper.getCurrentList(store);
+    const compact = storeHelper.getCompactEntries(store);
     arr.forEach(p=>{
       const isEx = p.namn === 'Exceptionellt karakt\u00e4rsdrag';
       const inChar = isEx ? false : charList.some(c=>c.namn===p.namn);
@@ -95,15 +98,15 @@ function initIndex() {
       const eliteBtn = isElityrke(p)
         ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
         : '';
-      const li=document.createElement('li'); li.className='card';
+      const li=document.createElement('li'); li.className='card' + (compact ? ' compact' : '');
       li.innerHTML = `
         <div class="card-title">${p.namn}${badge}</div>
         ${(p.taggar.typ||[])
           .concat(explodeTags(p.taggar.ark_trad), p.taggar.test||[])
           .map(t=>`<span class="tag">${t}</span>`).join(' ')}
         ${lvlSel}
-        <div class="card-desc">${desc}</div>
-        ${info}${btn}${eliteBtn}`;
+        ${compact ? '' : `<div class="card-desc">${desc}</div>`}
+        ${compact ? `<button class="char-btn" data-info="${encodeURIComponent(desc)}">Info</button>` : info}${btn}${eliteBtn}`;
       dom.lista.appendChild(li);
     });
   };
@@ -158,6 +161,13 @@ function initIndex() {
       const name=info.dataset.yrke;
       const p=DB.find(x=>x.namn===name);
       if(p) yrkePanel.open(p.namn,yrkeInfoHtml(p));
+      return;
+    }
+    const info2=e.target.closest('button[data-info]');
+    if(info2){
+      const html=decodeURIComponent(info2.dataset.info||'');
+      const title=info2.closest('li')?.querySelector('.card-title')?.textContent||'';
+      yrkePanel.open(title,html);
       return;
     }
     const btn=e.target.closest('button[data-act]');

--- a/js/main.js
+++ b/js/main.js
@@ -42,6 +42,7 @@ const dom  = {
   sIn   : $T('searchField'),  typSel : $T('typFilter'),
   arkSel: $T('arkFilter'),    tstSel : $T('testFilter'),
   filterUnion: $T('filterUnion'),
+  entryViewToggle: $T('entryViewToggle'),
 
   /* element i main-DOM */
   active : document.getElementById('activeFilters'),
@@ -252,6 +253,14 @@ function bindToolbar() {
       const val = dom.artBtn.classList.toggle('active');
       storeHelper.setPartyArtefacter(store, val);
       invUtil.renderInventory();
+      if (window.indexViewUpdate) window.indexViewUpdate();
+    });
+  }
+  if (dom.entryViewToggle) {
+    if (storeHelper.getCompactEntries(store)) dom.entryViewToggle.classList.add('active');
+    dom.entryViewToggle.addEventListener('click', () => {
+      const val = dom.entryViewToggle.classList.toggle('active');
+      storeHelper.setCompactEntries(store, val);
       if (window.indexViewUpdate) window.indexViewUpdate();
     });
   }

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -132,6 +132,7 @@ class SharedToolbar extends HTMLElement {
           <button id="partyAlchemist" class="party-toggle">⚗️</button>
           <button id="partyArtefacter" class="party-toggle">🏺</button>
           <button id="filterUnion" class="party-toggle" title="Matcha någon tag (OR)">🔭</button>
+          <button id="entryViewToggle" class="party-toggle" title="Växla kompakt vy">📄</button>
         </div>
       </aside>
 
@@ -172,6 +173,7 @@ class SharedToolbar extends HTMLElement {
       traitsPanel: $('traitsPanel'),
       filterPanel: $('filterPanel')
     };
+    this.entryViewToggle = $('entryViewToggle');
   }
 
   /* ------------------------------------------------------- */

--- a/js/store.js
+++ b/js/store.js
@@ -13,7 +13,8 @@
       current: '',          // id för vald karaktär
       characters: [],       // [{ id, name }]
       data: {},             // { [charId]: { list: [...], inventory: [], custom: [] } }
-      filterUnion: false
+      filterUnion: false,
+      compactEntries: false
     };
   }
 
@@ -145,6 +146,15 @@
     save(store);
   }
 
+  function getCompactEntries(store) {
+    return Boolean(store.compactEntries);
+  }
+
+  function setCompactEntries(store, val) {
+    store.compactEntries = Boolean(val);
+    save(store);
+  }
+
   function normalizeMoney(m) {
     const res = { ...defaultMoney(), ...(m || {}) };
     res.skilling += Math.floor(res["örtegar"] / 10);
@@ -247,6 +257,8 @@ function defaultTraits() {
     setPartyArtefacter,
     getFilterUnion,
     setFilterUnion,
+    getCompactEntries,
+    setCompactEntries,
     normalizeMoney,
     getTraits,
     setTraits,


### PR DESCRIPTION
## Summary
- add `compactEntries` option in store
- insert entry view toggle button in toolbar
- bind toggle in main logic
- support compact display mode in index view
- hide description via new CSS rule

## Testing
- `node -c js/*.js`

------
https://chatgpt.com/codex/tasks/task_e_6876afe869a88323975401238c9d85d4