### PR TITLE
Fix yrke panel listener duplication

### DIFF
--- a/js/yrke-panel.js
+++ b/js/yrke-panel.js
@@ -20,13 +20,19 @@
     document.getElementById('yrkeTitle').textContent = title || '';
     document.getElementById('yrkeContent').innerHTML = html || '';
     const panel = document.getElementById('yrkePanel');
+
+    // Ensure any previous listener is removed to avoid duplicates
+    if(outsideHandler){
+      document.removeEventListener('click', outsideHandler);
+    }
+
     panel.classList.add('open');
     outsideHandler = e => {
       if(!panel.contains(e.target)){
         close();
       }
     };
-    setTimeout(()=>document.addEventListener('click', outsideHandler));
+    setTimeout(() => document.addEventListener('click', outsideHandler));
   }
 
   function close(){


### PR DESCRIPTION
## Summary
- remove any previous outside click handler before opening the panel to avoid leftover listeners

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876b52b533c8323b790c2b31c68938c