### PR TITLE
Fix inventory buttons wrapping on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -169,6 +169,8 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
   align-self: flex-end;
   display: flex;
   gap: .4rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 .inv-controls button { align-self: initial; }
 


### PR DESCRIPTION
## Summary
- allow inventory control buttons to wrap and stay within the card

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6877920768fc8323a28126f906933175