### PR TITLE
Restrict qualities to weapons and armor

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -181,10 +181,7 @@ function initIndex() {
       if (!inv.length) return alert('Ingen utrustning i inventariet.');
       const elig = inv.filter(it => {
         const tag = (invUtil.getEntry(it.name)?.taggar?.typ) || [];
-        return !(
-          ['Diverse','Elixir','Mat','Dryck'].some(t => tag.includes(t)) ||
-          (tag.includes('L\u00e4gre Artefakt') && !['Vapen','Rustning'].some(t => tag.includes(t)))
-        );
+        return ['Vapen','Rustning'].some(t => tag.includes(t));
       });
  if (!elig.length) return alert('Ingen lämplig utrustning att förbättra.');
  invUtil.openQualPopup(elig, iIdx => {

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -355,10 +355,7 @@
 
           /* — knappar — */
           const isGear = ['Vapen', 'Rustning', 'L\u00e4gre Artefakt'].some(t => tagTyp.includes(t));
-          let allowQual = !['Diverse','Elixir','Mat','Dryck'].some(t => tagTyp.includes(t));
-          if (tagTyp.includes('L\u00e4gre Artefakt') && !['Vapen','Rustning'].some(t => tagTyp.includes(t))) {
-            allowQual = false;
-          }
+          const allowQual = ['Vapen','Rustning'].some(t => tagTyp.includes(t));
  const btnRow = isGear
   ? `<button data-act="del" class="char-btn danger">🗑</button>`
   : `<button data-act="add" class="char-btn">+</button>
@@ -513,10 +510,7 @@
       // "K+" öppnar popup för att lägga kvalitet
       if (act === 'addQual') {
         const tagTyp = (entry.taggar?.typ || []);
-        if (
-          ['Diverse','Elixir','Mat','Dryck'].some(t => tagTyp.includes(t)) ||
-          (tagTyp.includes('L\u00e4gre Artefakt') && !['Vapen','Rustning'].some(t => tagTyp.includes(t)))
-        ) return;
+        if (!['Vapen','Rustning'].some(t => tagTyp.includes(t))) return;
         const qualities = DB.filter(isQual);
         openQualPopup(qualities, qIdx => {
           if (idx >= 0 && qualities[qIdx]) {


### PR DESCRIPTION
## Summary
- only show `K+` when item is tagged as `Vapen` or `Rustning`
- enforce the same rule when adding qualities from the index view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687791cc3d1483239222b778988ced1b