### PR TITLE
Adjust button ordering for UI controls

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -346,9 +346,9 @@
           const allowQual = ['Vapen','Rustning'].some(t => tagTyp.includes(t));
  const btnRow = isGear
   ? `<button data-act="del" class="char-btn danger">🗑</button>`
-  : `<button data-act="add" class="char-btn">+</button>
+  : `<button data-act="del" class="char-btn danger">🗑</button>
       <button data-act="sub" class="char-btn">–</button>
-      <button data-act="del" class="char-btn danger">🗑</button>`;
+      <button data-act="add" class="char-btn">+</button>`;
           const freeCnt = Number(row.gratis || 0);
           const freeBtn = `<button data-act="free" class="char-btn${freeCnt? ' danger':''}">🆓</button>`;
           const freeQBtn = allowQual ? `<button data-act="freeQual" class="char-btn">K🆓</button>` : '';


### PR DESCRIPTION
## Summary
- reorder inventory controls so delete is far left and add is far right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877958a252c8323aee91c3753f493de