### PR TITLE
Remove elixir level dropdown

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -71,9 +71,12 @@ function initCharacter() {
     dom.valda.innerHTML = groups.length ? '' : '<li class="card">Inga träffar.</li>';
     groups.forEach(g=>{
       const p = g.entry;
-      const lvlSel=p.nivåer?`<select class="level" data-name="${p.namn}"${p.trait?` data-trait="${p.trait}"`:''}>
-        ${LVL.filter(l=>p.nivåer[l]).map(l=>`<option${l===p.nivå?' selected':''}>${l}</option>`).join('')}
-      </select>`:'';
+      const availLvls = LVL.filter(l=>p.nivåer?.[l]);
+      const lvlSel = availLvls.length>1
+        ? `<select class="level" data-name="${p.namn}"${p.trait?` data-trait="${p.trait}"`:''}>
+            ${availLvls.map(l=>`<option${l===p.nivå?' selected':''}>${l}</option>`).join('')}
+          </select>`
+        : '';
       const idx=LVL.indexOf(p.nivå);
       let desc = '';
       const base = formatText(p.beskrivning || '');
@@ -185,7 +188,8 @@ function initCharacter() {
         return;
       }
       const lvlSel = liEl.querySelector('select.level');
-      const lvl = lvlSel ? lvlSel.value : p.nivå;
+      let   lvl = lvlSel ? lvlSel.value : null;
+      if (!lvl && p.nivåer) lvl = LVL.find(l => p.nivåer[l]) || p.nivå;
       list = [...before, { ...p, nivå: lvl }];
     }else if(actBtn.dataset.act==='rem'){
       if(multi){

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -353,12 +353,8 @@
           const freeBtn = `<button data-act="free" class="char-btn${freeCnt? ' danger':''}">🆓</button>`;
           const freeQBtn = allowQual ? `<button data-act="freeQual" class="char-btn">K🆓</button>` : '';
 
-          const lvlInfo = tagTyp.includes('Elixir') && row.level
-            ? `<br>Nivå: ${row.level}`
-            : '';
-          const dataLevel = tagTyp.includes('Elixir') && row.level
-            ? ` data-level="${row.level}"`
-            : '';
+          const lvlInfo = '';
+          const dataLevel = '';
           const priceText = formatMoney(
             calcRowCost(row, hasForge, hasAlchemy, hasArtefacter)
           );
@@ -455,25 +451,19 @@
         return;
       }
 
-      // 2b) För + / - / K+ behöver vi id och level
+      // 2b) För + / - / K+ behöver vi id
       const itemName = li.dataset.name;
-      const level    = li.dataset.level;
       const entry    = getEntry(itemName);
-      const isElixir = (entry.taggar?.typ || []).includes('Elixir');
 
       // "+" lägger till qty eller en ny instans
       if (act === 'add') {
         const indiv = ['Vapen','Rustning','L\u00e4gre Artefakt'].some(t => entry.taggar.typ.includes(t));
         if (indiv) {
-          const obj = { name: entry.namn, qty: 1, gratis:0, gratisKval:[], removedKval:[] };
-          if (isElixir && level) obj.level = level;
-          inv.push(obj);
+          inv.push({ name: entry.namn, qty: 1, gratis:0, gratisKval:[], removedKval:[] });
         } else if (idx >= 0) {
           inv[idx].qty++;
         } else {
-          const obj = { name: entry.namn, qty: 1, gratis:0, gratisKval:[], removedKval:[] };
-          if (isElixir && level) obj.level = level;
-          inv.push(obj);
+          inv.push({ name: entry.namn, qty: 1, gratis:0, gratisKval:[], removedKval:[] });
         }
         saveInventory(inv);
         renderInventory();


### PR DESCRIPTION
## Summary
- hide level dropdown when an entry only has one level
- drop elixir level handling in inventory and index views
- auto-detect level when adding entries without dropdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d4544194c832393959bb0c85626f7