### PR TITLE
Implement accent-insensitive search

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -38,8 +38,9 @@ function initCharacter() {
   const filtered = () => storeHelper.getCurrentList(store)
       .filter(p => !isInv(p))
       .filter(p => {
-        const terms = [...F.search, ...(sTemp ? [sTemp] : [])].map(t => t.toLowerCase());
-        const text = `${p.namn} ${(p.beskrivning || '')}`.toLowerCase();
+        const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
+          .map(t => searchNormalize(t.toLowerCase()));
+        const text = searchNormalize(`${p.namn} ${(p.beskrivning || '')}`.toLowerCase());
         const txt = terms.every(q => text.includes(q));
         const tags = p.taggar || {};
         const selTags = [...F.typ, ...F.ark, ...F.test];

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -33,8 +33,9 @@ function initIndex() {
   };
 
   const filtered = () => DB.filter(p=>{
-    const terms = [...F.search, ...(sTemp ? [sTemp] : [])].map(t=>t.toLowerCase());
-    const text = `${p.namn} ${(p.beskrivning||'')}`.toLowerCase();
+    const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
+      .map(t => searchNormalize(t.toLowerCase()));
+    const text = searchNormalize(`${p.namn} ${(p.beskrivning||'')}`.toLowerCase());
     const txt = terms.every(q => text.includes(q));
     const tags = p.taggar || {};
     const selTags = [...F.typ, ...F.ark, ...F.test];

--- a/js/utils.js
+++ b/js/utils.js
@@ -70,6 +70,21 @@
     return `${d}D ${s}S ${o}\u00d6`;
   }
 
+  // Normalize text for searches by removing diacritics except for
+  // the Swedish characters å, ä and ö. Everything should be in
+  // lowercase before calling this function.
+  function searchNormalize(str){
+    return str
+      .replace(/\u00e5/g,'__ao__')  // å
+      .replace(/\u00e4/g,'__ae__')  // ä
+      .replace(/\u00f6/g,'__oe__')  // ö
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g,'')
+      .replace(/__ao__/g,'\u00e5')
+      .replace(/__ae__/g,'\u00e4')
+      .replace(/__oe__/g,'\u00f6');
+  }
+
   window.LVL = LVL;
   window.EQUIP = EQUIP;
   window.SBASE = SBASE;
@@ -87,4 +102,5 @@
   window.explodeTags = explodeTags;
   window.splitQuals = splitQuals;
   window.formatMoney = formatMoney;
+  window.searchNormalize = searchNormalize;
 })(window);


### PR DESCRIPTION
## Summary
- support accent-insensitive searching by adding `searchNormalize`
- use `searchNormalize` in index and character views

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687d457adae483238fda7db35bd6724b