### PR TITLE
Use structured HTML for ability descriptions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -149,6 +149,11 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
 .card-desc  { font-size: 1.15rem; }
 .card.compact .card-desc { display: none; }
 
+/* Lista med niva-beskrivningar for formagor */
+.levels { margin-top: .6rem; }
+.levels dt { font-weight: 600; }
+.levels dd { margin: 0 0 .4rem 1rem; }
+
 .card button {
   align-self: flex-end;
   background: var(--accent);

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -79,19 +79,7 @@ function initCharacter() {
           </select>`
         : '';
       const idx=LVL.indexOf(p.nivå);
-      let desc = '';
-      const base = formatText(p.beskrivning || '');
-      if (isYrke(p) || isElityrke(p) || isRas(p)) {
-        desc = base;
-      } else if (p.nivåer) {
-        const levels = LVL.slice(0, idx + 1)
-          .filter(l => p.nivåer[l])
-          .map(l => `<strong>${l}</strong><br>${formatText(p.nivåer[l])}`)
-          .join('<br>');
-        desc = base ? `${base}<br>${levels}` : levels;
-      } else {
-        desc = base;
-      }
+      let desc = abilityHtml(p, p.nivå);
       let infoHtml = desc;
       if (isRas(p) || isYrke(p) || isElityrke(p)) {
         const extra = yrkeInfoHtml(p);

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -66,18 +66,7 @@ function initIndex() {
             ${availLvls.map(l=>`<option${l===curLvl?' selected':''}>${l}</option>`).join('')}
           </select>`
         : '';
-      let desc = '';
-      const base = formatText(p.beskrivning || '');
-      if (isYrke(p) || isElityrke(p) || isRas(p)) {
-        desc = base;
-      } else if (p.nivåer) {
-        const levels = Object.entries(p.nivåer)
-          .map(([l,t]) => `<strong>${l}</strong><br>${formatText(t)}`)
-          .join('<br>');
-        desc = base ? `${base}<br>${levels}` : levels;
-      } else {
-        desc = base;
-      }
+      let desc = abilityHtml(p);
       if (isInv(p) && p.grundpris) {
         desc += `<br>Pris: ${formatMoney(invUtil.calcEntryCost(p))}`;
       }

--- a/js/text-format.js
+++ b/js/text-format.js
@@ -6,5 +6,23 @@
       .replace(/\*([^*]+)\*/g, '<em>$1</em>')
       .replace(/\n/g, '<br>');
   }
+
+  function abilityHtml(p, maxLevel){
+    if(!p) return '';
+    const base = formatText(p.beskrivning || '');
+    if(!p.nivåer) return base;
+    const lvls = [];
+    const levels = (window.LVL || ['Novis','Ges\u00e4ll','M\u00e4stare']);
+    const idx = maxLevel ? levels.indexOf(maxLevel) : -1;
+    const use = idx >= 0 ? levels.slice(0, idx+1) : levels;
+    use.forEach(l => {
+      if(p.nivåer[l]){
+        lvls.push(`<dt>${l}</dt><dd>${formatText(p.nivåer[l])}</dd>`);
+      }
+    });
+    const lvlHtml = `<dl class="levels">${lvls.join('')}</dl>`;
+    return base ? `<p>${base}</p>${lvlHtml}` : lvlHtml;
+  }
   window.formatText = formatText;
+  window.abilityHtml = abilityHtml;
 })(window);


### PR DESCRIPTION
## Summary
- add `abilityHtml` helper
- style ability level lists
- render abilities via `abilityHtml`

## Testing
- `node --check js/text-format.js`
- `node --check js/index-view.js`
- `node --check js/character-view.js`


------
https://chatgpt.com/codex/tasks/task_e_687d4ccdad58832382fd87fba2f89862