### PR TITLE
Implement permanent corruption tracking

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -208,6 +208,44 @@ function defaultTraits() {
 
   const RITUAL_COST = 10;
 
+  const TRAD_TO_SKILL = {
+    'Häxkonst': 'Häxkonster',
+    'Svartkonst': 'Svartkonst',
+    'Ordensmagi': 'Ordensmagi',
+    'Stavmagiker': 'Stavmagi',
+    'Teurgi': 'Teurgi',
+    'Trollsång': 'Trollsång',
+    'Symbolism': 'Symbolism'
+  };
+
+  const LEVEL_IDX = { '': 0, Novis: 1, Gesäll: 2, Mästare: 3 };
+
+  function abilityLevel(list, ability) {
+    const ent = list.find(x => x.namn === ability && (x.taggar?.typ || []).includes('Förmåga'));
+    return LEVEL_IDX[ent?.nivå || ''] || 0;
+  }
+
+  function calcPermanentCorruption(list) {
+    let cor = 0;
+    list.forEach(it => {
+      const types = it.taggar?.typ || [];
+      if (!['Mystisk kraft', 'Ritual'].some(t => types.includes(t))) return;
+      const trads = explodeTags(it.taggar?.ark_trad);
+      let lvl = 0;
+      trads.forEach(tr => {
+        const a = TRAD_TO_SKILL[tr];
+        if (a) lvl = Math.max(lvl, abilityLevel(list, a));
+      });
+      if (types.includes('Mystisk kraft')) {
+        const plvl = LEVEL_IDX[it.nivå || 'Novis'] || 1;
+        if (plvl > lvl) cor++;
+      } else if (types.includes('Ritual')) {
+        if (lvl < 1) cor++;
+      }
+    });
+    return cor;
+  }
+
   function calcUsedXP(list) {
     let xp = 0;
 
@@ -265,6 +303,7 @@ function defaultTraits() {
     getBaseXP,
     setBaseXP,
     calcUsedXP,
-    calcTotalXP
+    calcTotalXP,
+    calcPermanentCorruption
   };
 })(window);

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -38,7 +38,9 @@
       } else if (k === 'Viljestark') {
         const maxCor = strongGift ? val * 2 : val;
         const thresh = strongGift ? val : Math.ceil(val / 2);
-        extra = `<div class="trait-extra">Maximal korruption: ${maxCor} \u2022 Korruptionstr\u00f6skel: ${thresh}</div>`;
+        const perm = storeHelper.calcPermanentCorruption(list);
+        extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` +
+                `<div class="trait-extra">Maximal korruption: ${maxCor} \u2022 Korruptionstr\u00f6skel: ${thresh}</div>`;
       }
       return `
       <div class="trait" data-key="${k}">


### PR DESCRIPTION
## Summary
- compute permanent corruption based on picked powers and rituals
- display permanent corruption under the Viljestark trait

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d4e3e90d883238b99b258cfe5778d