### PR TITLE
Update permanent corruption rules

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -238,7 +238,7 @@ function defaultTraits() {
       });
       if (types.includes('Mystisk kraft')) {
         const plvl = LEVEL_IDX[it.nivå || 'Novis'] || 1;
-        if (plvl > lvl) cor++;
+        if (plvl > lvl) cor += (plvl - lvl);
       } else if (types.includes('Ritual')) {
         if (lvl < 1) cor++;
       }


### PR DESCRIPTION
## Summary
- adjust mystic power corruption so each level above the tradition skill gives +1 permanent corruption

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_687de3dacf148323bd1714796d04b55e