### PR TITLE
Remove Svartkonst from corruption protection list

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -210,7 +210,6 @@ function defaultTraits() {
 
   const TRAD_TO_SKILL = {
     'Häxkonst': 'Häxkonster',
-    'Svartkonst': 'Svartkonst',
     'Ordensmagi': 'Ordensmagi',
     'Stavmagiker': 'Stavmagi',
     'Teurgi': 'Teurgi',


### PR DESCRIPTION
## Summary
- adjust TRAD_TO_SKILL so Svartkonst no longer gives protection against permanent corruption

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687de3f12a948323b97badeb1477f0e9