### PR TITLE
Hide extra info for races and jobs

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -78,6 +78,7 @@ function initCharacter() {
             ${availLvls.map(l=>`<option${l===p.nivå?' selected':''}>${l}</option>`).join('')}
           </select>`
         : '';
+      const hideDetails = isRas(p) || isYrke(p) || isElityrke(p);
       const idx=LVL.indexOf(p.nivå);
       let desc = abilityHtml(p, p.nivå);
       let infoHtml = desc;
@@ -103,10 +104,12 @@ function initCharacter() {
       }else{
         btn = `<button class="char-btn danger icon" data-act="rem">🗑</button>`;
       }
+      const showInfo = compact || hideDetails;
+      const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}${traitInfo}</div>` : '';
       li.innerHTML = `<div class="card-title">${p.namn}${badge}</div>${lvlSel}
 
-        ${compact ? '' : `<div class="card-desc">${desc}${traitInfo}</div>`}
-        ${compact ? infoBtn : ''}${btn}`;
+        ${descHtml}
+        ${showInfo ? infoBtn : ''}${btn}`;
 
       dom.valda.appendChild(li);
     });

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -66,6 +66,7 @@ function initIndex() {
             ${availLvls.map(l=>`<option${l===curLvl?' selected':''}>${l}</option>`).join('')}
           </select>`
         : '';
+      const hideDetails = isRas(p) || isYrke(p) || isElityrke(p);
       let desc = abilityHtml(p);
       if (isInv(p) && p.grundpris) {
         desc += `<br>Pris: ${formatMoney(invUtil.calcEntryCost(p))}`;
@@ -93,13 +94,16 @@ function initIndex() {
         ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
         : '';
       const li=document.createElement('li'); li.className='card' + (compact ? ' compact' : '');
+      const tagsHtml = hideDetails ? '' : (p.taggar.typ||[])
+        .concat(explodeTags(p.taggar.ark_trad), p.taggar.test||[])
+        .map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const levelHtml = hideDetails ? '' : lvlSel;
+      const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
       li.innerHTML = `
         <div class="card-title">${p.namn}${badge}</div>
-        ${(p.taggar.typ||[])
-          .concat(explodeTags(p.taggar.ark_trad), p.taggar.test||[])
-          .map(t=>`<span class="tag">${t}</span>`).join(' ')}
-        ${lvlSel}
-        ${compact ? '' : `<div class="card-desc">${desc}</div>`}
+        ${tagsHtml}
+        ${levelHtml}
+        ${descHtml}
         ${infoBtn}${btn}${eliteBtn}`;
       dom.lista.appendChild(li);
     });


### PR DESCRIPTION
## Summary
- collapse details for races, professions and elite professions
- always show their info in a popup when requested

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687de3a36ea88323a5b413a05e87ead4