### PR TITLE
Fix inventory panel closing on quality add

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -193,6 +193,11 @@ class SharedToolbar extends HTMLElement {
     const path = e.composedPath();
     const toggles = ['invToggle','traitsToggle','filterToggle'];
     if (path.some(el => toggles.includes(el.id))) return;
+
+    // ignore clicks inside popups so panels stay open
+    const popups = ['qualPopup','customPopup','masterPopup'];
+    if (path.some(el => popups.includes(el.id))) return;
+
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));
     if (openPanel && !path.includes(openPanel)) {
       openPanel.classList.remove('open');


### PR DESCRIPTION
## Summary
- keep inventory panel open when selecting quality

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687df7f5e6f08323b0884f1affec57e8