### PR TITLE
Display tags and level in inventory

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -313,10 +313,16 @@
           const tagger  = entry.taggar ?? {};
           const tagTyp  = tagger.typ ?? [];
 
-          /* — beskrivning — */
+          /* — beskrivning / taggar / nivå — */
           // Ingen beskrivningstext ska visas i inventariet.
-          // "desc" används fortfarande för kvaliteter nedan.
+          // "desc" används fortfarande för taggar, nivå och kvaliteter nedan.
           let desc = '';
+          const tags = (tagger.typ || [])
+            .concat(explodeTags(tagger.ark_trad), tagger.test || []);
+          if (tags.length) {
+            const html = tags.map(t => `<span class="tag">${t}</span>`).join(' ');
+            desc += `<div class="tags">${html}</div>`;
+          }
 
           /* — kvaliteter — */
           const removedQ = row.removedKval ?? [];
@@ -353,8 +359,8 @@
           const freeBtn = `<button data-act="free" class="char-btn${freeCnt? ' danger':''}">🆓</button>`;
           const freeQBtn = allowQual ? `<button data-act="freeQual" class="char-btn">K🆓</button>` : '';
 
-          const lvlInfo = '';
-          const dataLevel = '';
+          const lvlInfo = row.nivå ? ` <span class="tag level">${row.nivå}</span>` : '';
+          const dataLevel = row.nivå ? ` data-level="${row.nivå}"` : '';
           const priceText = formatMoney(
             calcRowCost(row, hasForge, hasAlchemy, hasArtefacter)
           );


### PR DESCRIPTION
## Summary
- show tags in inventory item cards
- show item level when available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687df83cabfc832391185369b393c6c3