### PR TITLE
Add artifact effects support

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -196,13 +196,15 @@ function initIndex() {
       if (isInv(p)) {
         const inv = storeHelper.getInventory(store);
         const indiv = ['Vapen','Rustning','L\u00e4gre Artefakt'].some(t=>p.taggar.typ.includes(t));
+        const rowBase = { name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
+        if (p.artifactEffect) rowBase.artifactEffect = p.artifactEffect;
         if (indiv) {
-          inv.push({ name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] });
+          inv.push(rowBase);
         } else {
           const match = inv.find(x => x.name===p.namn);
           if (match) match.qty++;
           else {
-            inv.push({ name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] });
+            inv.push(rowBase);
           }
         }
         invUtil.saveInventory(inv); invUtil.renderInventory();

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -95,6 +95,8 @@
     const pop   = bar.shadowRoot.getElementById('customPopup');
     const name  = bar.shadowRoot.getElementById('customName');
     const type  = bar.shadowRoot.getElementById('customType');
+    const effBox= bar.shadowRoot.getElementById('customArtifactEffect');
+    const effSel= effBox ? effBox.querySelector('select') : null;
     const dIn   = bar.shadowRoot.getElementById('customDaler');
     const sIn   = bar.shadowRoot.getElementById('customSkilling');
     const oIn   = bar.shadowRoot.getElementById('customOrtegar');
@@ -105,6 +107,12 @@
     type.innerHTML = EQUIP.map(t=>`<option>${t}</option>`).join('');
 
     pop.classList.add('open');
+    if(effBox) effBox.style.display = type.value === 'Artefakter' ? '' : 'none';
+
+    const onType = () => {
+      if (effBox) effBox.style.display = type.value === 'Artefakter' ? '' : 'none';
+    };
+    type.addEventListener('change', onType);
 
     const close = () => {
       pop.classList.remove('open');
@@ -114,6 +122,9 @@
       name.value = '';
       dIn.value = sIn.value = oIn.value = '';
       desc.value = '';
+      if (effSel) effSel.value = '';
+      if (effBox) effBox.style.display = 'none';
+      type.removeEventListener('change', onType);
     };
     const onAdd = () => {
       const entry = {
@@ -124,7 +135,8 @@
           skilling: Number(sIn.value)||0,
           'örtegar': Number(oIn.value)||0
         },
-        beskrivning: desc.value.trim()
+        beskrivning: desc.value.trim(),
+        artifactEffect: effSel ? effSel.value : ''
       };
       close();
       callback(entry);
@@ -401,7 +413,7 @@
         list.push(entry);
         storeHelper.setCustomEntries(store, list);
         const inv = storeHelper.getInventory(store);
-        inv.push({ name: entry.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] });
+        inv.push({ name: entry.namn, qty:1, gratis:0, gratisKval:[], removedKval:[], artifactEffect: entry.artifactEffect });
         saveInventory(inv);
         renderInventory();
       });

--- a/js/main.js
+++ b/js/main.js
@@ -271,7 +271,8 @@ function bindToolbar() {
 function updateXP() {
   const list  = storeHelper.getCurrentList(store);
   const base  = storeHelper.getBaseXP(store);
-  const used  = storeHelper.calcUsedXP(list);
+  const effects = storeHelper.getArtifactEffects(store);
+  const used  = storeHelper.calcUsedXP(list, effects);
   const total = storeHelper.calcTotalXP(base, list);
   const free  = total - used;
   dom.xpOut.textContent = free;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -151,6 +151,14 @@ class SharedToolbar extends HTMLElement {
           <h3>Nytt föremål</h3>
           <input id="customName" placeholder="Namn">
           <select id="customType"></select>
+          <div id="customArtifactEffect" class="filter-group" style="display:none">
+            <label for="artifactEffect">Effekt</label>
+            <select id="artifactEffect">
+              <option value="">Ingen</option>
+              <option value="corruption">+1 permanent korruption</option>
+              <option value="xp">\u20131 erfarenhet</option>
+            </select>
+          </div>
           <div class="money-row">
             <input id="customDaler" type="number" min="0" placeholder="Daler">
             <input id="customSkilling" type="number" min="0" placeholder="Skilling">

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -38,7 +38,8 @@
       } else if (k === 'Viljestark') {
         const maxCor = strongGift ? val * 2 : val;
         const thresh = strongGift ? val : Math.ceil(val / 2);
-        const perm = storeHelper.calcPermanentCorruption(list);
+        const effects = storeHelper.getArtifactEffects(store);
+        const perm = storeHelper.calcPermanentCorruption(list, effects);
         extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` +
                 `<div class="trait-extra">Maximal korruption: ${maxCor} \u2022 Korruptionstr\u00f6skel: ${thresh}</div>`;
       }

--- a/js/utils.js
+++ b/js/utils.js
@@ -8,6 +8,7 @@
     'Mat',
     'Dryck',
     'L\u00e4gre Artefakt',
+    'Artefakter',
     'Kl\u00e4der',
     'Musikinstrument',
     'F\u00e4rdmedel',


### PR DESCRIPTION
## Summary
- extend equipment list with "Artefakter"
- add artifact effect selector in custom item popup
- handle artifact effect in openCustomPopup and inventory/index logic
- store artifact effects and include them in XP & corruption calculations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687df8eeaea88323ac202e277b662d5e