### PR TITLE
Add artifact effect handling

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -154,7 +154,6 @@ class SharedToolbar extends HTMLElement {
           <div id="customArtifactEffect" class="filter-group" style="display:none">
             <label for="artifactEffect">Effekt</label>
             <select id="artifactEffect">
-              <option value="">Ingen</option>
               <option value="corruption">+1 permanent korruption</option>
               <option value="xp">\u20131 erfarenhet</option>
             </select>


### PR DESCRIPTION
## Summary
- allow qualities on artifacts
- store artifact effects and update XP
- default custom artifact effect is permanent corruption
- show and toggle artifact effect on items

## Testing
- `node -c js/inventory-utils.js`
- `node -c js/shared-toolbar.js`


------
https://chatgpt.com/codex/tasks/task_e_687dfe79ed988323a4ab6eb3080ca407