### PR TITLE
Add descriptions to party toggles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -84,9 +84,26 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 
 /* Grupp för partytillhörighet */
 .party-toggles {
-  display: flex;
-  gap: .6rem;
+  padding: 0;
   margin-top: .6rem;
+}
+.toggle-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: .6rem;
+}
+.toggle-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.toggle-desc {
+  flex: 1;
+  margin-right: .5rem;
+  font-size: .95rem;
 }
 .party-toggle {
   padding: .45rem .6rem;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -128,11 +128,28 @@ class SharedToolbar extends HTMLElement {
           <select id="testFilter"></select>
         </div>
         <div class="filter-group party-toggles">
-          <button id="partySmith" class="party-toggle">⚒️</button>
-          <button id="partyAlchemist" class="party-toggle">⚗️</button>
-          <button id="partyArtefacter" class="party-toggle">🏺</button>
-          <button id="filterUnion" class="party-toggle" title="Matcha någon tag (OR)">🔭</button>
-          <button id="entryViewToggle" class="party-toggle" title="Växla kompakt vy">🤏</button>
+          <ul class="toggle-list">
+            <li>
+              <span class="toggle-desc">Har du en smed i partyt? Halverar kostnaden för vapen och rustningar.</span>
+              <button id="partySmith" class="party-toggle">⚒️</button>
+            </li>
+            <li>
+              <span class="toggle-desc">Har du en alkemist i partyt? Halverar priset på alla elixir.</span>
+              <button id="partyAlchemist" class="party-toggle">⚗️</button>
+            </li>
+            <li>
+              <span class="toggle-desc">Har du en artefaktmästare i partyt? Denna knapp halverar priset på Lägre Artefakter.</span>
+              <button id="partyArtefacter" class="party-toggle">🏺</button>
+            </li>
+            <li>
+              <span class="toggle-desc">Utvidga sökningen? När detta är aktiverat räcker det att någon av markerade taggar matchar.</span>
+              <button id="filterUnion" class="party-toggle" title="Matcha någon tag (OR)">🔭</button>
+            </li>
+            <li>
+              <span class="toggle-desc">Visa kompakt vy? Slår av eller på kortare listvy.</span>
+              <button id="entryViewToggle" class="party-toggle" title="Växla kompakt vy">🤏</button>
+            </li>
+          </ul>
         </div>
       </aside>
 


### PR DESCRIPTION
## Summary
- list party toggle buttons vertically with text
- style the party toggle list and descriptions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e1ae21fac8323b9b88ae3af37affe