### PR TITLE
Show item stats

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -68,8 +68,11 @@ function initIndex() {
         : '';
       const hideDetails = isRas(p) || isYrke(p) || isElityrke(p);
       let desc = abilityHtml(p);
-      if (isInv(p) && p.grundpris) {
-        desc += `<br>Pris: ${formatMoney(invUtil.calcEntryCost(p))}`;
+      if (isInv(p)) {
+        desc += itemStatHtml(p);
+        if (p.grundpris) {
+          desc += `<br>Pris: ${formatMoney(invUtil.calcEntryCost(p))}`;
+        }
       }
       let infoHtml = desc;
       if (isRas(p) || isYrke(p) || isElityrke(p)) {

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -354,6 +354,7 @@
             const html = tags.map(t => `<span class="tag">${t}</span>`).join(' ');
             desc += `<div class="tags">${html}</div>`;
           }
+          desc += itemStatHtml(entry);
 
           /* — kvaliteter — */
           const removedQ = row.removedKval ?? [];

--- a/js/utils.js
+++ b/js/utils.js
@@ -71,6 +71,25 @@
     return `${d}D ${s}S ${o}\u00d6`;
   }
 
+  // Returnera HTML med skada/skydd-stats för vapen och rustningar
+  function itemStatHtml(entry) {
+    if (!entry) return '';
+    const types = entry.taggar?.typ || [];
+    if (types.includes('Rustning')) {
+      const stats = entry.stat || {};
+      const parts = [];
+      if (stats.skydd) parts.push(`Skydd: ${stats.skydd}`);
+      if (stats.hasOwnProperty('begr\u00e4nsning'))
+        parts.push(`Begr\u00e4nsning: ${stats['begr\u00e4nsning']}`);
+      return parts.length ? `<br>${parts.join(' ')}` : '';
+    }
+    if (types.includes('Vapen')) {
+      const dmg = entry.stat?.skada;
+      return dmg ? `<br>Skada: ${dmg}` : '';
+    }
+    return '';
+  }
+
   // Normalize text for searches by removing diacritics except for
   // the Swedish characters å, ä and ö. Everything should be in
   // lowercase before calling this function.
@@ -103,5 +122,6 @@
   window.explodeTags = explodeTags;
   window.splitQuals = splitQuals;
   window.formatMoney = formatMoney;
+  window.itemStatHtml = itemStatHtml;
   window.searchNormalize = searchNormalize;
 })(window);


### PR DESCRIPTION
## Summary
- show weapon damage or armor stats inside item cards in inventory and index
- expose `itemStatHtml` helper

## Testing
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const code = fs.readFileSync('js/utils.js','utf8');
const sandbox = { window: {} };
vm.runInNewContext(code, sandbox);
const wp = JSON.parse(fs.readFileSync('data/vapen.json'))[0];
const ar = JSON.parse(fs.readFileSync('data/rustning.json'))[0];
console.log('weapon:', sandbox.window.itemStatHtml(wp));
console.log('armor:', sandbox.window.itemStatHtml(ar));
NODE

------
https://chatgpt.com/codex/tasks/task_e_6883af535fb0832383b1c36a721f44ee