### PR TITLE
Fix armor stat display

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -81,7 +81,7 @@
       if (stats.skydd) parts.push(`Skydd: ${stats.skydd}`);
       if (stats.hasOwnProperty('begr\u00e4nsning'))
         parts.push(`Begr\u00e4nsning: ${stats['begr\u00e4nsning']}`);
-      return parts.length ? `<br>${parts.join(' ')}` : '';
+      return parts.length ? `<br>${parts.join('<br>')}` : '';
     }
     if (types.includes('Vapen')) {
       const dmg = entry.stat?.skada;


### PR DESCRIPTION
## Summary
- update armor stat display to use line breaks between protection and limitation stats

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883b138bac083238ca05efbd16c027a