### PR TITLE
Handle arrows as stackable weapons

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -390,7 +390,7 @@
 
           /* — knappar — */
           const isGear = ['Vapen', 'Rustning', 'L\u00e4gre Artefakt', 'Artefakter'].some(t => tagTyp.includes(t));
-          const allowQual = ['Vapen','Rustning','Artefakter'].some(t => tagTyp.includes(t));
+          const allowQual = ['Vapen','Pil/Lod','Rustning','Artefakter'].some(t => tagTyp.includes(t));
  const btnRow = isGear
   ? `<button data-act="del" class="char-btn danger">🗑</button>`
   : `<button data-act="del" class="char-btn danger">🗑</button>
@@ -537,7 +537,7 @@
       // "K+" öppnar popup för att lägga kvalitet
       if (act === 'addQual') {
         const tagTyp = (entry.taggar?.typ || []);
-        if (!['Vapen','Rustning','Artefakter'].some(t => tagTyp.includes(t))) return;
+        if (!['Vapen','Pil/Lod','Rustning','Artefakter'].some(t => tagTyp.includes(t))) return;
         const qualities = DB.filter(isQual);
         openQualPopup(qualities, qIdx => {
           if (idx >= 0 && qualities[qIdx]) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -2,6 +2,7 @@
   const LVL   = ['Novis','Ges\u00e4ll','M\u00e4stare'];
   const EQUIP = [
     'Vapen',
+    'Pil/Lod',
     'Rustning',
     'Diverse',
     'Elixir',


### PR DESCRIPTION
## Summary
- add "Pil/Lod" to EQUIP categories
- allow arrows to use quality logic in inventory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883bf3990b4832389fd5af94cb42043