### PR TITLE
Remove 'Ingen' button and adjust alchemist popup spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -605,6 +605,11 @@ select.level {
 }
 #alcPopup.open .popup-inner { transform: translateY(0); }
 #alcPopup .popup-inner button { width: 100%; }
+#alcPopup #alcOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
 
 /* Gör samtliga popups scrollbara om innehållet blir för högt */
 #qualPopup .popup-inner,

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -206,7 +206,6 @@ class SharedToolbar extends HTMLElement {
         <div class="popup-inner">
           <h3>Alkemistniv\u00e5</h3>
           <div id="alcOptions">
-            <button data-level="" class="char-btn">Ingen</button>
             <button data-level="Novis" class="char-btn">Novis</button>
             <button data-level="Ges\u00e4ll" class="char-btn">Ges\u00e4ll</button>
             <button data-level="M\u00e4stare" class="char-btn">M\u00e4stare</button>


### PR DESCRIPTION
## Summary
- remove the *Ingen* selection from alchemist level popup
- add spacing between the level buttons

## Testing
- `npm test` *(fails: cannot find package.json)*
- `make test` *(fails: no rule for target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6888679554a48323abf3fcd9f428af51