### PR TITLE
Fix alchemist price discounts

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -221,7 +221,7 @@
       storeHelper.getCurrentList(store).some(x => x.namn === 'Smideskonst');
     const partyAlc = LEVEL_IDX[storeHelper.getPartyAlchemist(store) || ''] || 0;
     const skillAlc = storeHelper.abilityLevel(
-      storeHelper.getCurrentList(store), 'Alkemi');
+      storeHelper.getCurrentList(store), 'Alkemist');
     const alcLevel = Math.max(partyAlc, skillAlc);
     const hasArtefacter = storeHelper.getPartyArtefacter(store) ||
       storeHelper.getCurrentList(store).some(x => x.namn === 'Artefaktmakande');
@@ -283,7 +283,7 @@
       storeHelper.getCurrentList(store).some(x => x.namn === 'Smideskonst');
     const partyAlc = LEVEL_IDX[storeHelper.getPartyAlchemist(store) || ''] || 0;
     const skillAlc = storeHelper.abilityLevel(
-      storeHelper.getCurrentList(store), 'Alkemi');
+      storeHelper.getCurrentList(store), 'Alkemist');
     const alcLevel = Math.max(partyAlc, skillAlc);
     const hasArtefacter = storeHelper.getPartyArtefacter(store) ||
       storeHelper.getCurrentList(store).some(x => x.namn === 'Artefaktmakande');


### PR DESCRIPTION
## Summary
- use correct ability name 'Alkemist' when calculating alchemist discount

## Testing
- `grep -n "Alkemist" js/inventory-utils.js`

------
https://chatgpt.com/codex/tasks/task_e_688878dbfa1483238f498c7491f950cc