### PR TITLE
Implement OR search across text and tags

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -43,7 +43,7 @@ function initCharacter() {
         const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
           .map(t => searchNormalize(t.toLowerCase()));
         const text = searchNormalize(`${p.namn} ${(p.beskrivning || '')}`.toLowerCase());
-        const txt = terms.every(q => text.includes(q));
+        const txt = !terms.length || terms.every(q => text.includes(q));
         const tags = p.taggar || {};
         const selTags = [...F.typ, ...F.ark, ...F.test];
         const itmTags = [
@@ -54,7 +54,7 @@ function initCharacter() {
         const tagMatch = !selTags.length ||
           (union ? selTags.some(t => itmTags.includes(t))
                  : selTags.every(t => itmTags.includes(t)));
-        return txt && tagMatch;
+        return union ? (txt || tagMatch) : (txt && tagMatch);
       })
       .sort(sortByType);
   };

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -42,7 +42,7 @@ function initIndex() {
       const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
         .map(t => searchNormalize(t.toLowerCase()));
       const text = searchNormalize(`${p.namn} ${(p.beskrivning||'')}`.toLowerCase());
-      const txt = terms.every(q => text.includes(q));
+      const txt = !terms.length || terms.every(q => text.includes(q));
       const tags = p.taggar || {};
       const selTags = [...F.typ, ...F.ark, ...F.test];
       const itmTags = [
@@ -54,7 +54,7 @@ function initIndex() {
         (union ? selTags.some(t => itmTags.includes(t))
                : selTags.every(t => itmTags.includes(t)));
 
-      return txt && tagMatch;
+      return union ? (txt || tagMatch) : (txt && tagMatch);
     }).sort(sortByType);
   };
 


### PR DESCRIPTION
## Summary
- apply "filter union" mode to search text as well as tags
- allow matching either tags or text when union toggle is active

## Testing
- `node --check js/index-view.js`
- `node --check js/character-view.js`


------
https://chatgpt.com/codex/tasks/task_e_6888839252888323ab28033437e0d8c4