### PR TITLE
Fix expand search filter logic

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -43,18 +43,28 @@ function initCharacter() {
         const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
           .map(t => searchNormalize(t.toLowerCase()));
         const text = searchNormalize(`${p.namn} ${(p.beskrivning || '')}`.toLowerCase());
-        const txt = !terms.length || terms.every(q => text.includes(q));
+        const hasTerms = terms.length > 0;
+        const txt = hasTerms && terms.every(q => text.includes(q));
         const tags = p.taggar || {};
         const selTags = [...F.typ, ...F.ark, ...F.test];
+        const hasTags = selTags.length > 0;
         const itmTags = [
           ...(tags.typ      ?? []),
           ...explodeTags(tags.ark_trad),
           ...(tags.test     ?? [])
         ];
-        const tagMatch = !selTags.length ||
-          (union ? selTags.some(t => itmTags.includes(t))
-                 : selTags.every(t => itmTags.includes(t)));
-        return union ? (txt || tagMatch) : (txt && tagMatch);
+        const tagMatch = hasTags && (
+          union ? selTags.some(t => itmTags.includes(t))
+                : selTags.every(t => itmTags.includes(t))
+        );
+        if (union) {
+          if (!hasTerms && !hasTags) return true;
+          if (hasTerms && hasTags) return txt || tagMatch;
+          return hasTerms ? txt : tagMatch;
+        }
+        const txtOk = !hasTerms || txt;
+        const tagOk = !hasTags || tagMatch;
+        return txtOk && tagOk;
       })
       .sort(sortByType);
   };

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -42,19 +42,29 @@ function initIndex() {
       const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
         .map(t => searchNormalize(t.toLowerCase()));
       const text = searchNormalize(`${p.namn} ${(p.beskrivning||'')}`.toLowerCase());
-      const txt = !terms.length || terms.every(q => text.includes(q));
+      const hasTerms = terms.length > 0;
+      const txt = hasTerms && terms.every(q => text.includes(q));
       const tags = p.taggar || {};
       const selTags = [...F.typ, ...F.ark, ...F.test];
+      const hasTags = selTags.length > 0;
       const itmTags = [
         ...(tags.typ      ?? []),
         ...explodeTags(tags.ark_trad),
         ...(tags.test     ?? [])
       ];
-      const tagMatch = !selTags.length ||
-        (union ? selTags.some(t => itmTags.includes(t))
-               : selTags.every(t => itmTags.includes(t)));
+      const tagMatch = hasTags && (
+        union ? selTags.some(t => itmTags.includes(t))
+              : selTags.every(t => itmTags.includes(t))
+      );
 
-      return union ? (txt || tagMatch) : (txt && tagMatch);
+      if (union) {
+        if (!hasTerms && !hasTags) return true;
+        if (hasTerms && hasTags) return txt || tagMatch;
+        return hasTerms ? txt : tagMatch;
+      }
+      const txtOk  = !hasTerms || txt;
+      const tagOk  = !hasTags || tagMatch;
+      return txtOk && tagOk;
     }).sort(sortByType);
   };
 


### PR DESCRIPTION
## Summary
- refine expand search behavior so results are limited by active text and tag filters

## Testing
- `node --check js/index-view.js`
- `node --check js/character-view.js`


------
https://chatgpt.com/codex/tasks/task_e_68888e5a718c8323be20095b7de3c921