### PR TITLE
Add money management popup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -575,6 +575,37 @@ select.level {
 #customPopup.open .popup-inner { transform: translateY(0); }
 #customPopup .popup-inner button { width: 100%; }
 
+/* ---------- Popup för pengar ---------- */
+#moneyPopup {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 3000;
+}
+#moneyPopup.open { display: flex; }
+#moneyPopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem 1.2rem 0 0;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.4rem 2rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+  transform: translateY(100%);
+  transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: .8rem;
+}
+#moneyPopup.open .popup-inner { transform: translateY(0); }
+#moneyPopup .popup-inner button { width: 100%; }
+
 /* ---------- Popup f\u00f6r alkemistniv\u00e5 ---------- */
 #alcPopup {
   position: fixed;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -176,6 +176,47 @@
     pop.addEventListener('click', onOutside);
   }
 
+  function openMoneyPopup() {
+    const pop   = bar.shadowRoot.getElementById('moneyPopup');
+    const dIn   = bar.shadowRoot.getElementById('moneyDaler');
+    const sIn   = bar.shadowRoot.getElementById('moneySkilling');
+    const oIn   = bar.shadowRoot.getElementById('moneyOrtegar');
+    const save  = bar.shadowRoot.getElementById('moneySave');
+    const cancel= bar.shadowRoot.getElementById('moneyCancel');
+
+    const cur = storeHelper.getMoney(store);
+    dIn.value = cur.daler || 0;
+    sIn.value = cur.skilling || 0;
+    oIn.value = cur['örtegar'] || 0;
+
+    pop.classList.add('open');
+
+    const close = () => {
+      pop.classList.remove('open');
+      save.removeEventListener('click', onSave);
+      cancel.removeEventListener('click', onCancel);
+      pop.removeEventListener('click', onOutside);
+    };
+    const onSave = () => {
+      const money = storeHelper.normalizeMoney({
+        daler: Number(dIn.value)||0,
+        skilling: Number(sIn.value)||0,
+        'örtegar': Number(oIn.value)||0
+      });
+      storeHelper.setMoney(store, money);
+      close();
+      renderInventory();
+    };
+    const onCancel = () => { close(); };
+    const onOutside = e => {
+      if(!pop.querySelector('.popup-inner').contains(e.target)) close();
+    };
+
+    save.addEventListener('click', onSave);
+    cancel.addEventListener('click', onCancel);
+    pop.addEventListener('click', onOutside);
+  }
+
   function calcRowCost(row, forgeLvl, alcLevel, hasArtefacter) {
     const entry  = getEntry(row.name);
     const tagger = entry.taggar ?? {};
@@ -666,22 +707,9 @@
   }
 
   function bindMoney() {
-    if (!dom.moneyDBtn || !dom.moneySBtn || !dom.moneyOBtn || !dom.moneyResetBtn || !dom.clearInvBtn) return;
+    if (!dom.manageMoneyBtn || !dom.moneyResetBtn || !dom.clearInvBtn) return;
 
-    const add = (field, key) => {
-      const val = Number(field.value) || 0;
-      if (!val) return;
-      const cur = storeHelper.getMoney(store);
-      cur[key] = (cur[key] || 0) + val;
-      const total = storeHelper.normalizeMoney(cur);
-      storeHelper.setMoney(store, total);
-      field.value = '';
-      renderInventory();
-    };
-
-    dom.moneyDBtn.addEventListener('click', () => add(dom.moneyD, 'daler'));
-    dom.moneySBtn.addEventListener('click', () => add(dom.moneyS, 'skilling'));
-    dom.moneyOBtn.addEventListener('click', () => add(dom.moneyO, 'örtegar'));
+    dom.manageMoneyBtn.addEventListener('click', openMoneyPopup);
     dom.moneyResetBtn.addEventListener('click', () => {
       storeHelper.setMoney(store, { daler: 0, skilling: 0, 'örtegar': 0 });
       renderInventory();
@@ -704,6 +732,7 @@
     sortQualsForDisplay,
     openQualPopup,
     openCustomPopup,
+    openMoneyPopup,
     recalcArtifactEffects,
     renderInventory,
     bindInv,

--- a/js/main.js
+++ b/js/main.js
@@ -21,9 +21,10 @@ const dom  = {
   /* inventarie */
   invList : $T('invList'),      invBadge  : $T('invBadge'),
   wtOut   : $T('weightOut'),    slOut     : $T('slotOut'),
-  moneyD  : $T('moneyDaler'),     moneyDBtn: $T('moneyDalerBtn'),
-  moneyS  : $T('moneySkilling'),  moneySBtn: $T('moneySkillingBtn'),
-  moneyO  : $T('moneyOrtegar'),   moneyOBtn: $T('moneyOrtegarBtn'),
+  moneyD  : $T('moneyDaler'),
+  moneyS  : $T('moneySkilling'),
+  moneyO  : $T('moneyOrtegar'),
+  manageMoneyBtn: $T('manageMoneyBtn'),
   moneyResetBtn: $T('moneyResetBtn'),
   clearInvBtn : $T('clearInvBtn'),
   invTypeSel : $T('invTypeFilter'),

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -51,28 +51,12 @@ class SharedToolbar extends HTMLElement {
           <label for="invTypeFilter">Kategori</label>
           <select id="invTypeFilter"></select>
         </div>
-        <div id="moneyForm" class="money-form">
-          <div class="money-row">
-            <input id="moneyDaler" type="number" min="0" placeholder="Daler">
-            <button id="moneyDalerBtn" class="char-btn">Lägg till</button>
-          </div>
-          <div class="money-row">
-            <input id="moneySkilling" type="number" min="0" placeholder="Skilling">
-            <button id="moneySkillingBtn" class="char-btn">Lägg till</button>
-          </div>
-          <div class="money-row">
-            <input id="moneyOrtegar" type="number" min="0" placeholder="Örtegar">
-            <button id="moneyOrtegarBtn" class="char-btn">Lägg till</button>
-          </div>
-          <div class="money-row">
-            <button id="moneyResetBtn" class="char-btn danger" style="flex:1">Nollställ pengar</button>
-          </div>
-          <div class="money-row">
-            <button id="clearInvBtn" class="char-btn danger" style="flex:1">Rensa inventarie</button>
-          </div>
-          <div class="money-row">
-            <button id="addCustomBtn" class="char-btn" style="flex:1">Nytt föremål</button>
-          </div>
+        <button id="manageMoneyBtn" class="char-btn" style="flex:1">Hantera pengar</button>
+        <div class="money-row">
+          <button id="clearInvBtn" class="char-btn danger" style="flex:1">Rensa inventarie</button>
+        </div>
+        <div class="money-row">
+          <button id="addCustomBtn" class="char-btn" style="flex:1">Nytt föremål</button>
         </div>
         <ul id="invList" class="card-list"></ul>
       </aside>
@@ -201,6 +185,21 @@ class SharedToolbar extends HTMLElement {
         </div>
       </div>
 
+      <!-- ---------- Popup Pengar ---------- -->
+      <div id="moneyPopup">
+        <div class="popup-inner">
+          <h3>Hantera pengar</h3>
+          <div class="money-row">
+            <input id="moneyDaler" type="number" min="0" placeholder="Daler">
+            <input id="moneySkilling" type="number" min="0" placeholder="Skilling">
+            <input id="moneyOrtegar" type="number" min="0" placeholder="Örtegar">
+          </div>
+          <button id="moneySave" class="char-btn">Spara</button>
+          <button id="moneyResetBtn" class="char-btn danger">Nollställ pengar</button>
+          <button id="moneyCancel" class="char-btn danger">Avbryt</button>
+        </div>
+      </div>
+
       <!-- ---------- Popup Alkemistniv\u00e5 ---------- -->
       <div id="alcPopup">
         <div class="popup-inner">
@@ -262,7 +261,7 @@ class SharedToolbar extends HTMLElement {
     if (path.some(el => toggles.includes(el.id))) return;
 
     // ignore clicks inside popups so panels stay open
-    const popups = ['qualPopup','customPopup','masterPopup','alcPopup','smithPopup'];
+    const popups = ['qualPopup','customPopup','moneyPopup','masterPopup','alcPopup','smithPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));


### PR DESCRIPTION
## Summary
- replace inline money inputs with `Hantera pengar` button
- style new `moneyPopup` overlay
- expose `manageMoneyBtn` and implement `openMoneyPopup`
- tie popup into money bindings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6888911c42c48323992376a76b3792a2