### PR TITLE
Implement money popup improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# SymbaDA.github.io
+# Symbaroum Companion
+
+A static web app for managing characters and inventory for the Symbaroum RPG. Open `index.html` to browse items and `character.html` to manage a character sheet locally in your browser.

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -181,29 +181,45 @@
     const dIn   = bar.shadowRoot.getElementById('moneyDaler');
     const sIn   = bar.shadowRoot.getElementById('moneySkilling');
     const oIn   = bar.shadowRoot.getElementById('moneyOrtegar');
-    const save  = bar.shadowRoot.getElementById('moneySave');
+    const setBtn= bar.shadowRoot.getElementById('moneySetBtn');
+    const addBtn= bar.shadowRoot.getElementById('moneyAddBtn');
     const cancel= bar.shadowRoot.getElementById('moneyCancel');
 
     const cur = storeHelper.getMoney(store);
-    dIn.value = cur.daler || 0;
-    sIn.value = cur.skilling || 0;
-    oIn.value = cur['örtegar'] || 0;
+    dIn.value = cur.daler ? cur.daler : '';
+    sIn.value = cur.skilling ? cur.skilling : '';
+    oIn.value = cur['örtegar'] ? cur['örtegar'] : '';
 
     pop.classList.add('open');
 
     const close = () => {
       pop.classList.remove('open');
-      save.removeEventListener('click', onSave);
+      setBtn.removeEventListener('click', onSet);
+      addBtn.removeEventListener('click', onAdd);
       cancel.removeEventListener('click', onCancel);
       pop.removeEventListener('click', onOutside);
+      dIn.value = sIn.value = oIn.value = '';
     };
-    const onSave = () => {
-      const money = storeHelper.normalizeMoney({
-        daler: Number(dIn.value)||0,
-        skilling: Number(sIn.value)||0,
-        'örtegar': Number(oIn.value)||0
-      });
+    const getInputMoney = () => storeHelper.normalizeMoney({
+      daler: Number(dIn.value)||0,
+      skilling: Number(sIn.value)||0,
+      'örtegar': Number(oIn.value)||0
+    });
+    const onSet = () => {
+      const money = getInputMoney();
       storeHelper.setMoney(store, money);
+      close();
+      renderInventory();
+    };
+    const onAdd = () => {
+      const addMoney = getInputMoney();
+      const curMoney = storeHelper.getMoney(store);
+      const total = storeHelper.normalizeMoney({
+        daler: curMoney.daler + addMoney.daler,
+        skilling: curMoney.skilling + addMoney.skilling,
+        'örtegar': curMoney['örtegar'] + addMoney['örtegar']
+      });
+      storeHelper.setMoney(store, total);
       close();
       renderInventory();
     };
@@ -212,7 +228,8 @@
       if(!pop.querySelector('.popup-inner').contains(e.target)) close();
     };
 
-    save.addEventListener('click', onSave);
+    setBtn.addEventListener('click', onSet);
+    addBtn.addEventListener('click', onAdd);
     cancel.addEventListener('click', onCancel);
     pop.addEventListener('click', onOutside);
   }

--- a/js/main.js
+++ b/js/main.js
@@ -24,6 +24,8 @@ const dom  = {
   moneyD  : $T('moneyDaler'),
   moneyS  : $T('moneySkilling'),
   moneyO  : $T('moneyOrtegar'),
+  moneySetBtn: $T('moneySetBtn'),
+  moneyAddBtn: $T('moneyAddBtn'),
   manageMoneyBtn: $T('manageMoneyBtn'),
   moneyResetBtn: $T('moneyResetBtn'),
   clearInvBtn : $T('clearInvBtn'),

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -194,7 +194,8 @@ class SharedToolbar extends HTMLElement {
             <input id="moneySkilling" type="number" min="0" placeholder="Skilling">
             <input id="moneyOrtegar" type="number" min="0" placeholder="Örtegar">
           </div>
-          <button id="moneySave" class="char-btn">Spara</button>
+          <button id="moneySetBtn" class="char-btn">Spara som totalen</button>
+          <button id="moneyAddBtn" class="char-btn">Addera till totalen</button>
           <button id="moneyResetBtn" class="char-btn danger">Nollställ pengar</button>
           <button id="moneyCancel" class="char-btn danger">Avbryt</button>
         </div>


### PR DESCRIPTION
## Summary
- show placeholder text in money inputs when zero
- provide new `Spara som totalen` and `Addera till totalen` buttons
- wire new buttons up in main script
- add documentation to README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68889a9629f483238f9568caf5c85d1c