### PR TITLE
Empty money fields when popup opens

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -185,10 +185,8 @@
     const addBtn= bar.shadowRoot.getElementById('moneyAddBtn');
     const cancel= bar.shadowRoot.getElementById('moneyCancel');
 
-    const cur = storeHelper.getMoney(store);
-    dIn.value = cur.daler ? cur.daler : '';
-    sIn.value = cur.skilling ? cur.skilling : '';
-    oIn.value = cur['örtegar'] ? cur['örtegar'] : '';
+    // Fälten ska börja tomma oavsett aktuell summa pengar
+    dIn.value = sIn.value = oIn.value = '';
 
     pop.classList.add('open');
 


### PR DESCRIPTION
## Summary
- clear money input fields when opening the money popup

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888b4a6d7948323bc551cf117c4448a