### PR TITLE
Implement leveled artefact maker discount

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -686,13 +686,50 @@ select.level {
 }
 #smithPopup .popup-inner button { width: 100%; }
 
+/* ---------- Popup f\u00f6r artefaktmakarniv\u00e5 ---------- */
+#artPopup {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 3000;
+}
+#artPopup.open { display: flex; }
+#artPopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem 1.2rem 0 0;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.4rem 2rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+  transform: translateY(100%);
+  transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: .8rem;
+}
+#artPopup.open .popup-inner { transform: translateY(0); }
+#artPopup #artOptions {
+  display: flex;
+  flex-direction: column;
+  gap: .6rem;
+}
+#artPopup .popup-inner button { width: 100%; }
+
 /* Gör samtliga popups scrollbara om innehållet blir för högt */
 #qualPopup .popup-inner,
 #masterPopup .popup-inner,
 #traitPopup .popup-inner,
 #customPopup .popup-inner,
 #alcPopup .popup-inner,
-#smithPopup .popup-inner {
+#smithPopup .popup-inner,
+#artPopup .popup-inner {
   max-height: 100%;
   overflow-y: auto;
 }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -232,7 +232,7 @@
     pop.addEventListener('click', onOutside);
   }
 
-  function calcRowCost(row, forgeLvl, alcLevel, hasArtefacter) {
+  function calcRowCost(row, forgeLvl, alcLevel, artLevel) {
     const entry  = getEntry(row.name);
     const tagger = entry.taggar ?? {};
     const tagTyp = tagger.typ ?? [];
@@ -263,7 +263,11 @@
       const req = LEVEL_IDX[lvlName] || 0;
       if (alcLevel >= req) base = Math.floor(base / 2);
     }
-    if (tagTyp.includes('L\u00e4gre Artefakt') && hasArtefacter) base = Math.floor(base / 2);
+    if (tagTyp.includes('L\u00e4gre Artefakt')) {
+      const lvlName = row.nivå || Object.keys(entry.nivåer || {}).find(l=>l) || '';
+      const req = LEVEL_IDX[lvlName] || 0;
+      if (artLevel >= req) base = Math.floor(base / 2);
+    }
     let price = base;
     allQuals.forEach(q => {
       const qEntry = DB.find(x => x.namn === q) || {};
@@ -295,8 +299,10 @@
     const skillAlc = storeHelper.abilityLevel(
       storeHelper.getCurrentList(store), 'Alkemist');
     const alcLevel = Math.max(partyAlc, skillAlc);
-    const hasArtefacter = storeHelper.getPartyArtefacter(store) ||
-      storeHelper.getCurrentList(store).some(x => x.namn === 'Artefaktmakande');
+    const partyArt = LEVEL_IDX[storeHelper.getPartyArtefacter(store) || ''] || 0;
+    const skillArt = storeHelper.abilityLevel(
+      storeHelper.getCurrentList(store), 'Artefaktmakande');
+    const artLevel = Math.max(partyArt, skillArt);
 
     const forgeable = ['Vapen','Rustning'].some(t => tagTyp.includes(t));
     const baseQuals = [
@@ -319,7 +325,11 @@
       const req = LEVEL_IDX[lvlName] || 0;
       if (alcLevel >= req) price = Math.floor(price / 2);
     }
-    if (tagTyp.includes('L\u00e4gre Artefakt') && hasArtefacter) price = Math.floor(price / 2);
+    if (tagTyp.includes('L\u00e4gre Artefakt')) {
+      const lvlName = Object.keys(entry.nivåer || {}).find(l=>l) || '';
+      const req = LEVEL_IDX[lvlName] || 0;
+      if (artLevel >= req) price = Math.floor(price / 2);
+    }
 
     
     baseQuals.forEach(q => {
@@ -370,8 +380,10 @@
     const skillAlc = storeHelper.abilityLevel(
       storeHelper.getCurrentList(store), 'Alkemist');
     const alcLevel = Math.max(partyAlc, skillAlc);
-    const hasArtefacter = storeHelper.getPartyArtefacter(store) ||
-      storeHelper.getCurrentList(store).some(x => x.namn === 'Artefaktmakande');
+    const partyArt = LEVEL_IDX[storeHelper.getPartyArtefacter(store) || ''] || 0;
+    const skillArt = storeHelper.abilityLevel(
+      storeHelper.getCurrentList(store), 'Artefaktmakande');
+    const artLevel = Math.max(partyArt, skillArt);
 
     const tot = allInv.reduce((t, row) => {
       const entry = getEntry(row.name);
@@ -405,8 +417,12 @@
         const req = LEVEL_IDX[lvlName] || 0;
         if (alcLevel >= req) base = Math.floor(base / 2);
       }
-      const isArtifact = (entry.taggar?.typ || []).includes('Artefakter');
-      if (isArtifact && hasArtefacter) base = Math.floor(base / 2);
+      const isLArtifact = (entry.taggar?.typ || []).includes('L\u00e4gre Artefakt');
+      if (isLArtifact) {
+        const lvlName = row.nivå || Object.keys(entry.nivåer || {}).find(l=>l) || '';
+        const req = LEVEL_IDX[lvlName] || 0;
+        if (artLevel >= req) base = Math.floor(base / 2);
+      }
       let   price = base;                    // startvärde för kvaliteter
 
       const allQuals = allQualsRow;
@@ -515,13 +531,13 @@
           const toggleBtn = isArtifact ? `<button data-act="toggleEffect" class="char-btn">↔</button>` : '';
 
           const rowLevel = row.nivå ||
-            (tagTyp.includes('Elixir')
+            (['Elixir','L\u00e4gre Artefakt'].some(t => tagTyp.includes(t))
               ? Object.keys(entry.nivåer || {}).find(l => l)
               : null);
           const lvlInfo = rowLevel ? ` <span class="tag level">${rowLevel}</span>` : '';
           const dataLevel = rowLevel ? ` data-level="${rowLevel}"` : '';
           const priceText = formatMoney(
-            calcRowCost(row, forgeLvl, alcLevel, hasArtefacter)
+            calcRowCost(row, forgeLvl, alcLevel, artLevel)
           );
 
           return `

--- a/js/main.js
+++ b/js/main.js
@@ -259,10 +259,13 @@ function bindToolbar() {
   if (dom.artBtn) {
     if (storeHelper.getPartyArtefacter(store)) dom.artBtn.classList.add('active');
     dom.artBtn.addEventListener('click', () => {
-      const val = dom.artBtn.classList.toggle('active');
-      storeHelper.setPartyArtefacter(store, val);
-      invUtil.renderInventory();
-      if (window.indexViewUpdate) window.indexViewUpdate();
+      openArtefacterPopup(level => {
+        if (level === null) return;
+        dom.artBtn.classList.toggle('active', Boolean(level));
+        storeHelper.setPartyArtefacter(store, level);
+        invUtil.renderInventory();
+        if (window.indexViewUpdate) window.indexViewUpdate();
+      });
     });
   }
   if (dom.filterUnion) {
@@ -317,6 +320,36 @@ function openSmithPopup(cb) {
   const pop  = bar.shadowRoot.getElementById('smithPopup');
   const box  = bar.shadowRoot.getElementById('smithOptions');
   const cls  = bar.shadowRoot.getElementById('smithCancel');
+  pop.classList.add('open');
+  function close() {
+    pop.classList.remove('open');
+    box.removeEventListener('click', onBtn);
+    cls.removeEventListener('click', onCancel);
+    pop.removeEventListener('click', onOutside);
+  }
+  function onBtn(e) {
+    const b = e.target.closest('button[data-level]');
+    if (!b) return;
+    const lvl = b.dataset.level;
+    close();
+    cb(lvl);
+  }
+  function onCancel() { close(); cb(null); }
+  function onOutside(e) {
+    if(!pop.querySelector('.popup-inner').contains(e.target)){
+      close();
+      cb(null);
+    }
+  }
+  box.addEventListener('click', onBtn);
+  cls.addEventListener('click', onCancel);
+  pop.addEventListener('click', onOutside);
+}
+
+function openArtefacterPopup(cb) {
+  const pop  = bar.shadowRoot.getElementById('artPopup');
+  const box  = bar.shadowRoot.getElementById('artOptions');
+  const cls  = bar.shadowRoot.getElementById('artCancel');
   pop.classList.add('open');
   function close() {
     pop.classList.remove('open');

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -227,6 +227,20 @@ class SharedToolbar extends HTMLElement {
         </div>
       </div>
 
+      <!-- ---------- Popup Artefaktmakarniv\u00e5 ---------- -->
+      <div id="artPopup">
+        <div class="popup-inner">
+          <h3>Artefaktmakarniv\u00e5</h3>
+          <div id="artOptions">
+            <button data-level="" class="char-btn">Ingen</button>
+            <button data-level="Novis" class="char-btn">Novis</button>
+            <button data-level="Ges\u00e4ll" class="char-btn">Ges\u00e4ll</button>
+            <button data-level="M\u00e4stare" class="char-btn">M\u00e4stare</button>
+          </div>
+          <button id="artCancel" class="char-btn danger">Avbryt</button>
+        </div>
+      </div>
+
     `;
   }
 
@@ -260,7 +274,7 @@ class SharedToolbar extends HTMLElement {
     if (path.some(el => toggles.includes(el.id))) return;
 
     // ignore clicks inside popups so panels stay open
-    const popups = ['qualPopup','customPopup','moneyPopup','masterPopup','alcPopup','smithPopup'];
+    const popups = ['qualPopup','customPopup','moneyPopup','masterPopup','alcPopup','smithPopup','artPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));

--- a/js/store.js
+++ b/js/store.js
@@ -33,6 +33,9 @@
           if (typeof cur.partySmith === 'boolean') {
             cur.partySmith = cur.partySmith ? 'Mästare' : '';
           }
+          if (typeof cur.partyArtefacter === 'boolean') {
+            cur.partyArtefacter = cur.partyArtefacter ? 'Mästare' : '';
+          }
           store.data[id] = {
             custom: [],
             artifactEffects: { xp:0, corruption:0 },
@@ -147,15 +150,17 @@
   }
 
   function getPartyArtefacter(store) {
-    if (!store.current) return false;
+    if (!store.current) return '';
     const data = store.data[store.current] || {};
-    return Boolean(data.partyArtefacter);
+    const val = data.partyArtefacter;
+    if (typeof val === 'string') return val;
+    return val ? 'Mästare' : '';
   }
 
-  function setPartyArtefacter(store, val) {
+  function setPartyArtefacter(store, level) {
     if (!store.current) return;
     store.data[store.current] = store.data[store.current] || {};
-    store.data[store.current].partyArtefacter = Boolean(val);
+    store.data[store.current].partyArtefacter = level || '';
     save(store);
   }
 


### PR DESCRIPTION
## Summary
- add level selection popup for Artefaktmakare
- store artefact maker level instead of boolean
- show artefact level in inventory
- apply artefact maker discount only to lower artefacts and require appropriate level

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6888b9ecedc4832390e869cf075bd1ff