### PR TITLE
Implement XP cost for non-tiered monstrous traits

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -295,6 +295,8 @@ function defaultTraits() {
       if (item.nivåer && ['mystisk kraft','förmåga','särdrag','monstruöst särdrag']
           .some(t => types.includes(t))) {
         xp += XP_LADDER[item.nivå || 'Novis'] || 0;
+      } else if (types.includes('monstruöst särdrag')) {
+        xp += RITUAL_COST;
       }
       if (types.includes('fördel')) xp += 5;
       if (types.includes('ritual')) xp += RITUAL_COST;


### PR DESCRIPTION
## Summary
- treat monstrous traits without levels like rituals
- add 10 XP cost when applying these traits

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6888e174c72c832398617ce5d1e23e71