### PR TITLE
Load traps as inventory items

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -531,7 +531,7 @@
           const toggleBtn = isArtifact ? `<button data-act="toggleEffect" class="char-btn">↔</button>` : '';
 
           const rowLevel = row.nivå ||
-            (['Elixir','L\u00e4gre Artefakt'].some(t => tagTyp.includes(t))
+            (['Elixir','L\u00e4gre Artefakt','F\u00e4lla'].some(t => tagTyp.includes(t))
               ? Object.keys(entry.nivåer || {}).find(l => l)
               : null);
           const lvlInfo = rowLevel ? ` <span class="tag level">${rowLevel}</span>` : '';

--- a/js/main.js
+++ b/js/main.js
@@ -87,7 +87,8 @@ const DATA_FILES = [
   'dryck.json',
   'sardrag.json',
   'monstruost-sardrag.json',
-  'lagre-artefakter.json'
+  'lagre-artefakter.json',
+  'fallor.json'
 ].map(f => `data/${f}`);
 
 Promise.all(DATA_FILES.map(f => fetch(f).then(r => r.json())))

--- a/js/utils.js
+++ b/js/utils.js
@@ -16,7 +16,8 @@
     'F\u00f6rvaring',
     'G\u00e5rdsdjur',
     'Byggnad',
-    'Specialverktyg'
+    'Specialverktyg',
+    'F\u00e4lla'
   ];
   const SBASE = 10, OBASE = 10;
 


### PR DESCRIPTION
## Summary
- include traps (fallor) in data loading
- list `Fälla` as an equipment type
- display trap levels in inventory

## Testing
- `node --check js/utils.js`
- `node --check js/main.js`
- `node --check js/inventory-utils.js`


------
https://chatgpt.com/codex/tasks/task_e_6888fd997f4483238b34c0bf39f9a3f1