### PR TITLE
Fix empty option in dropdowns

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -14,9 +14,13 @@ function initCharacter() {
     const lst = storeHelper.getCurrentList(store).filter(p=>!isInv(p));
     const sets = { typ:new Set(), ark:new Set(), test:new Set() };
     lst.forEach(p=>{
-      (p.taggar.typ||[]).forEach(v=>sets.typ.add(v));
+      (p.taggar.typ||[])
+        .filter(Boolean)
+        .forEach(v=>sets.typ.add(v));
       explodeTags(p.taggar.ark_trad).forEach(v=>sets.ark.add(v));
-      (p.taggar.test||[]).forEach(v=>sets.test.add(v));
+      (p.taggar.test||[])
+        .filter(Boolean)
+        .forEach(v=>sets.test.add(v));
     });
     const fill=(sel,set,lbl)=>sel.innerHTML =
       `<option value="">${lbl} (alla)</option>` +

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -14,9 +14,13 @@ function initIndex() {
   const fillDropdowns = ()=>{
     const set = { typ:new Set(), ark:new Set(), test:new Set() };
     getEntries().forEach(p=>{
-      (p.taggar.typ||[]).forEach(v=>set.typ.add(v));
+      (p.taggar.typ||[])
+        .filter(Boolean)
+        .forEach(v=>set.typ.add(v));
       explodeTags(p.taggar.ark_trad).forEach(v=>set.ark.add(v));
-      (p.taggar.test||[]).forEach(v=>set.test.add(v));
+      (p.taggar.test||[])
+        .filter(Boolean)
+        .forEach(v=>set.test.add(v));
     });
     const fill=(sel,s,l)=>sel.innerHTML =
       `<option value="">${l} (alla)</option>` + [...s].sort().map(v=>`<option>${v}</option>`).join('');

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -355,7 +355,9 @@
       const types = new Set();
       allInv.forEach(row => {
         const entry = getEntry(row.name);
-        (entry.taggar?.typ || []).forEach(t => types.add(t));
+        (entry.taggar?.typ || [])
+          .filter(Boolean)
+          .forEach(t => types.add(t));
       });
       dom.invTypeSel.innerHTML =
         '<option value="">Kategori (alla)</option>' +


### PR DESCRIPTION
## Summary
- filter out empty tag values when building dropdown menus

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6889176a96bc8323838faba7a3e06442