### PR TITLE
Enable triple-pick disadvantages

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -72,7 +72,7 @@ function initCharacter() {
   const renderSkills = arr=>{
     const groups = [];
     arr.forEach(p=>{
-      const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel') && !p.trait;
+      const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ['Fördel','Nackdel'].includes(t)) && !p.trait;
       if(multi){
         const g = groups.find(x=>x.entry.namn===p.namn);
         if(g) { g.count++; return; }
@@ -107,7 +107,7 @@ function initCharacter() {
       li.dataset.name=p.namn;
       if(p.trait) li.dataset.trait=p.trait;
       if(p.trait) li.dataset.trait=p.trait;
-      const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel') && !p.trait;
+      const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ['Fördel','Nackdel'].includes(t)) && !p.trait;
       const badge = g.count>1 ? ` <span class="count-badge">×${g.count}</span>` : '';
       let btn = '';
       if(multi){
@@ -177,13 +177,13 @@ function initCharacter() {
     const before = storeHelper.getCurrentList(store);
     const p = DB.find(x=>x.namn===name) || before.find(x=>x.namn===name);
     if(!p) return;
-    const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel') && !tr;
+    const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ['Fördel','Nackdel'].includes(t)) && !tr;
     let list;
     if(actBtn.dataset.act==='add'){
       if(!multi) return;
       const cnt = before.filter(x=>x.namn===name && !x.trait).length;
       if(cnt >= 3){
-        alert('Denna fördel kan bara tas tre gånger.');
+        alert('Denna fördel eller nackdel kan bara tas tre gånger.');
         return;
       }
       const lvlSel = liEl.querySelector('select.level');

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -107,7 +107,7 @@ function initIndex() {
         if (extra) infoHtml += `<br>${extra}`;
       }
       const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
-      const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel');
+      const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ['Fördel','Nackdel'].includes(t));
       const count = charList.filter(c => c.namn===p.namn && !c.trait).length;
       const badge = multi && count>0 ? ` <span class="count-badge">×${count}</span>` : '';
       let btn = '';
@@ -284,11 +284,11 @@ function initIndex() {
           });
           return;
         }
-        const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel');
+        const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ['Fördel','Nackdel'].includes(t));
         if(multi){
           const cnt = list.filter(x=>x.namn===p.namn && !x.trait).length;
           if(cnt >= 3){
-            alert('Denna fördel kan bara tas tre gånger.');
+            alert('Denna fördel eller nackdel kan bara tas tre gånger.');
             return;
           }
         }else if(list.some(x=>x.namn===p.namn && !x.trait)){
@@ -309,7 +309,7 @@ function initIndex() {
         const tr = btn.closest('li').dataset.trait || null;
         const before = storeHelper.getCurrentList(store);
         let list;
-        const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).includes('Fördel');
+        const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ['Fördel','Nackdel'].includes(t));
         if(multi){
           let removed=false;
           list = [];


### PR DESCRIPTION
## Summary
- allow disadvantages with `kan_införskaffas_flera_gånger` to be selected up to three times just like advantages
- update alert text to mention disadvantages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889d78e318c8323b03de630640e44c7