### PR TITLE
Implement monstrous trait restriction with override

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -268,6 +268,13 @@ function initIndex() {
             if (!confirm(msg)) return;
           }
         }
+        if (isMonstrousTrait(p)) {
+          const allowed = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
+            list.some(x => x.namn === 'Mörkt blod');
+          if (!allowed) {
+            if (!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')) return;
+          }
+        }
         if (p.namn === 'Exceptionellt karakt\u00e4rsdrag' && window.exceptionSkill) {
           const used=list.filter(x=>x.namn===p.namn).map(x=>x.trait).filter(Boolean);
           exceptionSkill.pickTrait(used, trait => {

--- a/js/utils.js
+++ b/js/utils.js
@@ -31,6 +31,7 @@
   function isRas(p){ return (p.taggar?.typ||[]).includes('Ras'); }
   function isElityrke(p){ return (p.taggar?.typ||[]).includes('Elityrke'); }
   function isEliteSkill(p){ return (p.taggar?.typ||[]).includes('Elityrkesf\u00f6rm\u00e5ga'); }
+  function isMonstrousTrait(p){ return (p.taggar?.typ||[]).includes('Monstru\u00f6st s\u00e4rdrag'); }
   function isMysticQual(name){
     return (window.DB?.find(x => x.namn === name)?.taggar?.typ || []).includes('Mystisk kvalitet');
   }
@@ -128,6 +129,7 @@
   window.isRas = isRas;
   window.isElityrke = isElityrke;
   window.isEliteSkill = isEliteSkill;
+  window.isMonstrousTrait = isMonstrousTrait;
   window.isMysticQual = isMysticQual;
   window.isNegativeQual = isNegativeQual;
   window.isNeutralQual = isNeutralQual;


### PR DESCRIPTION
## Summary
- add `isMonstrousTrait` helper
- block selection of monstrous traits unless they are elite abilities or the character has *Mörkt blod*
- offer a confirmation popup to override when blocked

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6889d7a1b75883239b7f0164d9566a41