### PR TITLE
Add automated money handling for Besittning

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -722,6 +722,37 @@ select.level {
 }
 #artPopup .popup-inner button { width: 100%; }
 
+/* ---------- Popup f\u00f6r Besittning ---------- */
+#besittningPopup {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 3000;
+}
+#besittningPopup.open { display: flex; }
+#besittningPopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem 1.2rem 0 0;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.4rem 2rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+  transform: translateY(100%);
+  transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: .8rem;
+}
+#besittningPopup.open .popup-inner { transform: translateY(0); }
+#besittningPopup .popup-inner button { width: 100%; }
+
 /* Gör samtliga popups scrollbara om innehållet blir för högt */
 #qualPopup .popup-inner,
 #masterPopup .popup-inner,
@@ -729,7 +760,8 @@ select.level {
 #customPopup .popup-inner,
 #alcPopup .popup-inner,
 #smithPopup .popup-inner,
-#artPopup .popup-inner {
+#artPopup .popup-inner,
+#besittningPopup .popup-inner {
   max-height: 100%;
   overflow-y: auto;
 }

--- a/data/fordel.json
+++ b/data/fordel.json
@@ -31,7 +31,7 @@
   },
   {
     "namn": "Besittning",
-    "beskrivning": "Rollpersonen har en affärsrörelse av något slag – en liten taverna, en mindre handelsbod eller annan enklare hantverkstjänst som skomakare eller liknande. Andra möjligheter är en teater eller gycklargrupp. Besittningen kan vara stationär på en plats dit rollpersonen ofta återkommer mellan äventyr, eller rörlig i form av en vagn eller liten flodbåt om det passar spelet bättre. En gång per äventyr (lämpligen mellan äventyr) får spelaren slå mot Listig (för hantverk) eller Övertygande (för tjänster). Framgång ger en vinst om 1t10+10 daler, efter att alla omkostnader för affärsrörelsen är betalda. Om flera rollpersoner har Besittning kan det utgöra andelar i samma rörelse. Varje rollperson slår då separata slag för sin andel.",
+    "beskrivning": "Rollpersonen har en affärsrörelse av något slag – en liten taverna, en mindre handelsbod eller annan enklare hantverkstjänst som skomakare eller liknande. Andra möjligheter är en teater eller gycklargrupp. Besittningen kan vara stationär på en plats dit rollpersonen ofta återkommer mellan äventyr, eller rörlig i form av en vagn eller liten flodbåt om det passar spelet bättre. En gång per äventyr (lämpligen mellan äventyr) får spelaren slå mot Listig (för hantverk) eller Övertygande (för tjänster). Framgång ger en vinst om 1t10+10 daler, efter att alla omkostnader för affärsrörelsen är betalda. Om flera rollpersoner har Besittning kan det utgöra andelar i samma rörelse. Varje rollperson slår då separata slag för sin andel. Pengarna läggs automatiskt till i inventariet när fördelen väljs.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
       "typ": ["Fördel"],

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -194,6 +194,11 @@ function initCharacter() {
       let   lvl = lvlSel ? lvlSel.value : null;
       if (!lvl && p.nivåer) lvl = LVL.find(l => p.nivåer[l]) || p.nivå;
       list = [...before, { ...p, nivå: lvl }];
+      if(p.namn === 'Besittning') {
+        const gain = 10 + Math.floor(Math.random()*10);
+        storeHelper.setBesittningMoney(store, { daler: gain });
+        openBesittningPopup(gain);
+      }
     }else if(actBtn.dataset.act==='rem'){
       if(multi){
         let removed=false;
@@ -206,6 +211,25 @@ function initCharacter() {
         }
       }else{
         list = before.filter(x => !(x.namn===name && (tr?x.trait===tr:!x.trait)));
+      }
+      if(p.namn === 'Besittning') {
+        storeHelper.clearBesittningMoney(store);
+        const cnt = storeHelper.getBesittningCount(store) + 1;
+        storeHelper.setBesittningCount(store, cnt);
+        if(cnt === 2) {
+          alert('Misstänkt fusk: lägger du till och tar bort denna fördel igen raderas karaktären omedelbart');
+        } else if(cnt >= 3) {
+          const char = store.characters.find(c=>c.id===store.current);
+          if(char) {
+            store.characters = store.characters.filter(c=>c.id!==store.current);
+            delete store.data[store.current];
+            store.current = '';
+            storeHelper.save(store);
+            alert('Karaktären raderades pga misstänkt fusk.');
+            location.reload();
+            return;
+          }
+        }
       }
       if(eliteReq.canChange(before) && !eliteReq.canChange(list)){
         if(!confirm('Förmågan krävs för ett valt elityrke. Ta bort ändå?'))

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -306,6 +306,11 @@ function initIndex() {
           return;
         }
         list.push({ ...p, nivå: lvl });
+        if(p.namn === 'Besittning') {
+          const gain = 10 + Math.floor(Math.random()*10);
+          storeHelper.setBesittningMoney(store, { daler: gain });
+          openBesittningPopup(gain);
+        }
         storeHelper.setCurrentList(store, list); updateXP();
       }
     } else { /* rem */
@@ -337,6 +342,25 @@ function initIndex() {
         if(eliteReq.canChange(before) && !eliteReq.canChange(list)) {
           if(!confirm('Förmågan krävs för ett valt elityrke. Ta bort ändå?'))
             return;
+        }
+        if(p.namn === 'Besittning') {
+          storeHelper.clearBesittningMoney(store);
+          const cnt = storeHelper.getBesittningCount(store) + 1;
+          storeHelper.setBesittningCount(store, cnt);
+          if(cnt === 2) {
+            alert('Misstänkt fusk: lägger du till och tar bort denna fördel igen raderas karaktären omedelbart');
+          } else if(cnt >= 3) {
+            const char = store.characters.find(c=>c.id===store.current);
+            if(char) {
+              store.characters = store.characters.filter(c=>c.id!==store.current);
+              delete store.data[store.current];
+              store.current = '';
+              storeHelper.save(store);
+              alert('Karaktären raderades pga misstänkt fusk.');
+              location.reload();
+              return;
+            }
+          }
         }
         storeHelper.setCurrentList(store,list); updateXP();
       }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -211,7 +211,7 @@
     };
     const onAdd = () => {
       const addMoney = getInputMoney();
-      const curMoney = storeHelper.getMoney(store);
+      const curMoney = storeHelper.getBaseMoney(store);
       const total = storeHelper.normalizeMoney({
         daler: curMoney.daler + addMoney.daler,
         skilling: curMoney.skilling + addMoney.skilling,

--- a/js/main.js
+++ b/js/main.js
@@ -377,6 +377,27 @@ function openArtefacterPopup(cb) {
   pop.addEventListener('click', onOutside);
 }
 
+function openBesittningPopup(amount, cb) {
+  const pop  = bar.shadowRoot.getElementById('besittningPopup');
+  const text = bar.shadowRoot.getElementById('besittningText');
+  const ok   = bar.shadowRoot.getElementById('besittningOk');
+  text.textContent = `Du f\u00e5r ${amount} daler.`;
+  pop.classList.add('open');
+  function close() {
+    pop.classList.remove('open');
+    ok.removeEventListener('click', onOk);
+    pop.removeEventListener('click', onOutside);
+  }
+  function onOk() { close(); if(cb) cb(); }
+  function onOutside(e) {
+    if(!pop.querySelector('.popup-inner').contains(e.target)) {
+      close(); if(cb) cb();
+    }
+  }
+  ok.addEventListener('click', onOk);
+  pop.addEventListener('click', onOutside);
+}
+
 
 
 function updateXP() {

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -241,6 +241,15 @@ class SharedToolbar extends HTMLElement {
         </div>
       </div>
 
+      <!-- ---------- Popup Besittning ---------- -->
+      <div id="besittningPopup">
+        <div class="popup-inner">
+          <h3>Besittning</h3>
+          <p id="besittningText"></p>
+          <button id="besittningOk" class="char-btn">OK</button>
+        </div>
+      </div>
+
     `;
   }
 
@@ -274,7 +283,7 @@ class SharedToolbar extends HTMLElement {
     if (path.some(el => toggles.includes(el.id))) return;
 
     // ignore clicks inside popups so panels stay open
-    const popups = ['qualPopup','customPopup','moneyPopup','masterPopup','alcPopup','smithPopup','artPopup'];
+    const popups = ['qualPopup','customPopup','moneyPopup','masterPopup','alcPopup','smithPopup','artPopup','besittningPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));

--- a/js/store.js
+++ b/js/store.js
@@ -106,17 +106,57 @@
     return { xp: 0, corruption: 0 };
   }
 
-  function getMoney(store) {
+  function getBaseMoney(store) {
     if (!store.current) return defaultMoney();
     const data = store.data[store.current] || {};
     return { ...defaultMoney(), ...(data.money || {}) };
   }
 
-  function setMoney(store, money) {
+  function setBaseMoney(store, money) {
     if (!store.current) return;
     store.data[store.current] = store.data[store.current] || {};
     store.data[store.current].money = { ...defaultMoney(), ...money };
     save(store);
+  }
+
+  function getBesittningMoney(store) {
+    if (!store.current) return defaultMoney();
+    const data = store.data[store.current] || {};
+    return { ...defaultMoney(), ...(data.besittningMoney || {}) };
+  }
+
+  function setBesittningMoney(store, money) {
+    if (!store.current) return;
+    store.data[store.current] = store.data[store.current] || {};
+    const cur = getBesittningMoney(store);
+    store.data[store.current].besittningMoney = normalizeMoney({
+      daler: cur.daler + (money.daler || 0),
+      skilling: cur.skilling + (money.skilling || 0),
+      'örtegar': cur['örtegar'] + (money['örtegar'] || 0)
+    });
+    save(store);
+  }
+
+  function clearBesittningMoney(store) {
+    if (!store.current) return;
+    store.data[store.current] = store.data[store.current] || {};
+    store.data[store.current].besittningMoney = defaultMoney();
+    save(store);
+  }
+
+  function getMoney(store) {
+    if (!store.current) return defaultMoney();
+    const base = getBaseMoney(store);
+    const ext  = getBesittningMoney(store);
+    return normalizeMoney({
+      daler: base.daler + ext.daler,
+      skilling: base.skilling + ext.skilling,
+      'örtegar': base['örtegar'] + ext['örtegar']
+    });
+  }
+
+  function setMoney(store, money) {
+    setBaseMoney(store, money);
   }
 
   function getPartySmith(store) {
@@ -192,6 +232,19 @@
 
   function setCompactEntries(store, val) {
     store.compactEntries = Boolean(val);
+    save(store);
+  }
+
+  function getBesittningCount(store) {
+    if (!store.current) return 0;
+    const data = store.data[store.current] || {};
+    return Number(data.besittningRemoveCount || 0);
+  }
+
+  function setBesittningCount(store, val) {
+    if (!store.current) return;
+    store.data[store.current] = store.data[store.current] || {};
+    store.data[store.current].besittningRemoveCount = Number(val) || 0;
     save(store);
   }
 
@@ -330,6 +383,13 @@ function defaultTraits() {
     setCustomEntries,
     getMoney,
     setMoney,
+    getBaseMoney,
+    setBaseMoney,
+    getBesittningMoney,
+    setBesittningMoney,
+    clearBesittningMoney,
+    getBesittningCount,
+    setBesittningCount,
     getPartySmith,
     setPartySmith,
     getPartyAlchemist,


### PR DESCRIPTION
## Summary
- implement separate storage for Besittning money and removal count
- prevent money popup from editing Besittning cash
- show a popup with the amount when Besittning is added
- remove money and track removals with warnings and auto delete
- add Besittning popup UI and styles
- update Besittning description with note about automatic money

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6889d951fd548323b6a20906ada0b279