### PR TITLE
Implement Privileged bonus money

### DIFF
--- a/data/fordel.json
+++ b/data/fordel.json
@@ -415,7 +415,7 @@
 
 {
   "namn": "Privilegierad",
-  "beskrivning": "Rollpersonen tillhör en grupp med högt anseende och tydliga fördelar inom sitt eget samhälle, men betraktas som avvikande eller misstänkt utanför detta sammanhang. Inom sitt samhälle får rollpersonen slå två gånger på sociala utmaningar och välja det bästa utfallet. Men i främmande miljöer där den egna gruppen är ovanlig måste rollpersonen istället slå två gånger på sociala utmaningar mot lokalbefolkningen och ta det sämsta resultatet. Rollpersonen börjar spelet med 50 daler i bältesbörsen.",
+  "beskrivning": "Rollpersonen tillhör en grupp med högt anseende och tydliga fördelar inom sitt eget samhälle, men betraktas som avvikande eller misstänkt utanför detta sammanhang. Inom sitt samhälle får rollpersonen slå två gånger på sociala utmaningar och välja det bästa utfallet. Men i främmande miljöer där den egna gruppen är ovanlig måste rollpersonen istället slå två gånger på sociala utmaningar mot lokalbefolkningen och ta det sämsta resultatet. Rollpersonen börjar spelet med 50 daler i bältesbörsen. Pengarna läggs till i inventariet automatiskt.",
   "kan_införskaffas_flera_gånger": false,
   "taggar": {
     "typ": ["Fördel"],

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -349,7 +349,7 @@
     const allInv = storeHelper.getInventory(store);
     recalcArtifactEffects();
     if (window.updateXP) updateXP();
-    const cash = storeHelper.normalizeMoney(storeHelper.getMoney(store));
+    const cash = storeHelper.normalizeMoney(storeHelper.getTotalMoney(store));
 
     if (dom.invTypeSel) {
       const types = new Set();


### PR DESCRIPTION
## Summary
- add automatic money handling for the `Privilegierad` advantage
- expose bonus money helper functions
- show total money with advantage bonus in inventory view
- clarify that Privilegierad money is added automatically

## Testing
- `node -e "require('./js/store.js'); console.log('ok');"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6889da170878832387ed9dfbb0fda785