### PR TITLE
Implement pain threshold bonus from Smärttålig

### DIFF
--- a/data/fordel.json
+++ b/data/fordel.json
@@ -627,13 +627,13 @@
   },
   {
     "namn": "Smärttålig",
-    "beskrivning": "Karaktären har härdat kropp och sinne att uthärda smärta. Karaktärens smärtgräns ökar med +1 per nivå (max +3).",
+    "beskrivning": "Karaktären har härdat kropp och sinne att uthärda smärta. Karaktärens smärtgräns ökar med +1 per gång fördelen väljs (max +3).",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
-      "ark_trad": ["Krigare"],
-      "test": ["Stark"]
-    }
+        "typ": ["Fördel"],
+        "ark_trad": ["Krigare"],
+        "test": []
+      }
   },
   {
     "namn": "Hårdnackad",

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -23,7 +23,7 @@
       const tal  = hasKraftprov && k === 'Stark'
         ? val + 5
         : Math.max(10, val);
-      const pain = Math.ceil(val / 2);
+      let pain = Math.ceil(val / 2);
       let extra = '';
       let beforeExtra = '';
       let afterExtra = `<div class="trait-count">F\u00f6rm\u00e5gor: ${counts[k]}</div>`;
@@ -31,6 +31,9 @@
         let base = val;
         const hasPack = list.some(e => e.namn === 'Pack\u00e5sna');
         if (hasPack) base = Math.ceil(base * 1.5);
+        const painBonus = list.filter(e => e.namn === 'Sm\u00e4rtt\u00e5lig').length;
+        const painPenalty = list.filter(e => e.namn === 'Br\u00e4cklig').length;
+        pain += painBonus - painPenalty;
         beforeExtra = `<div class="trait-count">F\u00f6rm\u00e5gor: ${counts[k]}</div>` +
           `<div class="trait-extra">B\u00e4rkapacitet: ${base}</div>`;
         afterExtra = '';


### PR DESCRIPTION
## Summary
- update `Smärttålig` description and remove its `Stark` test tag
- take Smärttålig/Bräcklig into account when calculating pain threshold

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889dacc1a8083238e42ced6363ff0d7