### PR TITLE
Add auto inventory handling for Välutrustad

### DIFF
--- a/data/fordel.json
+++ b/data/fordel.json
@@ -507,7 +507,7 @@
   },
   {
     "namn": "Välutrustad",
-    "beskrivning": "En karaktär med välutrustad är ingen nybörjare. Det här är en som varit med ett tag och vet vad som krävs av ett äventyr, alternativt fått information av erfarna skattletare om vad som behövs. Karaktären börjar alla äventyr med i sin packning utöver standard: 3 långfärdsbröd, 3 örtkurer, 30m rep, Papper&krita, 3 facklor, 1 mistlur.",
+    "beskrivning": "En karaktär med välutrustad är ingen nybörjare. Det här är en som varit med ett tag och vet vad som krävs av ett äventyr, alternativt fått information av erfarna skattletare om vad som behövs. Karaktären börjar alla äventyr med i sin packning utöver standard: 3× 10 meter rep, Papper, kritor, 3 facklor, 1 signalhorn. Dessa föremål läggs automatiskt till i inventariet.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
       "typ": ["Fördel"],

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -307,6 +307,28 @@ function initIndex() {
         }
         list.push({ ...p, nivå: lvl });
         storeHelper.setCurrentList(store, list); updateXP();
+
+        if (p.namn === 'Välutrustad') {
+          const inv = storeHelper.getInventory(store);
+          const freebies = [
+            { name: 'Rep, 10 meter', qty: 3 },
+            { name: 'Papper', qty: 1 },
+            { name: 'Kritor', qty: 1 },
+            { name: 'Fackla', qty: 3 },
+            { name: 'Signalhorn', qty: 1 }
+          ];
+          freebies.forEach(it => {
+            const row = inv.find(r => r.name === it.name);
+            if (row) {
+              row.qty += it.qty;
+              row.gratis = (row.gratis || 0) + it.qty;
+              if (!row.perk) row.perk = 'Välutrustad';
+            } else {
+              inv.push({ name: it.name, qty: it.qty, gratis: it.qty, gratisKval: [], removedKval: [], perk: 'Välutrustad' });
+            }
+          });
+          invUtil.saveInventory(inv); invUtil.renderInventory();
+        }
       }
     } else { /* rem */
       if (isInv(p)) {
@@ -339,6 +361,11 @@ function initIndex() {
             return;
         }
         storeHelper.setCurrentList(store,list); updateXP();
+        if (p.namn === 'Välutrustad') {
+          const inv = storeHelper.getInventory(store);
+          inv.forEach(row => { if (row.perk === 'Välutrustad') delete row.perk; });
+          invUtil.saveInventory(inv); invUtil.renderInventory();
+        }
       }
     }
     renderList(filtered());

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -630,6 +630,12 @@
       // 2a) Röd soptunna tar bort hela posten
       if (act === 'del') {
         if (idx >= 0) {
+          const row = inv[idx];
+          const perkActive = storeHelper.getCurrentList(store)
+            .some(x => x.namn === 'Välutrustad');
+          if (perkActive && row.perk === 'Välutrustad' && row.qty <= row.gratis) {
+            if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) return;
+          }
           inv.splice(idx, 1);
           saveInventory(inv);
           renderInventory();
@@ -659,9 +665,15 @@
       // "–" minskar qty eller tar bort posten
       if (act === 'sub') {
         if (idx >= 0) {
-          if (inv[idx].qty > 1) {
-            inv[idx].qty--;
-            if (inv[idx].gratis > inv[idx].qty) inv[idx].gratis = inv[idx].qty;
+          const row = inv[idx];
+          const perkActive = storeHelper.getCurrentList(store)
+            .some(x => x.namn === 'Välutrustad');
+          if (perkActive && row.perk === 'Välutrustad' && (row.qty - 1) < row.gratis) {
+            if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) return;
+          }
+          if (row.qty > 1) {
+            row.qty--;
+            if (row.gratis > row.qty) row.gratis = row.qty;
           } else {
             inv.splice(idx, 1);
           }


### PR DESCRIPTION
## Summary
- update description of the perk "Välutrustad"
- auto-populate inventory items when "Välutrustad" is added
- restrict deletion of those free items while perk is active
- remove restrictions once perk is removed

## Testing
- `node -e "require('./js/index-view.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6889dc8f9d3c832380cb5aa8667253b4