### PR TITLE
Implement Motståndskraft corruption threshold bonus

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -19,6 +19,8 @@
         ['Gesäll', 'Mästare'].includes(p.nivå || '')
     );
 
+    const resistCount = list.filter(p => p.namn === 'Motståndskraft').length;
+
     dom.traits.innerHTML = KEYS.map(k => {
       const val = (data[k] || 0) + (bonus[k] || 0);
       const hardy = hasHardnackad && k === 'Stark' ? 1 : 0;
@@ -44,7 +46,8 @@
         extra = `<div class="trait-extra">T\u00e5lighet: ${tal} \u2022 Sm\u00e4rtgr\u00e4ns: ${pain}</div>`;
       } else if (k === 'Viljestark') {
         const maxCor = strongGift ? val * 2 : val;
-        const thresh = strongGift ? val : Math.ceil(val / 2);
+        const baseThresh = strongGift ? val : Math.ceil(val / 2);
+        const thresh = baseThresh + resistCount;
         const effects = storeHelper.getArtifactEffects(store);
         const perm = storeHelper.calcPermanentCorruption(list, effects);
         extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` +


### PR DESCRIPTION
## Summary
- account for the Motståndskraft advantage when rendering traits
- corruption threshold now gains +1 per Motståndskraft, without affecting base calculations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889ddf892c083239d5f987aafd7c842