### PR TITLE
Handle corruption threshold for Dark Past

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -318,7 +318,7 @@ function defaultTraits() {
     return LEVEL_IDX[ent?.nivå || ''] || 0;
   }
 
-  function calcPermanentCorruption(list, extra) {
+  function calcPermanentCorruption(list, extra, threshold = 0) {
     let cor = 0;
     list.forEach(it => {
       const types = it.taggar?.typ || [];
@@ -337,6 +337,9 @@ function defaultTraits() {
       }
     });
     cor += extra?.corruption || 0;
+    if (list.some(it => it.namn === 'Mörkt förflutet')) {
+      cor += Math.ceil(threshold / 3);
+    }
     return cor;
   }
 

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -44,9 +44,11 @@
         extra = `<div class="trait-extra">T\u00e5lighet: ${tal} \u2022 Sm\u00e4rtgr\u00e4ns: ${pain}</div>`;
       } else if (k === 'Viljestark') {
         const maxCor = strongGift ? val * 2 : val;
-        const thresh = strongGift ? val : Math.ceil(val / 2);
+        let thresh = strongGift ? val : Math.ceil(val / 2);
+        const korruptionsk = Math.min(3, list.filter(e => e.namn === 'Korruptionskänslig').length);
+        thresh -= korruptionsk;
         const effects = storeHelper.getArtifactEffects(store);
-        const perm = storeHelper.calcPermanentCorruption(list, effects);
+        const perm = storeHelper.calcPermanentCorruption(list, effects, thresh);
         extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` +
                 `<div class="trait-extra">Maximal korruption: ${maxCor} \u2022 Korruptionstr\u00f6skel: ${thresh}</div>`;
       }


### PR DESCRIPTION
## Summary
- adjust calcPermanentCorruption to accept threshold and add extra corruption for `Mörkt förflutet`
- factor in `Korruptionskänslig` when calculating corruption threshold and pass threshold to storeHelper

## Testing
- `node - <<'NODE'
const fs=require('fs');const vm=require('vm');let ctx={window:{}};vm.runInNewContext(fs.readFileSync('js/utils.js','utf8'), ctx);ctx.explodeTags=ctx.window.explodeTags;vm.runInNewContext(fs.readFileSync('js/store.js','utf8'), ctx);const list=[{namn:'Mörkt förflutet'}];console.log(ctx.window.storeHelper.calcPermanentCorruption(list,{corruption:0},6));console.log(ctx.window.storeHelper.calcPermanentCorruption(list,{corruption:0},7));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6889e02c43bc8323bbfbd04be529e3b1