### PR TITLE
Fix pain threshold update for 'Bräcklig' trait

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -26,7 +26,10 @@
         ? val + 5
         : Math.max(10, val);
       const tal  = talBase + hardy;
-      const pain = Math.ceil(val / 2);
+      // Base pain threshold is half of the current Strength value
+      // (rounded up). It can be modified by traits such as
+      // Smärttålig and Bräcklig.
+      let pain = Math.ceil(val / 2);
 
       let extra = '';
       let beforeExtra = '';
@@ -37,6 +40,8 @@
         if (hasPack) base = Math.ceil(base * 1.5);
         const painBonus = list.filter(e => e.namn === 'Sm\u00e4rtt\u00e5lig').length;
         const painPenalty = list.filter(e => e.namn === 'Br\u00e4cklig').length;
+        // Sm\u00e4rtt\u00e5lig adds to the threshold while each Br\u00e4cklig
+        // reduces it. Multiple selections stack since we count each entry.
         pain += painBonus - painPenalty;
         beforeExtra = `<div class="trait-count">F\u00f6rm\u00e5gor: ${counts[k]}</div>` +
           `<div class="trait-extra">B\u00e4rkapacitet: ${base}</div>`;

--- a/tests/traits-utils.test.js
+++ b/tests/traits-utils.test.js
@@ -1,0 +1,16 @@
+const assert = require('assert');
+
+function calcPain(val, list) {
+  let pain = Math.ceil(val / 2);
+  const painBonus = list.filter(e => e === 'Smärttålig').length;
+  const painPenalty = list.filter(e => e === 'Bräcklig').length;
+  pain += painBonus - painPenalty;
+  return pain;
+}
+
+assert.strictEqual(calcPain(11, []), 6);
+assert.strictEqual(calcPain(12, ['Smärttålig']), 7);
+assert.strictEqual(calcPain(10, ['Bräcklig']), 4);
+assert.strictEqual(calcPain(10, ['Smärttålig', 'Bräcklig', 'Bräcklig']), 4);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- allow adjusting pain threshold by making `pain` a `let`
- clarify how Smärttålig and Bräcklig modify pain
- add simple node test covering stacked effects

## Testing
- `node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6889e02ef4e08323bc40c9e98875c4a7