### PR TITLE
Add race-based trait restrictions

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -279,6 +279,14 @@ function initIndex() {
             if (!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')) return;
           }
         }
+        if (isSardrag(p) && (p.taggar.ras || []).length) {
+          const raceName = list.find(isRas)?.namn;
+          const ok = raceName && p.taggar.ras.includes(raceName);
+          if (!ok) {
+            const msg = 'Särdraget är bundet till rasen ' + p.taggar.ras.join(', ') + '.\nLägga till ändå?';
+            if (!confirm(msg)) return;
+          }
+        }
         if (p.namn === 'Exceptionellt karakt\u00e4rsdrag' && window.exceptionSkill) {
           const used=list.filter(x=>x.namn===p.namn).map(x=>x.trait).filter(Boolean);
           exceptionSkill.pickTrait(used, trait => {

--- a/js/store.js
+++ b/js/store.js
@@ -85,9 +85,27 @@
     }
   }
 
+  function applyRaceTraits(list) {
+    const race = list.find(isRas)?.namn || null;
+    DB.forEach(ent => {
+      if (!((ent.taggar?.typ || []).includes('S\u00e4rdrag'))) return;
+      const ras = ent.taggar?.ras;
+      if (!ras || !Array.isArray(ras)) return;
+      if (ent.niv\u00e5er) return;
+      const idx = list.findIndex(x => x.namn === ent.namn);
+      const allowed = race && ras.includes(race);
+      if (allowed) {
+        if (idx < 0) list.push({ ...ent });
+      } else {
+        if (idx >= 0) list.splice(idx, 1);
+      }
+    });
+  }
+
   function setCurrentList(store, list) {
     if (!store.current) return;
     applyDarkBloodEffects(list);
+    applyRaceTraits(list);
     store.data[store.current] = store.data[store.current] || {};
     store.data[store.current].list = list;
     const hasPriv = list.some(x => x.namn === 'Privilegierad');

--- a/js/utils.js
+++ b/js/utils.js
@@ -32,6 +32,7 @@
   function isElityrke(p){ return (p.taggar?.typ||[]).includes('Elityrke'); }
   function isEliteSkill(p){ return (p.taggar?.typ||[]).includes('Elityrkesf\u00f6rm\u00e5ga'); }
   function isMonstrousTrait(p){ return (p.taggar?.typ||[]).includes('Monstru\u00f6st s\u00e4rdrag'); }
+  function isSardrag(p){ return (p.taggar?.typ||[]).includes('S\u00e4rdrag'); }
   function isMysticQual(name){
     return (window.DB?.find(x => x.namn === name)?.taggar?.typ || []).includes('Mystisk kvalitet');
   }
@@ -130,6 +131,7 @@
   window.isElityrke = isElityrke;
   window.isEliteSkill = isEliteSkill;
   window.isMonstrousTrait = isMonstrousTrait;
+  window.isSardrag = isSardrag;
   window.isMysticQual = isMysticQual;
   window.isNegativeQual = isNegativeQual;
   window.isNeutralQual = isNeutralQual;


### PR DESCRIPTION
## Summary
- add helper `isSardrag`
- add `applyRaceTraits` in `store` and hook it into `setCurrentList`
- restrict race-linked traits in the index view

## Testing
- `node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6889e40f8b708323951eb7f2b3b99faf