### PR TITLE
Allow Troll race to pick some monstrous traits

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -281,8 +281,11 @@ function initIndex() {
           }
         }
         if (isMonstrousTrait(p)) {
+          const baseRace = list.find(isRas)?.namn;
+          const trollTraits = ['Naturligt vapen', 'Pansar', 'Regeneration', 'Robust'];
           const allowed = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
-            list.some(x => x.namn === 'Mörkt blod');
+            list.some(x => x.namn === 'Mörkt blod') ||
+            (baseRace === 'Troll' && trollTraits.includes(p.namn));
           if (!allowed) {
             if (!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')) return;
           }


### PR DESCRIPTION
## Summary
- let Troll characters pick monstrous traits `Naturligt vapen`, `Pansar`, `Regeneration` and `Robust` without confirmation prompt

## Testing
- `node tests/traits-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688a0923732c8323ad0e974c18c4c340