### PR TITLE
Warn when removing required abilities

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -217,7 +217,14 @@ function initCharacter() {
         list = before.filter(x => !(x.namn===name && (tr?x.trait===tr:!x.trait)));
       }
       if(eliteReq.canChange(before) && !eliteReq.canChange(list)){
-        if(!confirm('Förmågan krävs för ett valt elityrke. Ta bort ändå?'))
+        const deps = before
+          .filter(isElityrke)
+          .filter(el => eliteReq.check(el, before).ok && !eliteReq.check(el, list).ok)
+          .map(el => el.namn);
+        const msg = deps.length
+          ? `Förmågan krävs för: ${deps.join(', ')}. Ta bort ändå?`
+          : 'Förmågan krävs för ett valt elityrke. Ta bort ändå?';
+        if(!confirm(msg))
           return;
       }
     } else {

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -408,7 +408,14 @@ function initIndex() {
           }
         }
         if(eliteReq.canChange(before) && !eliteReq.canChange(list)) {
-          if(!confirm('Förmågan krävs för ett valt elityrke. Ta bort ändå?'))
+          const deps = before
+            .filter(isElityrke)
+            .filter(el => eliteReq.check(el, before).ok && !eliteReq.check(el, list).ok)
+            .map(el => el.namn);
+          const msg = deps.length
+            ? `Förmågan krävs för: ${deps.join(', ')}. Ta bort ändå?`
+            : 'Förmågan krävs för ett valt elityrke. Ta bort ändå?';
+          if(!confirm(msg))
             return;
         }
         storeHelper.setCurrentList(store,list); updateXP();


### PR DESCRIPTION
## Summary
- add specific dependency warnings when removing skills

## Testing
- `node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688a125328608323959064420d24c78f