### PR TITLE
Implement Besittning perk

### DIFF
--- a/data/fordel.json
+++ b/data/fordel.json
@@ -31,8 +31,8 @@
   },
   {
     "namn": "Besittning",
-    "beskrivning": "Rollpersonen har en affärsrörelse av något slag – en liten taverna, en mindre handelsbod eller annan enklare hantverkstjänst som skomakare eller liknande. Andra möjligheter är en teater eller gycklargrupp. Besittningen kan vara stationär på en plats dit rollpersonen ofta återkommer mellan äventyr, eller rörlig i form av en vagn eller liten flodbåt om det passar spelet bättre. En gång per äventyr (lämpligen mellan äventyr) får spelaren slå mot Listig (för hantverk) eller Övertygande (för tjänster). Framgång ger en vinst om 1t10+10 daler, efter att alla omkostnader för affärsrörelsen är betalda. Om flera rollpersoner har Besittning kan det utgöra andelar i samma rörelse. Varje rollperson slår då separata slag för sin andel.",
-    "kan_införskaffas_flera_gånger": true,
+    "beskrivning": "Rollpersonen har en affärsrörelse av något slag – en liten taverna, en mindre handelsbod eller annan enklare hantverkstjänst som skomakare eller liknande. Andra möjligheter är en teater eller gycklargrupp. Besittningen kan vara stationär på en plats dit rollpersonen ofta återkommer mellan äventyr, eller rörlig i form av en vagn eller liten flodbåt om det passar spelet bättre. En gång per äventyr (lämpligen mellan äventyr) får spelaren slå mot Listig (för hantverk) eller Övertygande (för tjänster). Framgång ger en vinst om 1t10+10 daler, efter att alla omkostnader för affärsrörelsen är betalda. Pengarna läggs till i inventariet automatiskt. Om flera rollpersoner har Besittning kan det utgöra andelar i samma rörelse. Varje rollperson slår då separata slag för sin andel.",
+    "kan_införskaffas_flera_gånger": false,
     "taggar": {
       "typ": ["Fördel"],
       "ark_trad": [],

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -337,6 +337,11 @@ function initIndex() {
         }
         list.push({ ...p, nivå: lvl });
         storeHelper.setCurrentList(store, list); updateXP();
+        if (p.namn === 'Besittning') {
+          const amount = Math.floor(Math.random() * 10) + 11;
+          storeHelper.setPossessionMoney(store, { daler: amount, skilling: 0, 'örtegar': 0 });
+          invUtil.renderInventory();
+        }
 
         if (p.namn === 'Välutrustad') {
           const inv = storeHelper.getInventory(store);
@@ -412,6 +417,20 @@ function initIndex() {
             return;
         }
         storeHelper.setCurrentList(store,list); updateXP();
+        if (p.namn === 'Besittning') {
+          storeHelper.setPossessionMoney(store, { daler: 0, skilling: 0, 'örtegar': 0 });
+          const cnt = storeHelper.incrementPossessionRemoved(store);
+          if (cnt >= 3) {
+            const id = store.current;
+            alert('Karaktären raderas på grund av misstänkt fusk.');
+            storeHelper.deleteCharacter(store, id);
+            location.reload();
+            return;
+          } else if (cnt === 2) {
+            alert('Misstänkt fusk: lägger du till och tar bort denna fördel igen raderas karaktären omedelbart');
+          }
+          invUtil.renderInventory();
+        }
         if (p.namn === 'Välutrustad') {
           const inv = storeHelper.getInventory(store);
           inv.forEach(row => { if (row.perk === 'Välutrustad') delete row.perk; });

--- a/js/main.js
+++ b/js/main.js
@@ -237,11 +237,8 @@ function bindToolbar() {
       const char = store.characters.find(c => c.id === store.current);
       if (!confirm(`Ta bort “${char.name}”?`)) return;
 
-      store.characters = store.characters.filter(c => c.id !== store.current);
-      delete store.data[store.current];
-      store.current = '';
-
-      storeHelper.save(store);
+      const idToDel = store.current;
+      storeHelper.deleteCharacter(store, idToDel);
       location.reload();
     }
   });


### PR DESCRIPTION
## Summary
- add automatic money payout and description updates for Besittning
- track bonus money from Privilegierad and Besittning separately
- warn and eventually delete characters repeatedly removing Besittning
- provide new store helper functions for perk handling
- integrate deletion helper in main view

## Testing
- `node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688a12789a588323be732eb60d261dfd