### PR TITLE
Handle Välutrustad inventory bonuses correctly

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -345,7 +345,9 @@ function initIndex() {
             { name: 'Papper', qty: 1 },
             { name: 'Kritor', qty: 1 },
             { name: 'Fackla', qty: 3 },
-            { name: 'Signalhorn', qty: 1 }
+            { name: 'Signalhorn', qty: 1 },
+            { name: 'Långfärdsbröd', qty: 3 },
+            { name: 'Örtkur', qty: 3 }
           ];
           freebies.forEach(it => {
             const row = inv.find(r => r.name === it.name);
@@ -414,7 +416,18 @@ function initIndex() {
         storeHelper.setCurrentList(store,list); updateXP();
         if (p.namn === 'Välutrustad') {
           const inv = storeHelper.getInventory(store);
-          inv.forEach(row => { if (row.perk === 'Välutrustad') delete row.perk; });
+          for (let i = inv.length - 1; i >= 0; i--) {
+            const row = inv[i];
+            if (row.perk === 'Välutrustad') {
+              const removed = Math.min(row.gratis || 0, row.qty);
+              row.qty -= removed;
+              row.gratis = Math.max(0, (row.gratis || 0) - removed);
+              delete row.perk;
+              if (row.qty <= 0) {
+                inv.splice(i, 1);
+              }
+            }
+          }
           invUtil.saveInventory(inv); invUtil.renderInventory();
         }
       }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -741,8 +741,18 @@
       if (act === 'free') {
         if (idx >= 0) {
           const row = inv[idx];
-          row.gratis = Number(row.gratis || 0) + 1;
-          if (row.gratis > row.qty) row.gratis = 0;
+          let newGratis = Number(row.gratis || 0) + 1;
+          if (newGratis > row.qty) newGratis = 0;
+
+          const perkActive = storeHelper.getCurrentList(store)
+            .some(x => x.namn === 'Välutrustad');
+          if (perkActive && row.perk === 'Välutrustad' && newGratis < (row.gratis || 0)) {
+            if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) {
+              return;
+            }
+          }
+
+          row.gratis = newGratis;
           saveInventory(inv);
           renderInventory();
         }


### PR DESCRIPTION
## Summary
- give `Välutrustad` perk the missing items _Långfärdsbröd_ and _Örtkur_
- remove all `Välutrustad` freebies when the perk disappears
- warn before turning off free status on `Välutrustad` gear

## Testing
- `node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688a1290c9c08323b2963f7f17c8cbd0