### PR TITLE
Update inventory money display when adding/removing perks

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -231,6 +231,18 @@ function initCharacter() {
       return;
     }
     storeHelper.setCurrentList(store, list);
+    if (p.namn === 'Privilegierad') {
+      invUtil.renderInventory();
+    }
+    if (p.namn === 'Besittning') {
+      if (actBtn.dataset.act === 'add') {
+        const amount = Math.floor(Math.random() * 10) + 11;
+        storeHelper.setPossessionMoney(store, { daler: amount, skilling: 0, 'örtegar': 0 });
+      } else {
+        storeHelper.setPossessionMoney(store, { daler: 0, skilling: 0, 'örtegar': 0 });
+      }
+      invUtil.renderInventory();
+    }
     renderSkills(filtered());
     updateXP();
     renderTraits();

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -340,6 +340,9 @@ function initIndex() {
         }
         list.push({ ...p, nivå: lvl });
         storeHelper.setCurrentList(store, list); updateXP();
+        if (p.namn === 'Privilegierad') {
+          invUtil.renderInventory();
+        }
         if (p.namn === 'Besittning') {
           const amount = Math.floor(Math.random() * 10) + 11;
           storeHelper.setPossessionMoney(store, { daler: amount, skilling: 0, 'örtegar': 0 });
@@ -429,6 +432,9 @@ function initIndex() {
             return;
         }
         storeHelper.setCurrentList(store,list); updateXP();
+        if (p.namn === 'Privilegierad') {
+          invUtil.renderInventory();
+        }
         if (p.namn === 'Besittning') {
           storeHelper.setPossessionMoney(store, { daler: 0, skilling: 0, 'örtegar': 0 });
           const cnt = storeHelper.incrementPossessionRemoved(store);


### PR DESCRIPTION
## Summary
- refresh the inventory display whenever `Privilegierad` or `Besittning` are toggled
- handle possession money in character view as well

## Testing
- `node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688a16237f348323a82955eb2ddace7d