### PR TITLE
Refactor toolbar layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -238,13 +238,26 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
   border-top: 1.5px solid var(--border);
   padding: .6rem .8rem;
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: .6rem;
 }
-.toolbar select,
-.toolbar input {
+.toolbar-top {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+}
+.toolbar-top input {
   flex: 1 1 110px;
   min-width: 90px;
+}
+.button-row {
+  display: flex;
+  gap: .6rem;
+}
+.button-row > a,
+.button-row > button {
+  flex: 1;
+  min-width: 0;
 }
 
 /* Badge för inventarie­knapp */

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -29,16 +29,19 @@ class SharedToolbar extends HTMLElement {
 
       <!-- ---------- Verktygsrad ---------- -->
       <footer class="toolbar">
-        <input id="searchField" placeholder="Sök…">
-        <span    class="exp-counter">XP: <span id="xpOut">0</span></span>
-        <a       id="switchRole" class="char-btn icon" title="Byt vy">🔄</a>
-
-        <button  id="invToggle"    class="char-btn icon" title="Inventarie">
-          🎒 <span id="invBadge">0</span>
-        </button>
-        <button  id="traitsToggle" class="char-btn icon" title="Egenskaper">📊</button>
-        <button  id="clearFilters" class="char-btn">Rensa filter</button>
-        <button  id="filterToggle" class="char-btn icon" title="Filter">⚙️</button>
+        <div class="toolbar-top">
+          <input id="searchField" placeholder="Sök…">
+          <span class="exp-counter">XP: <span id="xpOut">0</span></span>
+        </div>
+        <div class="button-row">
+          <a       id="switchRole" class="char-btn icon" title="Byt vy">🔄</a>
+          <button  id="invToggle"    class="char-btn icon" title="Inventarie">
+            🎒 <span id="invBadge">0</span>
+          </button>
+          <button  id="traitsToggle" class="char-btn icon" title="Egenskaper">📊</button>
+          <button  id="clearFilters" class="char-btn">Rensa filter</button>
+          <button  id="filterToggle" class="char-btn icon" title="Filter">⚙️</button>
+        </div>
       </footer>
 
       <!-- ---------- Inventarie ---------- -->


### PR DESCRIPTION
## Summary
- center toolbar buttons and place search row on top
- allow toolbar buttons to resize to fit screen

## Testing
- `node tests/traits-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688a169ceb688323bb7df956002a37d5