### PR TITLE
Fix Välutrustad free item removal warning

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -365,9 +365,10 @@ function initIndex() {
             if (row) {
               row.qty += it.qty;
               row.gratis = (row.gratis || 0) + it.qty;
+              row.perkGratis = (row.perkGratis || 0) + it.qty;
               if (!row.perk) row.perk = 'Välutrustad';
             } else {
-              inv.push({ name: it.name, qty: it.qty, gratis: it.qty, gratisKval: [], removedKval: [], perk: 'Välutrustad' });
+              inv.push({ name: it.name, qty: it.qty, gratis: it.qty, gratisKval: [], removedKval: [], perk: 'Välutrustad', perkGratis: it.qty });
             }
           });
           invUtil.saveInventory(inv); invUtil.renderInventory();
@@ -454,10 +455,13 @@ function initIndex() {
           for (let i = inv.length - 1; i >= 0; i--) {
             const row = inv[i];
             if (row.perk === 'Välutrustad') {
-              const removed = Math.min(row.gratis || 0, row.qty);
+              const pg = row.perkGratis || row.gratis || 0;
+              const removed = Math.min(pg, row.qty);
               row.qty -= removed;
               row.gratis = Math.max(0, (row.gratis || 0) - removed);
+              row.perkGratis = Math.max(0, (row.perkGratis || 0) - removed);
               delete row.perk;
+              delete row.perkGratis;
               if (row.qty <= 0) {
                 inv.splice(i, 1);
               }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -633,7 +633,8 @@
           const row = inv[idx];
           const perkActive = storeHelper.getCurrentList(store)
             .some(x => x.namn === 'Välutrustad');
-          if (perkActive && row.perk === 'Välutrustad' && row.qty <= row.gratis) {
+          const pg = row.perkGratis || 0;
+          if (perkActive && row.perk === 'Välutrustad' && pg > 0) {
             if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) return;
           }
           inv.splice(idx, 1);
@@ -668,12 +669,15 @@
           const row = inv[idx];
           const perkActive = storeHelper.getCurrentList(store)
             .some(x => x.namn === 'Välutrustad');
-          if (perkActive && row.perk === 'Välutrustad' && (row.qty - 1) < row.gratis) {
+          const pg = row.perkGratis || 0;
+          const removingPerkItem = (row.qty - 1) < pg;
+          if (perkActive && row.perk === 'Välutrustad' && removingPerkItem) {
             if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) return;
           }
           if (row.qty > 1) {
             row.qty--;
             if (row.gratis > row.qty) row.gratis = row.qty;
+            if (removingPerkItem && pg > 0) row.perkGratis = pg - 1;
           } else {
             inv.splice(idx, 1);
           }
@@ -746,7 +750,12 @@
 
           const perkActive = storeHelper.getCurrentList(store)
             .some(x => x.namn === 'Välutrustad');
-          if (perkActive && row.perk === 'Välutrustad' && newGratis < (row.gratis || 0)) {
+          if (
+            perkActive &&
+            row.perk === 'Välutrustad' &&
+            newGratis < (row.gratis || 0) &&
+            newGratis < (row.perkGratis || 0)
+          ) {
             if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) {
               return;
             }


### PR DESCRIPTION
## Summary
- track how many free items each Välutrustad entry provides
- adjust warnings when removing or unmarking free items
- keep Välutrustad freebies when removing the perk

## Testing
- `node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688a2357f9b483238b54591533ea0824