### PR TITLE
Update dark blood removal behavior

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -204,6 +204,10 @@ function initCharacter() {
         if(!confirm('Bestialisk hänger ihop med Mörkt blod. Ta bort ändå?'))
           return;
       }
+      if(isMonstrousTrait(p) && before.some(x=>x.namn==='Mörkt blod')){
+        if(!confirm(name+' hänger ihop med Mörkt blod. Ta bort ändå?'))
+          return;
+      }
       if(multi){
         let removed=false;
         list=[];
@@ -218,7 +222,11 @@ function initCharacter() {
       }
       const removed = before.find(it => it.namn===name && (tr?it.trait===tr:!it.trait));
       const remDeps = storeHelper.getDependents(before, removed);
-      if(remDeps.length){
+      if(name==='Mörkt blod' && remDeps.length){
+        if(confirm(`Ta bort även: ${remDeps.join(', ')}?`)){
+          list = list.filter(x => !remDeps.includes(x.namn));
+        }
+      } else if(remDeps.length){
         if(!confirm(`F\u00f6rm\u00e5gan kr\u00e4vs f\u00f6r: ${remDeps.join(', ')}. Ta bort \u00e4nd\u00e5?`)) return;
       }
       if(eliteReq.canChange(before) && !eliteReq.canChange(list)){

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -390,6 +390,10 @@ function initIndex() {
           if(!confirm('Bestialisk hänger ihop med Mörkt blod. Ta bort ändå?'))
             return;
         }
+        if(isMonstrousTrait(p) && before.some(x=>x.namn==='Mörkt blod')){
+          if(!confirm(p.namn+' hänger ihop med Mörkt blod. Ta bort ändå?'))
+            return;
+        }
         let list;
         const multi = p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ['Fördel','Nackdel'].includes(t));
         if(multi){
@@ -407,7 +411,11 @@ function initIndex() {
         }
         const removed = before.find(it => it.namn===p.namn && (tr?it.trait===tr:!it.trait));
         const remDeps = storeHelper.getDependents(before, removed);
-        if(remDeps.length){
+        if(p.namn==='Mörkt blod' && remDeps.length){
+          if(confirm(`Ta bort även: ${remDeps.join(', ')}?`)){
+            list = list.filter(x => !remDeps.includes(x.namn));
+          }
+        } else if(remDeps.length){
           if(!confirm(`F\u00f6rm\u00e5gan kr\u00e4vs f\u00f6r: ${remDeps.join(', ')}. Ta bort \u00e4nd\u00e5?`)) return;
         }
         if(eliteReq.canChange(before) && !eliteReq.canChange(list)) {

--- a/js/store.js
+++ b/js/store.js
@@ -89,30 +89,6 @@
         const entry = DB.find(x => x.namn === 'Bestialisk');
         if (entry) list.push({ ...entry });
       }
-    } else {
-      if (idxBest >= 0) list.splice(idxBest, 1);
-
-      const races = [];
-      const main = list.find(isRas)?.namn || null;
-      if (main) races.push(main);
-      list.forEach(it => {
-        if (it.namn === 'Blodsband' && it.race) races.push(it.race);
-      });
-
-      const raceExtras = {
-        'Rese': ['Robust'],
-        'Troll': ['Naturligt vapen', 'Pansar', 'Regeneration', 'Robust']
-      };
-
-      const allowed = new Set();
-      races.forEach(r => {
-        (raceExtras[r] || []).forEach(t => allowed.add(t));
-      });
-
-      for (let i = list.length - 1; i >= 0; i--) {
-        const name = list[i].namn;
-        if (extra.includes(name) && !allowed.has(name)) list.splice(i, 1);
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent `applyDarkBloodEffects` from removing traits when "Mörkt blod" is removed
- warn when removing monstrous traits with active "Mörkt blod"
- on removing "Mörkt blod" ask whether dependent traits should be removed

## Testing
- `node tests/darkblood.test.js`
- `node tests/traits-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688a27ec3068832386f43f56f4a20773