### PR TITLE
Prioritize title matches in text search

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -41,11 +41,11 @@ function initCharacter() {
 
   const filtered = () => {
     union = storeHelper.getFilterUnion(store);
+    const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
+      .map(t => searchNormalize(t.toLowerCase()));
     return storeHelper.getCurrentList(store)
       .filter(p => !isInv(p))
       .filter(p => {
-        const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
-          .map(t => searchNormalize(t.toLowerCase()));
         const text = searchNormalize(`${p.namn} ${(p.beskrivning || '')}`.toLowerCase());
         const hasTerms = terms.length > 0;
         const txt = hasTerms && terms.every(q => text.includes(q));
@@ -70,7 +70,7 @@ function initCharacter() {
         const tagOk = !hasTags || tagMatch;
         return txtOk && tagOk;
       })
-      .sort(sortByType);
+      .sort(createSearchSorter(terms));
   };
 
   const renderSkills = arr=>{

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -42,9 +42,9 @@ function initIndex() {
 
   const filtered = () => {
     union = storeHelper.getFilterUnion(store);
+    const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
+      .map(t => searchNormalize(t.toLowerCase()));
     return getEntries().filter(p=>{
-      const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
-        .map(t => searchNormalize(t.toLowerCase()));
       const text = searchNormalize(`${p.namn} ${(p.beskrivning||'')}`.toLowerCase());
       const hasTerms = terms.length > 0;
       const txt = hasTerms && terms.every(q => text.includes(q));
@@ -69,7 +69,7 @@ function initIndex() {
       const txtOk  = !hasTerms || txt;
       const tagOk  = !hasTags || tagMatch;
       return txtOk && tagOk;
-    }).sort(sortByType);
+    }).sort(createSearchSorter(terms));
   };
 
   const renderList = arr=>{

--- a/js/utils.js
+++ b/js/utils.js
@@ -120,6 +120,21 @@
       .replace(/__oe__/g,'\u00f6');
   }
 
+  function createSearchSorter(terms){
+    const t = (terms||[])
+      .map(s => searchNormalize(String(s).toLowerCase()))
+      .filter(Boolean);
+    return function(a,b){
+      const aName = searchNormalize((a.namn||'').toLowerCase());
+      const bName = searchNormalize((b.namn||'').toLowerCase());
+      const aMatch = t.length && t.every(q=>aName.includes(q));
+      const bMatch = t.length && t.every(q=>bName.includes(q));
+      if(aMatch && !bMatch) return -1;
+      if(!aMatch && bMatch) return 1;
+      return sortByType(a,b);
+    };
+  }
+
   window.LVL = LVL;
   window.EQUIP = EQUIP;
   window.SBASE = SBASE;
@@ -141,4 +156,5 @@
   window.formatMoney = formatMoney;
   window.itemStatHtml = itemStatHtml;
   window.searchNormalize = searchNormalize;
+  window.createSearchSorter = createSearchSorter;
 })(window);

--- a/tests/search-sort.test.js
+++ b/tests/search-sort.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+
+// Stub minimal window
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} }
+};
+
+require('../js/utils');
+
+const entries = [
+  { namn: 'Gruvhacka', beskrivning: 'Ett robust verktyg', taggar: { typ: ['S\u00e4rdrag'] } },
+  { namn: 'M\u00f6rkt blod', beskrivning: 'Robust beskrivning', taggar: { typ: ['S\u00e4rdrag'] } },
+  { namn: 'Robust', beskrivning: 'S\u00e4rdrag', taggar: { typ: ['S\u00e4rdrag'] } }
+];
+
+entries.sort(window.createSearchSorter(['robust']));
+
+assert.strictEqual(entries[0].namn, 'Robust');
+assert.deepStrictEqual(entries.slice(1).map(e => e.namn), ['Gruvhacka', 'M\u00f6rkt blod']);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add `createSearchSorter` utility
- sort search results using `createSearchSorter`
- test sorting so that title matches come first

## Testing
- `node tests/search-sort.test.js`
- `node tests/darkblood.test.js`
- `node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688a320303a0832386b5d64772a2f50f