### PR TITLE
Adjust inventory buttons for mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -382,6 +382,8 @@ select.level {
   .trait       { padding: .55rem .45rem; }
   .trait-btn   { padding: .1rem .5rem; }
   .trait-value { font-size: 1.15rem; }
+  .inv-controls { gap: .3rem; flex-wrap: nowrap; }
+  .inv-controls .char-btn { padding: .3rem .45rem; font-size: .9rem; }
 }
 /* ---------- Off-canvas-paneler från höger ---------- */
 #invPanel,


### PR DESCRIPTION
## Summary
- make inventory buttons smaller on small screens

## Testing
- `node tests/darkblood.test.js`
- `node tests/rawstrength.test.js`
- `node tests/search-sort.test.js`
- `node tests/traits-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688a3725746c8323a6d8bb369f65a247