### PR TITLE
Adjust mobile inventory buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -382,8 +382,8 @@ select.level {
   .trait       { padding: .55rem .45rem; }
   .trait-btn   { padding: .1rem .5rem; }
   .trait-value { font-size: 1.15rem; }
-  .inv-controls { gap: .3rem; flex-wrap: nowrap; }
-  .inv-controls .char-btn { padding: .3rem .45rem; font-size: .9rem; }
+  .inv-controls { gap: .25rem; flex-wrap: nowrap; }
+  .inv-controls .char-btn { padding: .25rem .35rem; font-size: .8rem; }
 }
 /* ---------- Off-canvas-paneler från höger ---------- */
 #invPanel,


### PR DESCRIPTION
## Summary
- tweak inventory button sizes for small screens

## Testing
- `node tests/darkblood.test.js`
- `node tests/search-sort.test.js`
- `node tests/rawstrength.test.js`
- `node tests/traits-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688a3d0da3548323bd9ca6b7e6c274ce