### PR TITLE
Shorter export codes

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -97,6 +97,7 @@ const DATA_FILES = [
 Promise.all(DATA_FILES.map(f => fetch(f).then(r => r.json())))
   .then(arrays => {
     DB = arrays.flat().sort(sortByType);
+    DB.forEach((ent, idx) => { ent.id = idx; });
     window.DB = DB;
     DBIndex = {};
     DB.forEach(ent => { DBIndex[ent.namn] = ent; });


### PR DESCRIPTION
## Summary
- assign numeric IDs to DB entries
- encode exports with base64-compressed binary
- look up inventory and trait items by numeric ID when exporting/importing

## Testing
- `node tests/rawstrength.test.js && node tests/darkblood.test.js && node tests/search-sort.test.js && node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688a5756e3488323bdddeb2fd259a19e