### PR TITLE
Fix mobile export copy

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -222,7 +222,9 @@ function bindToolbar() {
     if (id === 'exportChar') {
       if (!store.current) return alert('Ingen rollperson vald.');
       const code = storeHelper.exportCharacterCode(store, store.current);
-      prompt('Kopiera koden nedan:', code);
+      copyToClipboard(code)
+        .then(() => alert('Karakt\u00e4rskoden har kopierats.'))
+        .catch(() => prompt('Kopiera koden nedan:', code));
     }
 
     /* Importera rollperson -------------------------------- */

--- a/js/utils.js
+++ b/js/utils.js
@@ -120,6 +120,27 @@
       .replace(/__oe__/g,'\u00f6');
   }
 
+  // Copy text to clipboard. Uses the modern Clipboard API when available
+  // and falls back to a temporary textarea element for older browsers.
+  function copyToClipboard(text) {
+    if (navigator && navigator.clipboard && navigator.clipboard.writeText) {
+      return navigator.clipboard.writeText(text);
+    }
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'absolute';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    try {
+      document.execCommand('copy');
+    } finally {
+      document.body.removeChild(ta);
+    }
+    return Promise.resolve();
+  }
+
   function createSearchSorter(terms){
     const t = (terms||[])
       .map(s => searchNormalize(String(s).toLowerCase()))
@@ -157,4 +178,5 @@
   window.itemStatHtml = itemStatHtml;
   window.searchNormalize = searchNormalize;
   window.createSearchSorter = createSearchSorter;
+  window.copyToClipboard = copyToClipboard;
 })(window);


### PR DESCRIPTION
## Summary
- support copying export code via clipboard API
- fallback to old prompt when copy fails

## Testing
- `node tests/search-sort.test.js`
- `node tests/rawstrength.test.js`
- `node tests/darkblood.test.js`
- `node tests/traits-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688a6e1d4ca08323ac30a6f2e3f4e2ae