### PR TITLE
Adjust inventory buttons for mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -216,7 +216,11 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
   flex-wrap: wrap;
   justify-content: flex-end;
 }
-.inv-controls button { align-self: initial; }
+.inv-controls button {
+  align-self: initial;
+  flex: 1;
+  min-width: 0;
+}
 
 .count-badge {
   margin-left: .3rem;
@@ -383,7 +387,10 @@ select.level {
   .trait-btn   { padding: .1rem .5rem; }
   .trait-value { font-size: 1.15rem; }
   .inv-controls { gap: .25rem; flex-wrap: nowrap; }
-  .inv-controls .char-btn { padding: .25rem .35rem; font-size: .8rem; }
+  .inv-controls .char-btn {
+    padding: .42rem .6rem;
+    font-size: 1.3rem;
+  }
 }
 /* ---------- Off-canvas-paneler från höger ---------- */
 #invPanel,


### PR DESCRIPTION
## Summary
- allow inventory buttons to stretch and share row space
- enlarge inventory buttons on small screens

## Testing
- `node tests/darkblood.test.js && node tests/rawstrength.test.js && node tests/search-sort.test.js && node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688af822daa8832386fd9efce2344caa