### PR TITLE
Improve info slide-in readability and size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -404,13 +404,15 @@ select.level {
   z-index: 1000;
   overflow-y: auto;
   padding: 1.2rem 1rem 2rem;
+  font-size: 1rem;
 }
 
 /* Specifika max-breddar */
 #invPanel    { max-width: 420px; }
 #filterPanel { max-width: 360px; }
 #traitsPanel { max-width: 360px; }
-#yrkePanel   { max-width: 360px; }
+#yrkePanel   { max-width: 360px; font-size: 1.2rem; line-height: 1.6; }
+#yrkePanel p { margin: 0 0 1rem; }
 
 /* När klassen .open läggs på – låt panelen glida in */
 #invPanel.open,
@@ -418,6 +420,13 @@ select.level {
 #traitsPanel.open,
 #yrkePanel.open {
   right: 0;
+}
+
+@media (min-width: 1024px) {
+  #invPanel    { max-width: 520px; }
+  #filterPanel { max-width: 460px; }
+  #traitsPanel { max-width: 460px; }
+  #yrkePanel   { max-width: 520px; }
 }
 
 /* ---------- Popup för kvaliteter ---------- */

--- a/js/text-format.js
+++ b/js/text-format.js
@@ -2,9 +2,14 @@
   function formatText(str){
     if(!str) return '';
     return str
-      .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
-      .replace(/\*([^*]+)\*/g, '<em>$1</em>')
-      .replace(/\n/g, '<br>');
+      .split(/\n{2,}/)                   // dela upp i stycken vid tomma rader
+      .map(p => p
+        .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+        .replace(/\*([^*]+)\*/g, '<em>$1</em>')
+        .replace(/\n/g, '<br>')
+      )
+      .map(p => `<p>${p}</p>`)            // wrappa varje stycke i <p>
+      .join('');
   }
 
   function abilityHtml(p, maxLevel){
@@ -21,7 +26,7 @@
       }
     });
     const lvlHtml = `<dl class="levels">${lvls.join('')}</dl>`;
-    return base ? `<p>${base}</p>${lvlHtml}` : lvlHtml;
+    return base ? `${base}${lvlHtml}` : lvlHtml;
   }
   window.formatText = formatText;
   window.abilityHtml = abilityHtml;


### PR DESCRIPTION
## Summary
- format text into paragraphs in `formatText`
- remove redundant `<p>` wrapper when creating ability HTML
- enlarge text size and spacing in info panel
- make slide-in panels wider on desktops

## Testing
- `for f in tests/*.test.js; do node $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_688af8baad6083239c9c409546e0bf41