### PR TITLE
Update traits total display and highlight

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -335,6 +335,12 @@ select.level {
   gap: 1rem;
   margin: 1rem 0;
 }
+.traits-total {
+  margin-top: .5rem;
+  font-weight: 600;
+}
+.traits-total.good { color: #8fda8c; }
+.traits-total.bad  { color: #ff8989; }
 .trait {
   background: var(--card);
   border: 1.5px solid var(--card-border);

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -76,11 +76,10 @@ class SharedToolbar extends HTMLElement {
         </div>
         <!-- Sammanfattning -->
         <div id="xpSummary" class="exp-counter"></div>
-
-        <div id="traits" class="traits"></div>
-        <div class="exp-counter" style="text-align:right;">
+        <div class="exp-counter traits-total" style="text-align:center;">
           Tot: <span id="traitsTotal">0</span>
         </div>
+        <div id="traits" class="traits"></div>
         <div id="traitStats" class="exp-counter"></div>
       </aside>
 

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -87,7 +87,21 @@
       </div>`;
     }).join('');
 
-    dom.traitsTot.textContent = KEYS.reduce((sum,k)=>sum+(data[k]||0)+(bonus[k]||0),0);
+    const total = KEYS.reduce((sum,k)=>sum+(data[k]||0)+(bonus[k]||0),0);
+    dom.traitsTot.textContent = total;
+
+    const lvlMap = { Novis: 1, 'Gesäll': 2, 'Mästare': 3 };
+    let maxTot = 80;
+    list.forEach(it => {
+      if (it.namn === 'Exceptionellt karaktärsdrag') {
+        maxTot += lvlMap[it.nivå] || 0;
+      }
+    });
+    const parent = dom.traitsTot.closest('.traits-total');
+    if (parent) {
+      parent.classList.remove('good','bad');
+      parent.classList.add(total === maxTot ? 'good' : 'bad');
+    }
 
     if (dom.traitStats) {
       dom.traitStats.textContent = "";


### PR DESCRIPTION
## Summary
- move traits total to top of the traits panel
- style traits total and highlight when not matching max
- calculate max traits including Exceptionellt karaktärsdrag levels

## Testing
- `node tests/search-sort.test.js`
- `node tests/rawstrength.test.js`
- `node tests/traits-utils.test.js`
- `node tests/darkblood.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688afa7b9e14832389808520474ab2d2