### PR TITLE
Enable undead to buy special traits

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -283,9 +283,11 @@ function initIndex() {
         if (isMonstrousTrait(p)) {
           const baseRace = list.find(isRas)?.namn;
           const trollTraits = ['Naturligt vapen', 'Pansar', 'Regeneration', 'Robust'];
+          const undeadTraits = ['Gravkyla', 'Skräckslå'];
           const allowed = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
             list.some(x => x.namn === 'Mörkt blod') ||
-            (baseRace === 'Troll' && trollTraits.includes(p.namn));
+            (baseRace === 'Troll' && trollTraits.includes(p.namn)) ||
+            (baseRace === 'Vandöd' && undeadTraits.includes(p.namn));
           if (!allowed) {
             if (!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')) return;
           }


### PR DESCRIPTION
## Summary
- allow characters with race `Vandöd` to purchase `Gravkyla` and `Skräckslå` without confirmation

## Testing
- `node tests/darkblood.test.js && node tests/rawstrength.test.js && node tests/search-sort.test.js && node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688afb910ec4832390323968bb398f62