### PR TITLE
Restrict search results to active filters

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -57,17 +57,11 @@ function initCharacter() {
           ...explodeTags(tags.ark_trad),
           ...(tags.test     ?? [])
         ];
-        const tagMatch = hasTags && (
+        const tagOk = !hasTags || (
           union ? selTags.some(t => itmTags.includes(t))
                 : selTags.every(t => itmTags.includes(t))
         );
-        if (union) {
-          if (!hasTerms && !hasTags) return true;
-          if (hasTerms && hasTags) return txt || tagMatch;
-          return hasTerms ? txt : tagMatch;
-        }
         const txtOk = !hasTerms || txt;
-        const tagOk = !hasTags || tagMatch;
         return txtOk && tagOk;
       })
       .sort(createSearchSorter(terms));

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -56,19 +56,12 @@ function initIndex() {
         ...explodeTags(tags.ark_trad),
         ...(tags.test     ?? [])
       ];
-      const tagMatch = hasTags && (
+      const tagOk = !hasTags || (
         union ? selTags.some(t => itmTags.includes(t))
               : selTags.every(t => itmTags.includes(t))
       );
-
-      if (union) {
-        if (!hasTerms && !hasTags) return true;
-        if (hasTerms && hasTags) return txt || tagMatch;
-        return hasTerms ? txt : tagMatch;
-      }
       const txtOk  = !hasTerms || txt;
-      const tagOk  = !hasTags || tagMatch;
-      return txtOk && tagOk;
+      return tagOk && txtOk;
     }).sort(createSearchSorter(terms));
   };
 


### PR DESCRIPTION
## Summary
- confine text search to currently active tag filters
- ensure union mode doesn't ignore selected tags

## Testing
- `node tests/search-sort.test.js`
- `node tests/darkblood.test.js`
- `node tests/rawstrength.test.js`
- `node tests/traits-utils.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688b14e249c48323817b705a2513e7e6