### PR TITLE
Close filter menu on reset

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -167,6 +167,7 @@ function initCharacter() {
     F.search=[];F.typ=[];F.ark=[];F.test=[]; sTemp='';
     dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
     activeTags(); renderSkills(filtered()); renderTraits();
+    bar.close('filterPanel');
   });
 
   /* ta bort & nivåbyte */

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -188,6 +188,7 @@ function initIndex() {
     F.search=[]; F.typ=[];F.ark=[];F.test=[]; sTemp='';
     dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
     activeTags(); renderList(filtered());
+    bar.close('filterPanel');
   });
 
   /* lista-knappar */


### PR DESCRIPTION
## Summary
- close the filter menu when clicking the "Rensa filter" button

## Testing
- `node tests/search-sort.test.js && node tests/rawstrength.test.js && node tests/darkblood.test.js && node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688b2598977483239f99fb4cd3ce1f90