### PR TITLE
Show tags on every entry

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -126,10 +126,14 @@ function initCharacter() {
       }else{
         btn = `<button class="char-btn danger icon" data-act="rem">🗑</button>`;
       }
+      const tagsHtml = (p.taggar?.typ || [])
+        .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
+        .map(t => `<span class="tag">${t}</span>`).join(' ');
       const showInfo = compact || hideDetails;
       const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '';
-      li.innerHTML = `<div class="card-title">${p.namn}${badge}</div>${lvlSel}
-
+      li.innerHTML = `<div class="card-title">${p.namn}${badge}</div>
+        ${tagsHtml}
+        ${lvlSel}
         ${descHtml}
         ${showInfo ? infoBtn : ''}${btn}`;
 

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -136,8 +136,8 @@ function initIndex() {
         ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
         : '';
       const li=document.createElement('li'); li.className='card' + (compact ? ' compact' : '');
-      const tagsHtml = hideDetails ? '' : (p.taggar.typ||[])
-        .concat(explodeTags(p.taggar.ark_trad), p.taggar.test||[])
+      const tagsHtml = (p.taggar?.typ || [])
+        .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
         .map(t=>`<span class="tag">${t}</span>`).join(' ');
       const levelHtml = hideDetails ? '' : lvlSel;
       const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';


### PR DESCRIPTION
## Summary
- display tag badges for entries regardless of view mode
- show the same tags when viewing a character's abilities

## Testing
- `node tests/darkblood.test.js && node tests/rawstrength.test.js && node tests/search-sort.test.js && node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688b25cbf6588323942bb3ca5cbbb2f7