### PR TITLE
Add dwarf exemption for Vedergällning corruption

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -458,9 +458,11 @@ function defaultTraits() {
 
   function calcPermanentCorruption(list, extra) {
     let cor = 0;
+    const isDwarf = list.some(x => x.namn === 'Dvärg' && (x.taggar?.typ || []).includes('Ras'));
     list.forEach(it => {
       const types = it.taggar?.typ || [];
       if (!['Mystisk kraft', 'Ritual'].some(t => types.includes(t))) return;
+      if (isDwarf && types.includes('Mystisk kraft') && it.namn === 'Vedergällning') return;
       const trads = explodeTags(it.taggar?.ark_trad);
       let lvl = 0;
       trads.forEach(tr => {

--- a/tests/vedergallning.test.js
+++ b/tests/vedergallning.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+
+// Minimal DOM/window stubs
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+global.localStorage = window.localStorage;
+
+// Populate minimal database entries
+window.DB = [
+  { namn: 'Dvärg', taggar: { typ: ['Ras'] } },
+  { namn: 'Människa', taggar: { typ: ['Ras'] } },
+  { namn: 'Vedergällning', taggar: { typ: ['Mystisk kraft'], ark_trad: ['Svartkonst'] },
+    nivåer: { Novis: '', Gesäll: '', Mästare: '' } }
+];
+window.DB.forEach(e => { window.DBIndex[e.namn] = e; });
+global.DB = window.DB;
+global.DBIndex = window.DBIndex;
+
+require('../js/lz-string.min.js');
+require('../js/utils');
+global.isRas = window.isRas;
+global.explodeTags = window.explodeTags;
+require('../js/store');
+
+function permForRace(race, level) {
+  const defaultMoney = { "örtegar":0, skilling:0, daler:0 };
+  const store = { current: 'c', data: { c: { privMoney: defaultMoney, possessionMoney: defaultMoney } } };
+  const list = [
+    { namn: race, taggar: { typ: ['Ras'] } },
+    { namn: 'Vedergällning', taggar: { typ: ['Mystisk kraft'], ark_trad: ['Svartkonst'] }, nivå: level }
+  ];
+  window.storeHelper.setCurrentList(store, list);
+  return window.storeHelper.calcPermanentCorruption(store.data.c.list, {});
+}
+
+assert.strictEqual(permForRace('Dvärg', 'Novis'), 0);
+assert.strictEqual(permForRace('Dvärg', 'Mästare'), 0);
+assert.strictEqual(permForRace('Människa', 'Novis'), 1);
+assert.strictEqual(permForRace('Människa', 'Mästare'), 3);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- ignore permanent corruption for dwarves taking the mystic power `Vedergällning`
- test that Vedergällning grants no permanent corruption to dwarves

## Testing
- `node tests/darkblood.test.js`
- `node tests/rawstrength.test.js`
- `node tests/traits-utils.test.js`
- `node tests/search-sort.test.js`
- `node tests/vedergallning.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688b26650390832393feef023eb470cd