### PR TITLE
Disallow Mörkt förflutet with Jordnära trait

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -206,6 +206,10 @@ function initCharacter() {
               return;
           }
         }
+        if(name==='Mörkt förflutet' && before.some(x=>x.namn==='Jordnära')){
+          alert('Jordnära karaktärer kan inte ta Mörkt förflutet.');
+          return;
+        }
         list = [...before, { ...p, nivå: lvl }];
     }else if(actBtn.dataset.act==='rem'){
       if(name==='Bestialisk' && before.some(x=>x.namn==='Mörkt blod')){

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -299,6 +299,10 @@ function initIndex() {
             if (!confirm('Råstyrka kräver Robust på minst Novis-nivå. Lägga till ändå?')) return;
           }
         }
+        if (p.namn === 'Mörkt förflutet' && list.some(x => x.namn === 'Jordnära')) {
+          alert('Jordnära karaktärer kan inte ta Mörkt förflutet.');
+          return;
+        }
         if (isSardrag(p) && (p.taggar.ras || []).length) {
           const races = [];
           const base = list.find(isRas)?.namn;

--- a/js/store.js
+++ b/js/store.js
@@ -114,6 +114,13 @@
     });
   }
 
+  function enforceEarthbound(list) {
+    if (list.some(x => x.namn === 'Jordnära')) {
+      const idx = list.findIndex(x => x.namn === 'Mörkt förflutet');
+      if (idx >= 0) list.splice(idx, 1);
+    }
+  }
+
   function getDependents(list, entry) {
     if (!entry) return [];
     const name = entry.namn || entry;
@@ -167,6 +174,7 @@
     if (!store.current) return;
     applyDarkBloodEffects(list);
     applyRaceTraits(list);
+    enforceEarthbound(list);
     store.data[store.current] = store.data[store.current] || {};
     store.data[store.current].list = list;
     const hasPriv = list.some(x => x.namn === 'Privilegierad');

--- a/tests/earthbound.test.js
+++ b/tests/earthbound.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+
+// Minimal DOM/window stubs
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+global.localStorage = window.localStorage;
+
+// Populate minimal database entries
+window.DB = [
+  { namn: 'Jordnära', taggar: { typ: ['Särdrag'] } },
+  { namn: 'Mörkt förflutet', taggar: { typ: ['Nackdel'] } }
+];
+window.DB.forEach(e => { window.DBIndex[e.namn] = e; });
+
+global.DB = window.DB;
+global.DBIndex = window.DBIndex;
+
+require('../js/lz-string.min.js');
+require('../js/utils');
+
+global.isRas = window.isRas;
+global.isElityrke = window.isElityrke;
+global.isMonstrousTrait = window.isMonstrousTrait;
+require('../js/store');
+
+const defaultMoney = { "örtegar":0, skilling:0, daler:0 };
+const store = { current: 'c', data: { c: { privMoney: defaultMoney, possessionMoney: defaultMoney } } };
+const list = [
+  { namn: 'Jordnära', taggar: { typ: ['Särdrag'] } },
+  { namn: 'Mörkt förflutet', taggar: { typ: ['Nackdel'] } }
+];
+window.storeHelper.setCurrentList(store, list);
+const hasDarkPast = store.data.c.list.some(x => x.namn === 'Mörkt förflutet');
+assert.strictEqual(hasDarkPast, false);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- enforce that characters with the trait `Jordnära` cannot take the disadvantage `Mörkt förflutet`
- add client-side checks in character and index views
- ensure store logic removes the disadvantage if present with `Jordnära`
- add regression test

## Testing
- `node tests/darkblood.test.js`
- `node tests/rawstrength.test.js`
- `node tests/search-sort.test.js`
- `node tests/traits-utils.test.js`
- `node tests/earthbound.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688b25eff9548323aa9e46446fbd2c34