### PR TITLE
Add XP cost display for character entries

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -179,7 +179,19 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
   flex-direction: column;
   gap: .45rem;
 }
-.card-title { font-size: 1.34rem; font-weight: 600; }
+.card-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 1.34rem;
+  font-weight: 600;
+}
+.xp-cost {
+  font-size: .9rem;
+  color: var(--subtxt);
+  font-weight: 500;
+  margin-left: .8rem;
+}
 .card-desc  { font-size: 1.15rem; }
 .card.compact .card-desc { display: none; }
 

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -123,10 +123,13 @@ function initCharacter() {
       const tagsHtml = (p.taggar?.typ || [])
         .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
         .map(t => `<span class="tag">${t}</span>`).join(' ');
+      const xpVal = storeHelper.calcEntryXP(p);
+      const xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
+      const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
       const showInfo = compact || hideDetails;
       const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '';
-      li.innerHTML = `<div class="card-title">${p.namn}${badge}</div>
-        ${tagsHtml}
+      li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span>${xpHtml}</div>
+        <div class="tags">${tagsHtml}</div>
         ${lvlSel}
         ${descHtml}
         ${showInfo ? infoBtn : ''}${btn}`;

--- a/js/store.js
+++ b/js/store.js
@@ -508,6 +508,23 @@ function defaultTraits() {
     return xp;
   }
 
+  function calcEntryXP(entry) {
+    const types = (entry.taggar?.typ || []).map(t => t.toLowerCase());
+    if (types.includes('nackdel')) return -5;
+    let xp = 0;
+    if (
+      entry.nivåer &&
+      ['mystisk kraft', 'förmåga', 'särdrag', 'monstruöst särdrag'].some(t => types.includes(t))
+    ) {
+      xp += XP_LADDER[entry.nivå || 'Novis'] || 0;
+    } else if (types.includes('monstruöst särdrag')) {
+      xp += RITUAL_COST;
+    }
+    if (types.includes('fördel')) xp += 5;
+    if (types.includes('ritual')) xp += RITUAL_COST;
+    return xp;
+  }
+
   function countDisadvantages(list) {
     const hasDark = list.some(x => x.namn === 'Mörkt blod');
     return list.filter(item => {
@@ -750,6 +767,7 @@ function defaultTraits() {
     getBaseXP,
     setBaseXP,
     calcUsedXP,
+    calcEntryXP,
     calcTotalXP,
     calcPermanentCorruption,
     abilityLevel,

--- a/tests/entryxp.test.js
+++ b/tests/entryxp.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+
+require('../js/lz-string.min.js');
+require('../js/utils');
+require('../js/store');
+
+delete global.window.DB;
+
+test();
+
+function test(){
+  const ability = { namn: 'Testförmåga', taggar:{ typ:['Förmåga']}, nivå:'Novis', nivåer:{Novis:''} };
+  const ritual = { namn: 'Testritual', taggar:{ typ:['Ritual'] } };
+  const dis = { namn: 'Dålig vana', taggar:{ typ:['Nackdel'] } };
+  assert.strictEqual(window.storeHelper.calcEntryXP(ability), 10);
+  assert.strictEqual(window.storeHelper.calcEntryXP(ritual), 10);
+  assert.strictEqual(window.storeHelper.calcEntryXP(dis), -5);
+  console.log('All tests passed.');
+}


### PR DESCRIPTION
## Summary
- show tags in cards with a tags container
- display current XP value for each selected entry
- expose `calcEntryXP` helper
- style card title and XP label
- test XP calculation for individual entries

## Testing
- `for f in tests/*.test.js; do node $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_688b2bbeeaa083238ed2ab9df61f8774