### PR TITLE
Fix clear filter closing off-canvas panels

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -168,7 +168,6 @@ function initCharacter() {
     F.search=[];F.typ=[];F.ark=[];F.test=[]; sTemp='';
     dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
     activeTags(); renderSkills(filtered()); renderTraits();
-    bar.close('filterPanel');
   });
 
   /* ta bort & nivåbyte */

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -181,7 +181,6 @@ function initIndex() {
     F.search=[]; F.typ=[];F.ark=[];F.test=[]; sTemp='';
     dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
     activeTags(); renderList(filtered());
-    bar.close('filterPanel');
   });
 
   /* lista-knappar */


### PR DESCRIPTION
## Summary
- adjust toolbar actions so the *Rensa filter* button no longer closes the filter panel

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_688b310ecb108323a086466698b1910f