### PR TITLE
Handle negative XP visually

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -300,6 +300,10 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
 
 .exp-counter { font-weight: 500; }
 
+/* Rödmarkering för negativa värden */
+.exp-counter.under { color: #ffb0b0; }
+.exp-counter.under span { color: inherit; }
+
 
 /* Specifika paneler använder samma klass plus egna id:n */
 #invPanel    { max-width: 420px; }

--- a/js/main.js
+++ b/js/main.js
@@ -415,8 +415,12 @@ function updateXP() {
   const free  = total - used;
   dom.xpOut.textContent = free;
   dom.xpIn.value = base;
-  if (dom.xpSum) dom.xpSum.textContent =
-    `Använt: ${used} • Oanvänt: ${free} • Totalt: ${total}`;
+  const xpContainer = dom.xpOut.closest('.exp-counter');
+  if (xpContainer) xpContainer.classList.toggle('under', free < 0);
+  if (dom.xpSum) {
+    dom.xpSum.textContent = `Använt: ${used} • Oanvänt: ${free} • Totalt: ${total}`;
+    dom.xpSum.classList.toggle('under', free < 0);
+  }
 }
 /* -----------------------------------------------------------
    Synk när annan flik ändrar localStorage


### PR DESCRIPTION
## Summary
- flag XP counters with red text when unused XP goes negative
- apply same red tint as under-filled traits total

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_688b3b54da508323998150a0dd31877c