### PR TITLE
Swap button positions in Nilas popup

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -257,8 +257,8 @@ class SharedToolbar extends HTMLElement {
         <div class="popup-inner">
           <h3>Nilas \u00e4r b\u00e4st. H\u00e5ller du med?</h3>
           <div class="button-row">
-            <button id="nilasYes" class="char-btn">Ja!</button>
             <button id="nilasNo" class="char-btn">Nej!</button>
+            <button id="nilasYes" class="char-btn">Ja!</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update `shared-toolbar.js` to place 'Nej' before 'Ja' in the Nilas popup

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_688b50713ce8832388e4df27805ab655