### PR TITLE
Add Djurmask artifact functionality

### DIFF
--- a/character.html
+++ b/character.html
@@ -19,6 +19,7 @@
   <script src="js/main.js"            defer></script>
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
+  <script src="js/djurmask.js" defer></script>
 </head>
 <body data-role="character">
 

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <script src="js/main.js"         defer></script>
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
+  <script src="js/djurmask.js" defer></script>
   <script src="js/elite-add.js"    defer></script>
 </head>
 <body data-role="index">

--- a/js/djurmask.js
+++ b/js/djurmask.js
@@ -1,0 +1,63 @@
+(function(window){
+  const TRAITS = ['Diskret','Kvick','Listig','Stark','Vaksam'];
+
+  function createPopup(){
+    if(document.getElementById('maskPopup')) return;
+    const div=document.createElement('div');
+    div.id='maskPopup';
+    div.innerHTML=`<div class="popup-inner"><h3 id="maskTitle">V\u00e4lj karakt\u00e4rsdrag</h3><div id="maskOpts"></div><button id="maskCancel" class="char-btn danger">Avbryt</button></div>`;
+    document.body.appendChild(div);
+  }
+
+  function openPopup(options, cb){
+    createPopup();
+    const pop=document.getElementById('maskPopup');
+    const box=pop.querySelector('#maskOpts');
+    const cls=pop.querySelector('#maskCancel');
+    box.innerHTML=options.map((n,i)=>`<button data-i="${i}" class="char-btn">${n}</button>`).join('');
+    pop.classList.add('open');
+    function close(){
+      pop.classList.remove('open');
+      box.innerHTML='';
+      box.removeEventListener('click',onClick);
+      cls.removeEventListener('click',onCancel);
+      pop.removeEventListener('click',onOutside);
+    }
+    function onClick(e){
+      const b=e.target.closest('button[data-i]'); if(!b) return;
+      const idx=Number(b.dataset.i); close(); cb(options[idx]);
+    }
+    function onCancel(){ close(); cb(null); }
+    function onOutside(e){ if(!pop.querySelector('.popup-inner').contains(e.target)){ close(); cb(null); } }
+    box.addEventListener('click',onClick);
+    cls.addEventListener('click',onCancel);
+    pop.addEventListener('click',onOutside);
+  }
+
+  function pickTrait(used, cb){
+    openPopup(TRAITS, trait=>{
+      if(!trait) { cb(null); return; }
+      if(used.includes(trait) && !confirm('Du har redan en Djurmask med detta karakt\u00e4rsdrag. L\u00e4gga till \u00e4nd\u00e5?')){
+        cb(null); return;
+      }
+      cb(trait);
+    });
+  }
+
+  function getBonuses(inv){
+    const list = inv || storeHelper.getInventory(store);
+    const res = {};
+    list.forEach(row => {
+      if(row.name === 'Djurmask' && row.trait){
+        res[row.trait] = (res[row.trait]||0) + 1;
+      }
+    });
+    return res;
+  }
+
+  function getBonus(trait, inv){
+    return getBonuses(inv)[trait] || 0;
+  }
+
+  window.animalMask = { pickTrait, getBonuses, getBonus };
+})(window);

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -230,6 +230,16 @@ function initIndex() {
     if (btn.dataset.act==='add') {
       if (isInv(p)) {
         const inv = storeHelper.getInventory(store);
+        if (p.namn === 'Djurmask' && window.animalMask) {
+          const used = inv.filter(x => x.name === 'Djurmask' && x.trait).map(x => x.trait);
+          animalMask.pickTrait(used, trait => {
+            if(!trait) return;
+            const rowBase = { name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[], trait };
+            inv.push(rowBase);
+            invUtil.saveInventory(inv); invUtil.renderInventory(); renderTraits();
+          });
+          return;
+        }
         const indiv = ['Vapen','Rustning','L\u00e4gre Artefakt'].some(t=>p.taggar.typ.includes(t));
         const rowBase = { name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
         if (p.artifactEffect) rowBase.artifactEffect = p.artifactEffect;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -486,6 +486,9 @@
             desc += `<div class="tags">${html}</div>`;
           }
           desc += itemStatHtml(entry);
+          if (row.trait) {
+            desc += `<br><strong>Karakt\u00e4rsdrag:</strong> ${row.trait}`;
+          }
 
           /* — kvaliteter — */
           const removedQ = row.removedKval ?? [];
@@ -651,6 +654,15 @@
       // "+" lägger till qty eller en ny instans
       if (act === 'add') {
         const indiv = ['Vapen','Rustning','L\u00e4gre Artefakt','Artefakter'].some(t => entry.taggar.typ.includes(t));
+        if (entry.namn === 'Djurmask' && window.animalMask) {
+          const used = inv.filter(x => x.name === 'Djurmask' && x.trait).map(x => x.trait);
+          animalMask.pickTrait(used, trait => {
+            if(!trait) return;
+            inv.push({ name: entry.namn, qty:1, gratis:0, gratisKval:[], removedKval:[], trait });
+            saveInventory(inv); renderInventory(); renderTraits();
+          });
+          return;
+        }
         if (indiv) {
           inv.push({ name: entry.namn, qty: 1, gratis:0, gratisKval:[], removedKval:[] });
         } else if (idx >= 0) {

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -5,7 +5,10 @@
     const KEYS = ['Diskret','Kvick','Listig','Stark','Tr\u00e4ffs\u00e4ker','Vaksam','Viljestark','\u00d6vertygande'];
 
     const list  = storeHelper.getCurrentList(store);
-    const bonus = window.exceptionSkill ? exceptionSkill.getBonuses(list) : {};
+    const exBonus = window.exceptionSkill ? exceptionSkill.getBonuses(list) : {};
+    const maskBonus = window.animalMask ? animalMask.getBonuses() : {};
+    const bonus = {};
+    KEYS.forEach(k => { bonus[k] = (exBonus[k]||0) + (maskBonus[k]||0); });
     const counts = {};
     KEYS.forEach(k => {
       counts[k] = list.filter(p => (p.taggar?.test || []).includes(k)).length;
@@ -96,6 +99,8 @@
         maxTot += lvlMap[it.nivå] || 0;
       }
     });
+    const maskCnt = storeHelper.getInventory(store).filter(r => r.name === 'Djurmask').length;
+    maxTot += maskCnt;
     if (dom.traitsTot) dom.traitsTot.textContent = total;
     if (dom.traitsMax) dom.traitsMax.textContent = maxTot;
     const parent = dom.traitsTot.closest('.traits-total');
@@ -124,7 +129,9 @@
       const d   = Number(btn.dataset.d);
 
       const t   = storeHelper.getTraits(store);
-      const bonus = window.exceptionSkill ? exceptionSkill.getBonus(key) : 0;
+      const b1 = window.exceptionSkill ? exceptionSkill.getBonus(key) : 0;
+      const b2 = window.animalMask ? animalMask.getBonus(key) : 0;
+      const bonus = b1 + b2;
       const min   = bonus;
       const next  = Math.max(0, (t[key] || 0) + d);
       t[key] = Math.max(min - bonus, next);

--- a/tests/djurmask.test.js
+++ b/tests/djurmask.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+global.localStorage = window.localStorage;
+
+require('../js/lz-string.min.js');
+require('../js/utils');
+require('../js/store');
+require('../js/djurmask');
+
+const defaultMoney = { "\u00f6rtegar":0, skilling:0, daler:0 };
+const store = { current:'c', data:{ c:{ inventory:[
+  { name:'Djurmask', trait:'Stark', qty:1 },
+  { name:'Djurmask', trait:'Kvick', qty:1 }
+], privMoney: defaultMoney, possessionMoney: defaultMoney } } };
+
+const bonuses = window.animalMask.getBonuses(store.data.c.inventory);
+assert.deepStrictEqual(bonuses, { Stark:1, Kvick:1 });
+assert.strictEqual(window.animalMask.getBonus('Stark', store.data.c.inventory), 1);
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add `djurmask.js` to handle trait selection for the Djurmask artifact
- include the new script on both HTML pages
- support choosing trait when adding a Djurmask from lists or inventory
- display chosen trait on inventory cards
- apply Djurmask bonuses to traits and max trait total
- add unit test for Djurmask bonus logic

## Testing
- `for f in tests/*.test.js; do node "$f" || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_688c468e46d08323a06e21946ea9370e