### PR TITLE
Update monstrous trait rules and add Hamnskifte discounts

### DIFF
--- a/data/lagre-artefakter.json
+++ b/data/lagre-artefakter.json
@@ -70,6 +70,7 @@
     "nivåer": {
       "Gesäll": "För blodvadande häxor är identifikationen med bestar stor och djurmasken markerar deras närhet till djuren. Varje djurmask med kraft symboliserar ett djur och ger +1 på ett karaktärsdrag som associeras med djuret; antingen Diskret, Kvick, Listig, Stark eller Vaksam."
     },
+    "traits": ["Diskret", "Kvick", "Listig", "Stark", "Vaksam"],
     "grundpris": { "daler": 10, "skilling": 0, "örtegar": 0 }
   },
   {

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -123,7 +123,7 @@ function initCharacter() {
       const tagsHtml = (p.taggar?.typ || [])
         .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
         .map(t => `<span class="tag">${t}</span>`).join(' ');
-      const xpVal = storeHelper.calcEntryXP(p);
+      const xpVal = storeHelper.calcEntryXP(p, storeHelper.getCurrentList(store));
       const xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
       const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
       const showInfo = compact || hideDetails;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -281,10 +281,12 @@ function initIndex() {
           const baseRace = list.find(isRas)?.namn;
           const trollTraits = ['Naturligt vapen', 'Pansar', 'Regeneration', 'Robust'];
           const undeadTraits = ['Gravkyla', 'Skräckslå'];
+          const bloodvaderTraits = ['Naturligt vapen','Pansar','Regeneration','Robust'];
           const allowed = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
             list.some(x => x.namn === 'Mörkt blod') ||
             (baseRace === 'Troll' && trollTraits.includes(p.namn)) ||
-            (baseRace === 'Vandöd' && undeadTraits.includes(p.namn));
+            (baseRace === 'Vandöd' && undeadTraits.includes(p.namn)) ||
+            (list.some(x => x.namn === 'Blodvadare') && bloodvaderTraits.includes(p.namn));
           if (!allowed) {
             if (!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')) return;
           }

--- a/js/store.js
+++ b/js/store.js
@@ -480,6 +480,20 @@ function defaultTraits() {
     return LEVEL_IDX[ent?.nivå || ''] || 0;
   }
 
+  function isFreeMonsterTrait(list, item) {
+    if (!isMonstrousTrait(item)) return false;
+    const lvl = LEVEL_IDX[item.nivå || 'Novis'] || 1;
+    if (lvl !== 1) return false;
+    const hamnskifte = abilityLevel(list, 'Hamnskifte');
+    if (['Naturligt vapen', 'Pansar'].includes(item.namn)) {
+      return hamnskifte >= 2;
+    }
+    if (['Regeneration', 'Robust'].includes(item.namn)) {
+      return hamnskifte >= 3;
+    }
+    return false;
+  }
+
   function calcPermanentCorruption(list, extra) {
     let cor = 0;
     const isDwarf = list.some(x => x.namn === 'Dvärg' && (x.taggar?.typ || []).includes('Ras'));
@@ -512,9 +526,13 @@ function defaultTraits() {
 
       if (item.nivåer && ['mystisk kraft','förmåga','särdrag','monstruöst särdrag']
           .some(t => types.includes(t))) {
-        xp += XP_LADDER[item.nivå || 'Novis'] || 0;
+        if (isFreeMonsterTrait(list, item)) {
+          xp += 0;
+        } else {
+          xp += XP_LADDER[item.nivå || 'Novis'] || 0;
+        }
       } else if (types.includes('monstruöst särdrag')) {
-        xp += RITUAL_COST;
+        xp += isFreeMonsterTrait(list, item) ? 0 : RITUAL_COST;
       }
       if (types.includes('fördel')) xp += 5;
       if (types.includes('ritual')) xp += RITUAL_COST;
@@ -524,7 +542,7 @@ function defaultTraits() {
     return xp;
   }
 
-  function calcEntryXP(entry) {
+  function calcEntryXP(entry, list) {
     const types = (entry.taggar?.typ || []).map(t => t.toLowerCase());
     if (types.includes('nackdel')) return -5;
     let xp = 0;
@@ -532,9 +550,9 @@ function defaultTraits() {
       entry.nivåer &&
       ['mystisk kraft', 'förmåga', 'särdrag', 'monstruöst särdrag'].some(t => types.includes(t))
     ) {
-      xp += XP_LADDER[entry.nivå || 'Novis'] || 0;
+      xp += isFreeMonsterTrait(list || [], entry) ? 0 : (XP_LADDER[entry.nivå || 'Novis'] || 0);
     } else if (types.includes('monstruöst särdrag')) {
-      xp += RITUAL_COST;
+      xp += isFreeMonsterTrait(list || [], entry) ? 0 : RITUAL_COST;
     }
     if (types.includes('fördel')) xp += 5;
     if (types.includes('ritual')) xp += RITUAL_COST;

--- a/tests/entryxp.test.js
+++ b/tests/entryxp.test.js
@@ -8,6 +8,7 @@ global.window = {
 
 require('../js/lz-string.min.js');
 require('../js/utils');
+global.isMonstrousTrait = window.isMonstrousTrait;
 require('../js/store');
 
 delete global.window.DB;

--- a/tests/hamnskifte-cost.test.js
+++ b/tests/hamnskifte-cost.test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+
+// Minimal DOM/window stubs
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+global.localStorage = window.localStorage;
+
+// Populate minimal database entries
+window.DB = [
+  { namn: 'Hamnskifte', taggar: { typ: ['Förmåga'] }, nivåer: { Novis:'', 'Gesäll':'', 'Mästare':'' } },
+  { namn: 'Naturligt vapen', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
+  { namn: 'Pansar', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
+  { namn: 'Regeneration', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
+  { namn: 'Robust', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } }
+];
+window.DB.forEach(e => { window.DBIndex[e.namn] = e; });
+global.DB = window.DB;
+global.DBIndex = window.DBIndex;
+
+require('../js/lz-string.min.js');
+require('../js/utils');
+global.isMonstrousTrait = window.isMonstrousTrait;
+require('../js/store');
+
+test();
+
+function test(){
+  const defaultMoney = { "örtegar":0, skilling:0, daler:0 };
+  function xpFor(items){
+    const list = items.map(it => {
+      const base = window.DBIndex[it.namn] || {};
+      return { ...base, ...it };
+    });
+    return window.storeHelper.calcUsedXP(list, {});
+  }
+
+  const nv = window.DB.find(x => x.namn === 'Naturligt vapen');
+  const pan = window.DB.find(x => x.namn === 'Pansar');
+  const reg = window.DB.find(x => x.namn === 'Regeneration');
+  const rob = window.DB.find(x => x.namn === 'Robust');
+  const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
+  const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
+
+  // No Hamnskifte: full cost
+  assert.strictEqual(xpFor([nv]), 10);
+
+  // Gesäll Hamnskifte: Naturligt vapen och Pansar free
+  assert.strictEqual(xpFor([hamGes, nv, pan]), 30);
+
+  // Mästare Hamnskifte: all four free
+  assert.strictEqual(xpFor([hamMas, reg, rob]), 60);
+
+  console.log('All tests passed.');
+}


### PR DESCRIPTION
## Summary
- allow Blodvadare characters to acquire certain monstrous traits without warnings
- add Hamnskifte-based XP discounts for monstrous traits
- expose helper for free monstrous traits and update XP calculations
- update character view to use the new calcEntryXP signature
- restrict Djurmask artefact to relevant traits in data
- add tests for Hamnskifte XP logic

## Testing
- `node tests/entryxp.test.js && node tests/traits-utils.test.js && node tests/darkblood.test.js && node tests/rawstrength.test.js && node tests/vedergallning.test.js && node tests/hamnskifte-cost.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688c47906ee48323b152b92c3c61a7e9