### PR TITLE
Update info panel to show XP separately

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -311,6 +311,7 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
 #traitsPanel { max-width: 360px; }
 
 .inv-header { display: flex; justify-content: space-between; align-items: center; }
+.inv-actions { display: flex; align-items: baseline; gap: .4rem; }
 
 /* Knappar i inventariepanelen */
 .inv-buttons {

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -126,6 +126,7 @@ function initCharacter() {
       const xpVal = storeHelper.calcEntryXP(p);
       const xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
       const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
+      li.dataset.xp = xpVal;
       const showInfo = compact || hideDetails;
       const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '';
       li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span>${xpHtml}</div>
@@ -179,8 +180,10 @@ function initCharacter() {
     const infoBtn=e.target.closest('button[data-info]');
     if(infoBtn){
       const html=decodeURIComponent(infoBtn.dataset.info||'');
-      const title=infoBtn.closest('li')?.querySelector('.card-title')?.textContent||'';
-      yrkePanel.open(title,html);
+      const liEl = infoBtn.closest('li');
+      const title = liEl?.querySelector('.card-title > span')?.textContent || '';
+      const xpVal = liEl?.dataset.xp ? Number(liEl.dataset.xp) : undefined;
+      yrkePanel.open(title, html, xpVal);
       return;
     }
     const actBtn=e.target.closest('button[data-act]');

--- a/js/yrke-panel.js
+++ b/js/yrke-panel.js
@@ -7,7 +7,10 @@
     panel.innerHTML = `
       <header class="inv-header">
         <h2 id="yrkeTitle"></h2>
-        <button id="yrkeClose" class="char-btn icon">✕</button>
+        <div class="inv-actions">
+          <span id="yrkeXp" class="xp-cost"></span>
+          <button id="yrkeClose" class="char-btn icon">✕</button>
+        </div>
       </header>
       <div id="yrkeContent"></div>
     `;
@@ -15,9 +18,17 @@
     panel.querySelector('#yrkeClose').addEventListener('click', close);
   }
 
-  function open(title, html){
+  function open(title, html, xp){
     create();
     document.getElementById('yrkeTitle').textContent = title || '';
+    const xpEl = document.getElementById('yrkeXp');
+    if (xpEl) {
+      if (xp === undefined || xp === null) xpEl.textContent = '';
+      else {
+        const xpText = xp < 0 ? `+${-xp}` : xp;
+        xpEl.textContent = `Erf: ${xpText}`;
+      }
+    }
     document.getElementById('yrkeContent').innerHTML = html || '';
     const panel = document.getElementById('yrkePanel');
 


### PR DESCRIPTION
## Summary
- show XP separately from the entry name in the info panel
- expose XP in list items so the info panel can access it
- style a new `.inv-actions` container

## Testing
- `node tests/entryxp.test.js && node tests/search-sort.test.js && node tests/darkblood.test.js && node tests/rawstrength.test.js && node tests/vedergallning.test.js && node tests/earthbound.test.js && node tests/traits-utils.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688c4b77735083239de5ecdb1776867d