### PR TITLE
Fix info button visibility on index

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -134,12 +134,13 @@ function initIndex() {
         .map(t=>`<span class="tag">${t}</span>`).join(' ');
       const levelHtml = hideDetails ? '' : lvlSel;
       const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
+      const showInfo = compact || hideDetails;
       li.innerHTML = `
         <div class="card-title">${p.namn}${badge}</div>
         ${tagsHtml}
         ${levelHtml}
         ${descHtml}
-        ${infoBtn}${btn}${eliteBtn}`;
+        ${showInfo ? infoBtn : ''}${btn}${eliteBtn}`;
       dom.lista.appendChild(li);
     });
   };


### PR DESCRIPTION
## Summary
- only display the Info button on index entries when details are hidden or in compact mode

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_688c4bb9a19483238de6bdfea42e36fc