### PR TITLE
Fix Hamnskifte trait costs

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -294,12 +294,20 @@ function initIndex() {
           const trollTraits = ['Naturligt vapen', 'Pansar', 'Regeneration', 'Robust'];
           const undeadTraits = ['Gravkyla', 'Skräckslå', 'Vandödhet'];
           const bloodvaderTraits = ['Naturligt vapen','Pansar','Regeneration','Robust'];
-          const allowed = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
+          const allowedBase = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
             list.some(x => x.namn === 'Mörkt blod') ||
             (baseRace === 'Troll' && trollTraits.includes(p.namn)) ||
             (baseRace === 'Vandöd' && undeadTraits.includes(p.namn)) ||
             (list.some(x => x.namn === 'Blodvadare') && bloodvaderTraits.includes(p.namn));
-          if (!allowed) {
+          const ham = storeHelper.abilityLevel(list, 'Hamnskifte');
+          const lvlName = lvl || 'Novis';
+          const hamFree = lvlName === 'Novis' && (
+            (ham >= 2 && ['Naturligt vapen','Pansar'].includes(p.namn)) ||
+            (ham >= 3 && ['Regeneration','Robust'].includes(p.namn))
+          );
+          const needsWarn = !allowedBase && !hamFree;
+          const overNovis = ham > 0 && ['Naturligt vapen','Pansar','Regeneration','Robust'].includes(p.namn) && lvlName !== 'Novis';
+          if (needsWarn || overNovis) {
             if (!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')) return;
           }
         }

--- a/tests/hamnskifte-cost.test.js
+++ b/tests/hamnskifte-cost.test.js
@@ -53,5 +53,17 @@ function test(){
   // Mästare Hamnskifte: all four free
   assert.strictEqual(xpFor([hamMas, reg, rob]), 60);
 
+  // Discounted higher levels with Hamnskifte
+  const nvGes = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, nivå:'Gesäll' };
+  const regGes = { namn:'Regeneration', taggar:{typ:['Monstruöst särdrag']}, nivå:'Gesäll' };
+  const regMas = { namn:'Regeneration', taggar:{typ:['Monstruöst särdrag']}, nivå:'Mästare' };
+
+  // Gesäll Hamnskifte gives 20 XP cost for Gesäll nivå
+  assert.strictEqual(xpFor([hamGes, nvGes]), 50);
+
+  // Mästare Hamnskifte gives 20/50 XP costs
+  assert.strictEqual(xpFor([hamMas, regGes]), 80);
+  assert.strictEqual(xpFor([hamMas, regMas]), 110);
+
   console.log('All tests passed.');
 }


### PR DESCRIPTION
## Summary
- adjust monstrous trait costs based on Hamnskifte level
- warn when taking Hamnskifte traits above Novis
- test updated costs for Hamnskifte traits

## Testing
- `node tests/darkblood.test.js`
- `node tests/earthbound.test.js`
- `node tests/entryxp.test.js`
- `node tests/hamnskifte-cost.test.js`
- `node tests/rawstrength.test.js`
- `node tests/search-sort.test.js`
- `node tests/traits-utils.test.js`
- `node tests/vedergallning.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688c51bd93f88323a3b684296dd7036a