### PR TITLE
Fix Hamnskifte trait cost logic

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -295,13 +295,23 @@ function initIndex() {
           const trollTraits = ['Naturligt vapen', 'Pansar', 'Regeneration', 'Robust'];
           const undeadTraits = ['Gravkyla', 'Skräckslå', 'Vandödhet'];
           const bloodvaderTraits = ['Naturligt vapen','Pansar','Regeneration','Robust'];
+          const hamLvl = storeHelper.abilityLevel(list, 'Hamnskifte');
           monsterOk = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
             list.some(x => x.namn === 'Mörkt blod') ||
             (baseRace === 'Troll' && trollTraits.includes(p.namn)) ||
             (baseRace === 'Vandöd' && undeadTraits.includes(p.namn)) ||
-            (list.some(x => x.namn === 'Blodvadare') && bloodvaderTraits.includes(p.namn));
+            (list.some(x => x.namn === 'Blodvadare') && bloodvaderTraits.includes(p.namn)) ||
+            (hamLvl >= 2 && lvl === 'Novis' && ['Naturligt vapen','Pansar'].includes(p.namn)) ||
+            (hamLvl >= 3 && lvl === 'Novis' && ['Regeneration'].includes(p.namn));
           if (!monsterOk) {
             if (!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')) return;
+          }
+        }
+        if (p.namn === 'Robust') {
+          const hamLvl = storeHelper.abilityLevel(list, 'Hamnskifte');
+          const robustOk = hamLvl >= 3 && lvl === 'Novis';
+          if (!robustOk) {
+            if (!confirm('Robust kan normalt inte väljas. Lägga till ändå?')) return;
           }
         }
         if (p.namn === 'Råstyrka') {

--- a/js/store.js
+++ b/js/store.js
@@ -481,16 +481,19 @@ function defaultTraits() {
   }
 
   function isFreeMonsterTrait(list, item) {
-    if (!isMonstrousTrait(item)) return false;
     const lvl = LEVEL_IDX[item.nivå || 'Novis'] || 1;
-    if (lvl !== 1) return false;
+    if (lvl !== 1) return false; // Only Novis level can be free
+
     const hamnskifte = abilityLevel(list, 'Hamnskifte');
+
     if (['Naturligt vapen', 'Pansar'].includes(item.namn)) {
       return hamnskifte >= 2;
     }
+
     if (['Regeneration', 'Robust'].includes(item.namn)) {
       return hamnskifte >= 3;
     }
+
     return false;
   }
 


### PR DESCRIPTION
## Summary
- handle Robust in free trait logic
- allow Hamnskifte to bypass warnings when taking certain monster traits

## Testing
- `for t in tests/*.test.js; do node $t || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_688c53d8c3f48323a870c8cb2a41cc55