### PR TITLE
Fix abilityLevel to detect mystical powers

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -476,7 +476,10 @@ function defaultTraits() {
   const LEVEL_IDX = { '': 0, Novis: 1, Gesäll: 2, Mästare: 3 };
 
   function abilityLevel(list, ability) {
-    const ent = list.find(x => x.namn === ability && (x.taggar?.typ || []).includes('Förmåga'));
+    const ent = list.find(x =>
+      x.namn === ability &&
+      (x.taggar?.typ || []).some(t => ['Förmåga', 'Mystisk kraft'].includes(t))
+    );
     return LEVEL_IDX[ent?.nivå || ''] || 0;
   }
 


### PR DESCRIPTION
## Summary
- update `abilityLevel` to recognize `Mystisk kraft` when determining ability level

## Testing
- `for f in tests/*.test.js; do node $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_688c57ed107c8323999b38846751125a