### PR TITLE
Implement monster trait XP discount

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -497,6 +497,20 @@ function defaultTraits() {
     return false;
   }
 
+  function monsterTraitDiscount(list, item) {
+    const hamnskifte = abilityLevel(list, 'Hamnskifte');
+
+    if (hamnskifte >= 2 && ['Naturligt vapen', 'Pansar'].includes(item.namn)) {
+      return 10;
+    }
+
+    if (hamnskifte >= 3 && ['Regeneration', 'Robust'].includes(item.namn)) {
+      return 10;
+    }
+
+    return 0;
+  }
+
   function calcPermanentCorruption(list, extra) {
     let cor = 0;
     const isDwarf = list.some(x => x.namn === 'Dvärg' && (x.taggar?.typ || []).includes('Ras'));
@@ -529,13 +543,15 @@ function defaultTraits() {
 
       if (item.nivåer && ['mystisk kraft','förmåga','särdrag','monstruöst särdrag']
           .some(t => types.includes(t))) {
-        if (isFreeMonsterTrait(list, item)) {
-          xp += 0;
-        } else {
-          xp += XP_LADDER[item.nivå || 'Novis'] || 0;
-        }
+        let cost = isFreeMonsterTrait(list, item)
+          ? 0
+          : (XP_LADDER[item.nivå || 'Novis'] || 0);
+        cost = Math.max(0, cost - monsterTraitDiscount(list, item));
+        xp += cost;
       } else if (types.includes('monstruöst särdrag')) {
-        xp += isFreeMonsterTrait(list, item) ? 0 : RITUAL_COST;
+        let cost = isFreeMonsterTrait(list, item) ? 0 : RITUAL_COST;
+        cost = Math.max(0, cost - monsterTraitDiscount(list, item));
+        xp += cost;
       }
       if (types.includes('fördel')) xp += 5;
       if (types.includes('ritual')) xp += RITUAL_COST;
@@ -553,9 +569,15 @@ function defaultTraits() {
       entry.nivåer &&
       ['mystisk kraft', 'förmåga', 'särdrag', 'monstruöst särdrag'].some(t => types.includes(t))
     ) {
-      xp += isFreeMonsterTrait(list || [], entry) ? 0 : (XP_LADDER[entry.nivå || 'Novis'] || 0);
+      let cost = isFreeMonsterTrait(list || [], entry)
+        ? 0
+        : (XP_LADDER[entry.nivå || 'Novis'] || 0);
+      cost = Math.max(0, cost - monsterTraitDiscount(list || [], entry));
+      xp += cost;
     } else if (types.includes('monstruöst särdrag')) {
-      xp += isFreeMonsterTrait(list || [], entry) ? 0 : RITUAL_COST;
+      let cost = isFreeMonsterTrait(list || [], entry) ? 0 : RITUAL_COST;
+      cost = Math.max(0, cost - monsterTraitDiscount(list || [], entry));
+      xp += cost;
     }
     if (types.includes('fördel')) xp += 5;
     if (types.includes('ritual')) xp += RITUAL_COST;
@@ -827,6 +849,7 @@ function defaultTraits() {
     calcPermanentCorruption,
     calcPainThreshold,
     abilityLevel,
+    monsterTraitDiscount,
     exportCharacterCode,
     importCharacterCode,
     getPossessionMoney,

--- a/tests/hamnskifte-discount.test.js
+++ b/tests/hamnskifte-discount.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+
+// Minimal DOM/window stubs
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+global.localStorage = window.localStorage;
+
+// Populate minimal database entries
+window.DB = [
+  { namn: 'Hamnskifte', taggar: { typ: ['Förmåga'] }, nivåer: { Novis:'', 'Gesäll':'', 'Mästare':'' } },
+  { namn: 'Naturligt vapen', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'', Gesäll:'', Mästare:'' } },
+  { namn: 'Regeneration', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'', Gesäll:'', Mästare:'' } }
+];
+window.DB.forEach(e => { window.DBIndex[e.namn] = e; });
+global.DB = window.DB;
+global.DBIndex = window.DBIndex;
+
+require('../js/lz-string.min.js');
+require('../js/utils');
+global.isMonstrousTrait = window.isMonstrousTrait;
+require('../js/store');
+
+test();
+
+function xpFor(items){
+  const list = items.map(it => {
+    const base = window.DBIndex[it.namn] || {};
+    return { ...base, ...it };
+  });
+  return window.storeHelper.calcUsedXP(list, {});
+}
+
+function test(){
+  const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
+  const nvGes = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, nivå:'Gesäll' };
+  const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
+  const regGes = { namn:'Regeneration', taggar:{typ:['Monstruöst särdrag']}, nivå:'Gesäll' };
+
+  assert.strictEqual(xpFor([hamGes, nvGes]), 50);
+  assert.strictEqual(xpFor([hamMas, regGes]), 80);
+
+  console.log('All tests passed.');
+}


### PR DESCRIPTION
## Summary
- add `monsterTraitDiscount` helper and export it
- apply discount in XP calculations
- test XP discount with Hamnskifte

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_688c57f36a10832381b39a69a9ad82a2