### PR TITLE
Add hamnskifte upgrade cost tests

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -532,7 +532,15 @@ function defaultTraits() {
         if (isFreeMonsterTrait(list, item)) {
           xp += 0;
         } else {
-          xp += XP_LADDER[item.nivå || 'Novis'] || 0;
+          let cost = XP_LADDER[item.nivå || 'Novis'] || 0;
+          if (
+            types.includes('monstruöst särdrag') &&
+            LEVEL_IDX[item.nivå || 'Novis'] > 1 &&
+            isFreeMonsterTrait(list, { ...item, nivå: 'Novis' })
+          ) {
+            cost -= XP_LADDER['Novis'];
+          }
+          xp += cost;
         }
       } else if (types.includes('monstruöst särdrag')) {
         xp += isFreeMonsterTrait(list, item) ? 0 : RITUAL_COST;
@@ -553,7 +561,19 @@ function defaultTraits() {
       entry.nivåer &&
       ['mystisk kraft', 'förmåga', 'särdrag', 'monstruöst särdrag'].some(t => types.includes(t))
     ) {
-      xp += isFreeMonsterTrait(list || [], entry) ? 0 : (XP_LADDER[entry.nivå || 'Novis'] || 0);
+      if (isFreeMonsterTrait(list || [], entry)) {
+        xp += 0;
+      } else {
+        let cost = XP_LADDER[entry.nivå || 'Novis'] || 0;
+        if (
+          types.includes('monstruöst särdrag') &&
+          LEVEL_IDX[entry.nivå || 'Novis'] > 1 &&
+          isFreeMonsterTrait(list || [], { ...entry, nivå: 'Novis' })
+        ) {
+          cost -= XP_LADDER['Novis'];
+        }
+        xp += cost;
+      }
     } else if (types.includes('monstruöst särdrag')) {
       xp += isFreeMonsterTrait(list || [], entry) ? 0 : RITUAL_COST;
     }

--- a/tests/hamnskifte-cost.test.js
+++ b/tests/hamnskifte-cost.test.js
@@ -10,7 +10,7 @@ global.localStorage = window.localStorage;
 
 // Populate minimal database entries
 window.DB = [
-  { namn: 'Hamnskifte', taggar: { typ: ['Förmåga'] }, nivåer: { Novis:'', 'Gesäll':'', 'Mästare':'' } },
+  { namn: 'Hamnskifte', taggar: { typ: ['Förmåga','Mystisk kraft'] }, nivåer: { Novis:'', 'Gesäll':'', 'Mästare':'' } },
   { namn: 'Naturligt vapen', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
   { namn: 'Pansar', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
   { namn: 'Regeneration', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
@@ -41,8 +41,8 @@ function test(){
   const pan = window.DB.find(x => x.namn === 'Pansar');
   const reg = window.DB.find(x => x.namn === 'Regeneration');
   const rob = window.DB.find(x => x.namn === 'Robust');
-  const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
-  const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
+  const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga','Mystisk kraft']}, nivå:'Gesäll' };
+  const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga','Mystisk kraft']}, nivå:'Mästare' };
 
   // No Hamnskifte: full cost
   assert.strictEqual(xpFor([nv]), 10);
@@ -50,8 +50,20 @@ function test(){
   // Gesäll Hamnskifte: Naturligt vapen och Pansar free
   assert.strictEqual(xpFor([hamGes, nv, pan]), 30);
 
+  // Gesäll-level trait upgrade still costs XP
+  assert.strictEqual(
+    xpFor([hamGes, { ...nv, nivå: 'Gesäll' }]),
+    50
+  );
+
   // Mästare Hamnskifte: all four free
   assert.strictEqual(xpFor([hamMas, reg, rob]), 60);
+
+  // Mästare-level trait upgrade still costs XP
+  assert.strictEqual(
+    xpFor([hamMas, { ...reg, nivå: 'Mästare' }]),
+    110
+  );
 
   console.log('All tests passed.');
 }


### PR DESCRIPTION
## Summary
- verify Hamnskifte uses Mystisk kraft tag
- ensure buying monster trait upgrades still costs XP
- discount novice cost when upgrading monstrous traits

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_688c57fa462883239906ee3313bffcc3