### PR TITLE
Enforce Hamnskifte trait limits

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -298,6 +298,12 @@ function initCharacter() {
         e.target.value = old;
         return;
       }
+      if (storeHelper.hamnskifteNoviceLimit(list, name, ent.nivå)) {
+        alert('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
+        ent.nivå = old;
+        e.target.value = old;
+        return;
+      }
       storeHelper.setCurrentList(store,list); updateXP();
     }
     renderSkills(filtered()); renderTraits();

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -306,6 +306,10 @@ function initIndex() {
           if (!monsterOk) {
             if (!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')) return;
           }
+          if (storeHelper.hamnskifteNoviceLimit(list, p.namn, lvl)) {
+            alert('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
+            return;
+          }
         }
         if (p.namn === 'Robust') {
           const hamLvl = storeHelper.abilityLevel(list, 'Hamnskifte');
@@ -520,6 +524,12 @@ function initIndex() {
       ent.nivå = e.target.value;
       if(eliteReq.canChange(before) && !eliteReq.canChange(list)){
         alert('Förmågan krävs för ett valt elityrke och kan inte ändras.');
+        ent.nivå = old;
+        e.target.value = old;
+        return;
+      }
+      if (storeHelper.hamnskifteNoviceLimit(list, name, ent.nivå)) {
+        alert('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
         ent.nivå = old;
         e.target.value = old;
         return;

--- a/js/store.js
+++ b/js/store.js
@@ -483,6 +483,31 @@ function defaultTraits() {
     return LEVEL_IDX[ent?.nivå || ''] || 0;
   }
 
+  function hasOtherMonsterAccess(list, trait) {
+    const baseRace = list.find(isRas)?.namn;
+    const trollTraits = ['Naturligt vapen', 'Pansar', 'Regeneration', 'Robust'];
+    const undeadTraits = ['Gravkyla', 'Skräckslå', 'Vandödhet'];
+    const bloodvaderTraits = ['Naturligt vapen','Pansar','Regeneration','Robust'];
+    if (list.some(x => x.namn === 'Mörkt blod')) return true;
+    if (baseRace === 'Troll' && trollTraits.includes(trait)) return true;
+    if (baseRace === 'Vandöd' && undeadTraits.includes(trait)) return true;
+    if (list.some(x => x.namn === 'Blodvadare') && bloodvaderTraits.includes(trait)) return true;
+    return false;
+  }
+
+  function hamnskifteNoviceLimit(list, trait, level) {
+    const lvl = LEVEL_IDX[level || 'Novis'] || 1;
+    if (lvl <= 1) return false;
+    const hamlvl = abilityLevel(list, 'Hamnskifte');
+    if (['Naturligt vapen', 'Pansar'].includes(trait) && hamlvl >= 2) {
+      return !hasOtherMonsterAccess(list, trait);
+    }
+    if (['Regeneration', 'Robust'].includes(trait) && hamlvl >= 3) {
+      return !hasOtherMonsterAccess(list, trait);
+    }
+    return false;
+  }
+
   function isFreeMonsterTrait(list, item) {
     const lvl = LEVEL_IDX[item.nivå || 'Novis'] || 1;
     if (lvl !== 1) return false; // Only Novis level can be free
@@ -853,6 +878,7 @@ function defaultTraits() {
     calcPermanentCorruption,
     calcPainThreshold,
     abilityLevel,
+    hamnskifteNoviceLimit,
     monsterTraitDiscount,
     exportCharacterCode,
     importCharacterCode,

--- a/tests/hamnskifte-limit.test.js
+++ b/tests/hamnskifte-limit.test.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+
+// Minimal DOM/window stubs
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+global.localStorage = window.localStorage;
+
+// Populate minimal database entries
+window.DB = [
+  { namn: 'Hamnskifte', taggar: { typ: ['Förmåga'] }, nivåer: { Novis:'', 'Gesäll':'', 'Mästare':'' } },
+  { namn: 'Naturligt vapen', taggar: { typ: ['Monstruöst särdrag'] }, nivåer: { Novis:'', Gesäll:'' } },
+  { namn: 'Pansar', taggar: { typ: ['Monstruöst särdrag'] }, nivåer: { Novis:'', Gesäll:'' } },
+  { namn: 'Regeneration', taggar: { typ: ['Monstruöst särdrag'] }, nivåer: { Novis:'', Gesäll:'' } },
+  { namn: 'Robust', taggar: { typ: ['Monstruöst särdrag'] }, nivåer: { Novis:'', Gesäll:'' } },
+  { namn: 'Blodvadare', taggar: { typ: ['Yrke'] } },
+  { namn: 'Mörkt blod', taggar: { typ: ['Fördel'] } }
+];
+window.DB.forEach(e => { window.DBIndex[e.namn] = e; });
+global.DB = window.DB;
+global.DBIndex = window.DBIndex;
+
+require('../js/lz-string.min.js');
+require('../js/utils');
+global.isMonstrousTrait = window.isMonstrousTrait;
+global.isRas = window.isRas;
+require('../js/store');
+
+function limit(list, name, lvl){
+  return window.storeHelper.hamnskifteNoviceLimit(list, name, lvl);
+}
+
+(function test(){
+  const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
+  assert.strictEqual(limit([hamGes], 'Naturligt vapen', 'Gesäll'), true);
+  assert.strictEqual(limit([hamGes, { namn:'Blodvadare', taggar:{typ:['Yrke']} }], 'Naturligt vapen', 'Gesäll'), false);
+  assert.strictEqual(limit([hamGes, { namn:'Mörkt blod', taggar:{typ:['Fördel']} }], 'Naturligt vapen', 'Gesäll'), false);
+  const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
+  assert.strictEqual(limit([hamMas], 'Robust', 'Gesäll'), true);
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- add helper to check if Hamnskifte-granted traits may go beyond Novice
- warn when selecting or raising those traits without Blodvadare or similar
- expose new helper from store
- test that the Novice restriction logic works

## Testing
- `node tests/darkblood.test.js && node tests/earthbound.test.js && node tests/entryxp.test.js && node tests/hamnskifte-cost.test.js && node tests/hamnskifte-discount.test.js && node tests/hamnskifte-limit.test.js && node tests/rawstrength.test.js && node tests/search-sort.test.js && node tests/traits-utils.test.js && node tests/vedergallning.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688c5d195ba0832386e1f9dbf93e8bd5