### PR TITLE
Add beast-form toggle for monstrous traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Både i index-vyn och i din karaktär visas poster som kort.
 - **🆓** gör hela föremålet gratis vid beräkning av totalkostnad.
 - **↔** finns på artefakter och växlar dess effekt mellan att ge 1 XP eller permanent korruption.
 - **🗑** tar bort posten helt.
+- Monstruösa särdrag som blir gratis via Hamnskifte eller Blodvadare ger ett val
+  mellan *best-form (gratis)* och *normal form* när de läggs till.
 
 ### 8. Export och import
 Se avsnittet ovan. Exportera kopierar all data för karaktären som en sträng i urklipp. Importera klistrar in en tidigare sträng och återställer karaktären. All data sparas i webblagring så inget backend behövs.

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -377,7 +377,14 @@ function initIndex() {
         }else if(list.some(x=>x.namn===p.namn && !x.trait)){
           return;
         }
-        list.push({ ...p, nivå: lvl });
+        let form = 'normal';
+        if (isMonstrousTrait(p)) {
+          const test = { ...p, nivå: lvl, form: 'beast' };
+          if (storeHelper.isFreeMonsterTrait(list, test)) {
+            form = confirm('Välj "best-form" (gratis)?\nVälj Avbryt för normal form som kostar XP.') ? 'beast' : 'normal';
+          }
+        }
+        list.push({ ...p, nivå: lvl, form });
         storeHelper.setCurrentList(store, list); updateXP();
         if (p.namn === 'Privilegierad') {
           invUtil.renderInventory();

--- a/js/store.js
+++ b/js/store.js
@@ -509,6 +509,7 @@ function defaultTraits() {
   }
 
   function isFreeMonsterTrait(list, item) {
+    if (item.form !== 'beast') return false;
     const lvl = LEVEL_IDX[item.nivå || 'Novis'] || 1;
     if (lvl !== 1) return false; // Only Novis level can be free
 
@@ -526,6 +527,7 @@ function defaultTraits() {
   }
 
   function monsterTraitDiscount(list, item) {
+    if (item.form !== 'beast') return 0;
     const hamnskifte = abilityLevel(list, 'Hamnskifte');
 
     if (hamnskifte >= 2 && ['Naturligt vapen', 'Pansar'].includes(item.namn)) {
@@ -705,6 +707,7 @@ function defaultTraits() {
         if (it.nivå) row.l = it.nivå;
         if (it.trait) row.t = it.trait;
         if (it.race) row.r = it.race;
+        if (it.form) row.f = it.form;
         return row;
       }
       return it;
@@ -718,6 +721,7 @@ function defaultTraits() {
         if (it.l) base.nivå = it.l;
         if (it.t) base.trait = it.t;
         if (it.r) base.race = it.r;
+        if (it.f) base.form = it.f;
         return base;
       }
       if (it && it.n && window.DBIndex && window.DBIndex[it.n]) {
@@ -725,6 +729,7 @@ function defaultTraits() {
         if (it.l) base.nivå = it.l;
         if (it.t) base.trait = it.t;
         if (it.r) base.race = it.r;
+        if (it.f) base.form = it.f;
         return base;
       }
       return it;

--- a/tests/hamnskifte-cost.test.js
+++ b/tests/hamnskifte-cost.test.js
@@ -37,10 +37,10 @@ function test(){
     return window.storeHelper.calcUsedXP(list, {});
   }
 
-  const nv = window.DB.find(x => x.namn === 'Naturligt vapen');
-  const pan = window.DB.find(x => x.namn === 'Pansar');
-  const reg = window.DB.find(x => x.namn === 'Regeneration');
-  const rob = window.DB.find(x => x.namn === 'Robust');
+  const nv = { ...window.DB.find(x => x.namn === 'Naturligt vapen'), form:'beast' };
+  const pan = { ...window.DB.find(x => x.namn === 'Pansar'), form:'beast' };
+  const reg = { ...window.DB.find(x => x.namn === 'Regeneration'), form:'beast' };
+  const rob = { ...window.DB.find(x => x.namn === 'Robust'), form:'beast' };
   const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga','Mystisk kraft']}, nivå:'Gesäll' };
   const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga','Mystisk kraft']}, nivå:'Mästare' };
 

--- a/tests/hamnskifte-form.test.js
+++ b/tests/hamnskifte-form.test.js
@@ -11,8 +11,8 @@ global.localStorage = window.localStorage;
 // Populate minimal database entries
 window.DB = [
   { namn: 'Hamnskifte', taggar: { typ: ['Förmåga'] }, nivåer: { Novis:'', 'Gesäll':'', 'Mästare':'' } },
-  { namn: 'Naturligt vapen', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'', Gesäll:'', Mästare:'' } },
-  { namn: 'Regeneration', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'', Gesäll:'', Mästare:'' } }
+  { namn: 'Naturligt vapen', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
+  { namn: 'Regeneration', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } }
 ];
 window.DB.forEach(e => { window.DBIndex[e.namn] = e; });
 global.DB = window.DB;
@@ -23,8 +23,6 @@ require('../js/utils');
 global.isMonstrousTrait = window.isMonstrousTrait;
 require('../js/store');
 
-test();
-
 function xpFor(items){
   const list = items.map(it => {
     const base = window.DBIndex[it.namn] || {};
@@ -33,14 +31,19 @@ function xpFor(items){
   return window.storeHelper.calcUsedXP(list, {});
 }
 
-function test(){
+(function test(){
   const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
-  const nvGes = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, nivå:'Gesäll', form:'beast' };
+  const nvBeast = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
+  const nvNorm = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, form:'normal' };
   const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
-  const regGes = { namn:'Regeneration', taggar:{typ:['Monstruöst särdrag']}, nivå:'Gesäll', form:'beast' };
+  const regBeast = { namn:'Regeneration', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
+  const regNorm = { namn:'Regeneration', taggar:{typ:['Monstruöst särdrag']}, form:'normal' };
 
-  assert.strictEqual(xpFor([hamGes, nvGes]), 50);
-  assert.strictEqual(xpFor([hamMas, regGes]), 80);
+  assert.strictEqual(xpFor([hamGes, nvNorm]), 40);
+  assert.strictEqual(xpFor([hamGes, nvBeast]), 30);
+
+  assert.strictEqual(xpFor([hamMas, regNorm]), 70);
+  assert.strictEqual(xpFor([hamMas, regBeast]), 60);
 
   console.log('All tests passed.');
-}
+})();


### PR DESCRIPTION
## Summary
- support a new `form` property on list entries
- only apply Hamnskifte discounts when `form` is `"beast"`
- let the user choose beast-form when adding monstrous traits
- document the new choice in README
- add tests for the form logic

## Testing
- `for f in tests/*.test.js; do node $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_688c7c77a7b883239490fd352d9673b7