### PR TITLE
Implement monster stack limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Både i index-vyn och i din karaktär visas poster som kort.
 - **↔** finns på artefakter och växlar dess effekt mellan att ge 1 XP eller permanent korruption.
 - **🗑** tar bort posten helt.
 - Monstruösa särdrag som blir gratis via Hamnskifte eller Blodvadare ger ett val mellan Humanoid eller Hamnskifte (−10 XP) när de läggs till.
+- Naturligt vapen, Pansar, Regeneration och Robust kan tas högst två gånger med Hamnskifte (annars en gång) och visas som separata poster.
 
 ### 8. Export och import
 Se avsnittet ovan. Exportera kopierar all data för karaktären som en sträng i urklipp. Importera klistrar in en tidigare sträng och återställer karaktären. All data sparas i webblagring så inget backend behövs.

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -70,14 +70,14 @@ function initCharacter() {
   const renderSkills = arr=>{
     const groups = [];
     arr.forEach(p=>{
-      const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
-      if(multi){
-        const g = groups.find(x=>x.entry.namn===p.namn);
-        if(g) { g.count++; return; }
-        groups.push({entry:p, count:1});
-      } else {
-        groups.push({entry:p, count:1});
-      }
+        const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
+        if(multi && !['Naturligt vapen','Pansar','Regeneration','Robust'].includes(p.namn)){
+          const g = groups.find(x=>x.entry.namn===p.namn);
+          if(g) { g.count++; return; }
+          groups.push({entry:p, count:1});
+        } else {
+          groups.push({entry:p, count:1});
+        }
     });
     const compact = storeHelper.getCompactEntries(store);
     dom.valda.innerHTML = groups.length ? '' : '<li class="card">Inga träffar.</li>';
@@ -111,12 +111,14 @@ function initCharacter() {
       if(p.trait) li.dataset.trait=p.trait;
       if(p.trait) li.dataset.trait=p.trait;
       const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
-      const badge = g.count>1 ? ` <span class="count-badge">×${g.count}</span>` : '';
-      let btn = '';
-      if(multi){
-        const addBtn = g.count < 3 ? `<button data-act="add" class="char-btn" data-name="${p.namn}">+</button>` : '';
-        const remBtn = `<button data-act="rem" class="char-btn danger${addBtn ? '' : ' icon'}" data-name="${p.namn}">${addBtn ? '−' : '🗑'}</button>`;
-        btn = `<div class="inv-controls">${remBtn}${addBtn}</div>`;
+        const total = storeHelper.getCurrentList(store).filter(x=>x.namn===p.namn && !x.trait).length;
+        const limit = storeHelper.monsterStackLimit(storeHelper.getCurrentList(store), p.namn);
+        const badge = g.count>1 ? ` <span class="count-badge">×${g.count}</span>` : '';
+        let btn = '';
+        if(multi){
+          const addBtn = total < limit ? `<button data-act="add" class="char-btn" data-name="${p.namn}">+</button>` : '';
+          const remBtn = `<button data-act="rem" class="char-btn danger${addBtn ? '' : ' icon'}" data-name="${p.namn}">${addBtn ? '−' : '🗑'}</button>`;
+          btn = `<div class="inv-controls">${remBtn}${addBtn}</div>`;
       }else{
         btn = `<button class="char-btn danger icon" data-act="rem">🗑</button>`;
       }
@@ -196,13 +198,14 @@ function initCharacter() {
     if(!p) return;
     const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !tr;
     let list;
-      if(actBtn.dataset.act==='add'){
-        if(!multi) return;
-        const cnt = before.filter(x=>x.namn===name && !x.trait).length;
-        if(cnt >= 3){
-          alert('Denna fördel eller nackdel kan bara tas tre gånger.');
-          return;
-        }
+        if(actBtn.dataset.act==='add'){
+          if(!multi) return;
+          const cnt = before.filter(x=>x.namn===name && !x.trait).length;
+          const limit = storeHelper.monsterStackLimit(before, name);
+          if(cnt >= limit){
+            alert(`Denna fördel eller nackdel kan bara tas ${limit} gånger.`);
+            return;
+          }
         const lvlSel = liEl.querySelector('select.level');
         let   lvl = lvlSel ? lvlSel.value : null;
         if (!lvl && p.nivåer) lvl = LVL.find(l => p.nivåer[l]) || p.nivå;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -112,14 +112,15 @@ function initIndex() {
         }
       }
       const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
-      const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
-      const count = charList.filter(c => c.namn===p.namn && !c.trait).length;
-      const badge = multi && count>0 ? ` <span class="count-badge">×${count}</span>` : '';
-      let btn = '';
-      if(multi){
-        const addBtn = count<3 ? `<button data-act="add" class="char-btn" data-name="${p.namn}">+</button>` : '';
-        const remBtn = count>0 ? `<button data-act="rem" class="char-btn danger" data-name="${p.namn}">−</button>` : '';
-        btn = `<div class="inv-controls">${remBtn}${addBtn}</div>`;
+        const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
+        const count = charList.filter(c => c.namn===p.namn && !c.trait).length;
+        const limit = storeHelper.monsterStackLimit(charList, p.namn);
+        const badge = multi && count>0 ? ` <span class="count-badge">×${count}</span>` : '';
+        let btn = '';
+        if(multi){
+          const addBtn = count < limit ? `<button data-act="add" class="char-btn" data-name="${p.namn}">+</button>` : '';
+          const remBtn = count>0 ? `<button data-act="rem" class="char-btn danger" data-name="${p.namn}">−</button>` : '';
+          btn = `<div class="inv-controls">${remBtn}${addBtn}</div>`;
       }else{
         btn = inChar
           ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
@@ -370,8 +371,9 @@ function initIndex() {
         const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         if(multi){
           const cnt = list.filter(x=>x.namn===p.namn && !x.trait).length;
-          if(p.namn !== 'Blodsband' && cnt >= 3){
-            alert('Denna fördel eller nackdel kan bara tas tre gånger.');
+          const limit = storeHelper.monsterStackLimit(list, p.namn);
+          if(p.namn !== 'Blodsband' && cnt >= limit){
+            alert(`Denna fördel eller nackdel kan bara tas ${limit} gånger.`);
             return;
           }
         }else if(list.some(x=>x.namn===p.namn && !x.trait)){

--- a/js/store.js
+++ b/js/store.js
@@ -541,6 +541,22 @@ function defaultTraits() {
     return 0;
   }
 
+  function monsterStackLimit(list, name) {
+    const entry = window.DBIndex?.[name];
+    if (!entry || !isMonstrousTrait(entry)) return 3;
+    const hamlvl = abilityLevel(list, 'Hamnskifte');
+
+    if (['Naturligt vapen', 'Pansar'].includes(name)) {
+      return hamlvl >= 2 ? 2 : 1;
+    }
+
+    if (['Regeneration', 'Robust'].includes(name)) {
+      return hamlvl >= 3 ? 2 : 1;
+    }
+
+    return 1;
+  }
+
   function calcPermanentCorruption(list, extra) {
     let cor = 0;
     const isDwarf = list.some(x => x.namn === 'Dvärg' && (x.taggar?.typ || []).includes('Ras'));
@@ -886,6 +902,7 @@ function defaultTraits() {
     hamnskifteNoviceLimit,
     isFreeMonsterTrait,
     monsterTraitDiscount,
+    monsterStackLimit,
     exportCharacterCode,
     importCharacterCode,
     getPossessionMoney,

--- a/tests/hamnskifte-stack.test.js
+++ b/tests/hamnskifte-stack.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+
+// Minimal DOM/window stubs
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+global.localStorage = window.localStorage;
+
+// Populate minimal database entries
+window.DB = [
+  { namn: 'Hamnskifte', taggar: { typ: ['Förmåga'] }, nivåer: { Novis:'', 'Gesäll':'', 'Mästare':'' } },
+  { namn: 'Naturligt vapen', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
+  { namn: 'Pansar', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
+  { namn: 'Regeneration', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
+  { namn: 'Robust', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } },
+  { namn: 'Vingar', taggar: { typ: ['Monstruöst särdrag'] }, nivåer:{ Novis:'' } }
+];
+window.DB.forEach(e => { window.DBIndex[e.namn] = e; });
+global.DB = window.DB;
+global.DBIndex = window.DBIndex;
+
+require('../js/lz-string.min.js');
+require('../js/utils');
+global.isMonstrousTrait = window.isMonstrousTrait;
+require('../js/store');
+
+function limit(list, name){
+  return window.storeHelper.monsterStackLimit(list, name);
+}
+
+(function test(){
+  const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
+  const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
+
+  assert.strictEqual(limit([], 'Naturligt vapen'), 1);
+  assert.strictEqual(limit([hamGes], 'Naturligt vapen'), 2);
+  assert.strictEqual(limit([hamGes], 'Pansar'), 2);
+  assert.strictEqual(limit([hamGes], 'Regeneration'), 1);
+  assert.strictEqual(limit([hamMas], 'Regeneration'), 2);
+  assert.strictEqual(limit([hamMas], 'Robust'), 2);
+  assert.strictEqual(limit([hamMas], 'Vingar'), 1);
+
+  console.log('All tests passed.');
+})();


### PR DESCRIPTION
## Summary
- add `monsterStackLimit` helper in store
- limit plus buttons based on stack limit
- show special monstrous traits as separate entries
- document monstrous trait stacking rules
- test stack limit behaviour

## Testing
- `for f in tests/*.test.js; do node $f || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_688ca5d722688323b87ac25a2c48c8c3