### PR TITLE
Add automatic traits for Hamnskifte

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -124,6 +124,20 @@
     }
   }
 
+  function applyHamnskifteTraits(list) {
+    const hamLvl = abilityLevel(list, 'Hamnskifte');
+    const extras = [];
+    if (hamLvl >= 2) extras.push('Naturligt vapen', 'Pansar');
+    if (hamLvl >= 3) extras.push('Robust', 'Regeneration');
+    extras.forEach(name => {
+      const idx = list.findIndex(it => it.namn === name && it.form === 'beast');
+      if (idx < 0) {
+        const entry = DB.find(e => e.namn === name);
+        if (entry) list.push({ ...entry, form: 'beast' });
+      }
+    });
+  }
+
   function getDependents(list, entry) {
     if (!entry) return [];
     const name = entry.namn || entry;
@@ -154,6 +168,13 @@
       });
     }
 
+    if (name === 'Hamnskifte') {
+      const extras = ['Naturligt vapen','Pansar','Robust','Regeneration'];
+      list.forEach(it => {
+        if (extras.includes(it.namn) && it.form === 'beast') out.push(it.namn);
+      });
+    }
+
     if (isRas(ent)) {
       const race = name;
       list.forEach(it => {
@@ -178,6 +199,7 @@
     applyDarkBloodEffects(list);
     applyRaceTraits(list);
     enforceEarthbound(list);
+    applyHamnskifteTraits(list);
     store.data[store.current] = store.data[store.current] || {};
     store.data[store.current].list = list;
     const hasPriv = list.some(x => x.namn === 'Privilegierad');

--- a/tests/hamnskifte-auto.test.js
+++ b/tests/hamnskifte-auto.test.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+
+// Minimal DOM/window stubs
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+global.localStorage = window.localStorage;
+
+// Populate minimal database entries
+window.DB = [
+  { namn: 'Hamnskifte', taggar: { typ: ['Förmåga'] }, nivåer: { Novis:'', 'Gesäll':'', 'Mästare':'' } },
+  { namn: 'Naturligt vapen', taggar: { typ: ['Monstruöst särdrag'] }, nivåer: { Novis:'' } },
+  { namn: 'Pansar', taggar: { typ: ['Monstruöst särdrag'] }, nivåer: { Novis:'' } },
+  { namn: 'Regeneration', taggar: { typ: ['Monstruöst särdrag'] }, nivåer: { Novis:'' } },
+  { namn: 'Robust', taggar: { typ: ['Monstruöst särdrag'] }, nivåer: { Novis:'' } }
+];
+window.DB.forEach(e => { window.DBIndex[e.namn] = e; });
+global.DB = window.DB;
+global.DBIndex = window.DBIndex;
+
+require('../js/lz-string.min.js');
+require('../js/utils');
+global.isMonstrousTrait = window.isMonstrousTrait;
+global.isRas = window.isRas;
+global.isElityrke = window.isElityrke;
+require('../js/store');
+
+const defaultMoney = { "örtegar":0, skilling:0, daler:0 };
+
+function traitsFor(level){
+  const store = { current: 'c', data: { c: { privMoney: defaultMoney, possessionMoney: defaultMoney } } };
+  const list = [ { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå: level } ];
+  window.storeHelper.setCurrentList(store, list);
+  return store.data.c.list.filter(x => ['Naturligt vapen','Pansar','Robust','Regeneration'].includes(x.namn)).map(x => x.namn).sort();
+}
+
+assert.deepStrictEqual(traitsFor('Novis'), []);
+assert.deepStrictEqual(traitsFor('Gesäll'), ['Naturligt vapen','Pansar'].sort());
+assert.deepStrictEqual(traitsFor('Mästare'), ['Naturligt vapen','Pansar','Regeneration','Robust'].sort());
+
+(function testDependents(){
+  const store = { current:'c', data:{ c:{ privMoney:defaultMoney, possessionMoney:defaultMoney } } };
+  const list = [ { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' } ];
+  window.storeHelper.setCurrentList(store, list);
+  const deps = window.storeHelper.getDependents(store.data.c.list, 'Hamnskifte').sort();
+  assert.deepStrictEqual(deps, ['Naturligt vapen','Pansar']);
+})();
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- auto-add monster traits for Hamnskifte when gaining Gesäll and Mästare
- remove those traits when Hamnskifte is removed
- test automatic Hamnskifte traits

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_688ca9b7cb30832394f3027aee808831