### PR TITLE
Limit beastform trait description to selected level

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -154,7 +154,7 @@
       const idx = list.findIndex(it => it.namn === name && it.form === 'beast');
       if (idx < 0 && !removed.includes(name)) {
         const entry = DB.find(e => e.namn === name);
-        if (entry) list.push({ ...entry, form: 'beast' });
+        if (entry) list.push({ ...entry, form: 'beast', nivå: 'Novis' });
       }
     });
 


### PR DESCRIPTION
## Summary
- ensure Hamnskifte auto-added beastform traits include a Novis level
  so ability descriptions don't show higher tiers in character view

## Testing
- `for f in tests/*.test.js; do node "$f" || exit 1; done`

------
https://chatgpt.com/codex/tasks/task_e_688cb1bcbc948323a921f9f2b10d1748