### PR TITLE
Fix Välutrustad inventory cleanup

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -284,6 +284,16 @@ function initCharacter() {
       }
       invUtil.renderInventory();
     }
+    if (p.namn === 'Välutrustad') {
+      const inv = storeHelper.getInventory(store);
+      if (actBtn.dataset.act === 'add') {
+        invUtil.addWellEquippedItems(inv);
+      } else {
+        invUtil.removeWellEquippedItems(inv);
+      }
+      invUtil.saveInventory(inv);
+      invUtil.renderInventory();
+    }
     renderSkills(filtered());
     updateXP();
     renderTraits();

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -397,26 +397,7 @@ function initIndex() {
           }
           if (p.namn === 'Välutrustad') {
             const inv = storeHelper.getInventory(store);
-            const freebies = [
-              { name: 'Rep, 10 meter', qty: 3 },
-              { name: 'Papper', qty: 1 },
-              { name: 'Kritor', qty: 1 },
-              { name: 'Fackla', qty: 3 },
-              { name: 'Signalhorn', qty: 1 },
-              { name: 'Långfärdsbröd', qty: 3 },
-              { name: 'Örtkur', qty: 3 }
-            ];
-            freebies.forEach(it => {
-              const row = inv.find(r => r.name === it.name);
-              if (row) {
-                row.qty += it.qty;
-                row.gratis = (row.gratis || 0) + it.qty;
-                row.perkGratis = (row.perkGratis || 0) + it.qty;
-                if (!row.perk) row.perk = 'Välutrustad';
-              } else {
-                inv.push({ name: it.name, qty: it.qty, gratis: it.qty, gratisKval: [], removedKval: [], perk: 'Välutrustad', perkGratis: it.qty });
-              }
-            });
+            invUtil.addWellEquippedItems(inv);
             invUtil.saveInventory(inv); invUtil.renderInventory();
           }
           renderList(filtered());
@@ -522,25 +503,11 @@ function initIndex() {
           }
           invUtil.renderInventory();
         }
-        if (p.namn === 'Välutrustad') {
-          const inv = storeHelper.getInventory(store);
-          for (let i = inv.length - 1; i >= 0; i--) {
-            const row = inv[i];
-            if (row.perk === 'Välutrustad') {
-              const pg = row.perkGratis || row.gratis || 0;
-              const removed = Math.min(pg, row.qty);
-              row.qty -= removed;
-              row.gratis = Math.max(0, (row.gratis || 0) - removed);
-              row.perkGratis = Math.max(0, (row.perkGratis || 0) - removed);
-              delete row.perk;
-              delete row.perkGratis;
-              if (row.qty <= 0) {
-                inv.splice(i, 1);
-              }
-            }
+          if (p.namn === 'Välutrustad') {
+            const inv = storeHelper.getInventory(store);
+            invUtil.removeWellEquippedItems(inv);
+            invUtil.saveInventory(inv); invUtil.renderInventory();
           }
-          invUtil.saveInventory(inv); invUtil.renderInventory();
-        }
       }
     }
     renderList(filtered());

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -33,6 +33,45 @@
     if (window.renderTraits) renderTraits();
   }
 
+  function addWellEquippedItems(inv) {
+    const freebies = [
+      { name: 'Rep, 10 meter', qty: 3 },
+      { name: 'Papper', qty: 1 },
+      { name: 'Kritor', qty: 1 },
+      { name: 'Fackla', qty: 3 },
+      { name: 'Signalhorn', qty: 1 },
+      { name: 'Långfärdsbröd', qty: 3 },
+      { name: 'Örtkur', qty: 3 }
+    ];
+    freebies.forEach(it => {
+      const row = inv.find(r => r.name === it.name);
+      if (row) {
+        row.qty += it.qty;
+        row.gratis = (row.gratis || 0) + it.qty;
+        row.perkGratis = (row.perkGratis || 0) + it.qty;
+        if (!row.perk) row.perk = 'Välutrustad';
+      } else {
+        inv.push({ name: it.name, qty: it.qty, gratis: it.qty, gratisKval: [], removedKval: [], perk: 'Välutrustad', perkGratis: it.qty });
+      }
+    });
+  }
+
+  function removeWellEquippedItems(inv) {
+    for (let i = inv.length - 1; i >= 0; i--) {
+      const row = inv[i];
+      if (row.perk === 'Välutrustad') {
+        const pg = row.perkGratis || row.gratis || 0;
+        const removed = Math.min(pg, row.qty);
+        row.qty -= removed;
+        row.gratis = Math.max(0, (row.gratis || 0) - removed);
+        row.perkGratis = Math.max(0, (row.perkGratis || 0) - removed);
+        delete row.perk;
+        delete row.perkGratis;
+        if (row.qty <= 0) inv.splice(i, 1);
+      }
+    }
+  }
+
   function recalcArtifactEffects() {
     const inv = storeHelper.getInventory(store);
     const effects = inv.reduce((acc, row) => {
@@ -818,6 +857,8 @@
     openCustomPopup,
     openMoneyPopup,
     recalcArtifactEffects,
+    addWellEquippedItems,
+    removeWellEquippedItems,
     renderInventory,
     bindInv,
     bindMoney

--- a/tests/wellequipped.test.js
+++ b/tests/wellequipped.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+
+global.window = { localStorage: { getItem: () => null, setItem: () => {} } };
+global.localStorage = window.localStorage;
+
+require('../js/inventory-utils');
+
+const { addWellEquippedItems, removeWellEquippedItems } = window.invUtil;
+
+// Adding items should populate inventory with the perk flag
+let inv = [];
+addWellEquippedItems(inv);
+assert.strictEqual(inv.length, 7);
+assert(inv.every(r => r.perk === 'Välutrustad'));
+
+// Removing should clean up all perk items entirely
+removeWellEquippedItems(inv);
+assert.deepStrictEqual(inv, []);
+
+// Partial removal when other quantities exist
+inv = [
+  { name: 'Fackla', qty: 5, gratis: 3, perk: 'Välutrustad', perkGratis: 3 },
+  { name: 'Rep, 10 meter', qty: 1 }
+];
+removeWellEquippedItems(inv);
+assert.deepStrictEqual(inv, [
+  { name: 'Fackla', qty: 2, gratis: 0 },
+  { name: 'Rep, 10 meter', qty: 1 }
+]);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- centralize Välutrustad inventory logic in helpers
- use helpers in index and character views so perk items vanish when perk is removed
- cover helper with unit tests

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_688e61fff990832393e2138eaff6411a