### PR TITLE
Make bomb command case sensitive

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -443,7 +443,7 @@ function tryNilasPopup(term) {
 }
 
 function tryBomb(term) {
-  if (term.toLowerCase() !== 'bomb') return false;
+  if (term !== 'BOMB!') return false;
   storeHelper.deleteAllCharacters(store);
   location.reload();
   return true;

--- a/tests/bomb.test.js
+++ b/tests/bomb.test.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const code = fs.readFileSync(path.join(__dirname, '../js/main.js'), 'utf8');
+const match = code.match(/function tryBomb\(term\) {[^]*?}/);
+assert(match, 'tryBomb function not found');
+
+let deleted = false;
+let reloaded = false;
+const context = {
+  storeHelper: { deleteAllCharacters: () => { deleted = true; } },
+  store: {},
+  location: { reload: () => { reloaded = true; } }
+};
+vm.createContext(context);
+vm.runInContext(match[0], context);
+
+assert.strictEqual(context.tryBomb('BOMB!'), true);
+assert.strictEqual(deleted, true);
+assert.strictEqual(reloaded, true);
+
+deleted = false;
+reloaded = false;
+assert.strictEqual(context.tryBomb('bomb!'), false);
+assert.strictEqual(deleted, false);
+assert.strictEqual(reloaded, false);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- Require the exact trigger `BOMB!` to delete all characters, making the bomb command case sensitive
- Add tests ensuring only `BOMB!` activates the deletion

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688e613df0a88323a8bf672d781bcb89