### PR TITLE
Allow Andrik traits via Blodsband

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -301,11 +301,13 @@ function initIndex() {
           const undeadTraits = ['Gravkyla', 'Skräckslå', 'Vandödhet'];
           const bloodvaderTraits = ['Naturligt vapen','Pansar','Regeneration','Robust'];
           const hamLvl = storeHelper.abilityLevel(list, 'Hamnskifte');
+          const bloodRaces = list.filter(x => x.namn === 'Blodsband' && x.race).map(x => x.race);
           monsterOk = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
             list.some(x => x.namn === 'Mörkt blod') ||
             (baseRace === 'Troll' && trollTraits.includes(p.namn)) ||
             (baseRace === 'Vandöd' && undeadTraits.includes(p.namn)) ||
             (list.some(x => x.namn === 'Blodvadare') && bloodvaderTraits.includes(p.namn)) ||
+            ((baseRace === 'Andrik' || bloodRaces.includes('Andrik')) && p.namn === 'Diminutiv') ||
             (hamLvl >= 2 && lvl === 'Novis' && ['Naturligt vapen','Pansar'].includes(p.namn)) ||
             (hamLvl >= 3 && lvl === 'Novis' && ['Regeneration','Robust'].includes(p.namn));
           if (!monsterOk) {

--- a/tests/andrik.test.js
+++ b/tests/andrik.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const code = fs.readFileSync(path.join(__dirname, '../js/index-view.js'), 'utf8');
+const match = code.match(/if \(isMonstrousTrait\(p\)\) {([^]*?)if \(!monsterOk\)/);
+assert(match, 'monstrous trait block not found');
+const fn = new Function('p','list','lvl','isRas','storeHelper', match[1] + 'return monsterOk;');
+
+const isRas = x => (x.taggar?.typ || []).includes('Ras');
+const abilityLevel = () => 0;
+
+function canTake(list){
+  const p = { namn: 'Diminutiv', taggar: { typ: ['Monstruöst särdrag'] } };
+  return fn(p, list, 'Novis', isRas, { abilityLevel });
+}
+
+assert.strictEqual(canTake([{ namn:'Andrik', taggar:{ typ:['Ras'] } }]), true);
+assert.strictEqual(canTake([
+  { namn:'Människa', taggar:{ typ:['Ras'] } },
+  { namn:'Blodsband', race:'Andrik' }
+]), true);
+assert.strictEqual(canTake([{ namn:'Människa', taggar:{ typ:['Ras'] } }]), false);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- Allow monstrous trait Diminutiv for characters of Andrik lineage or bonded through Blodsband
- Test Andrik Blodsband access to Diminutiv

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688e67368e6c8323af1aa669f97d8081