### PR TITLE
Add defense calculation to character traits

### DIFF
--- a/tests/defense.test.js
+++ b/tests/defense.test.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+
+// Minimal DOM/window stubs
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {}
+};
+global.localStorage = window.localStorage;
+
+global.DB = window.DB;
+global.DBIndex = window.DBIndex;
+
+require('../js/utils');
+global.splitQuals = window.splitQuals;
+require('../js/store');
+global.storeHelper = window.storeHelper;
+require('../js/inventory-utils');
+global.invUtil = window.invUtil;
+require('../js/traits-utils');
+
+// Add sample armor to database
+window.DB.push({
+  namn: 'Kråkrustning',
+  taggar: { typ: ['Rustning'] },
+  stat: { skydd: '1T6', begränsning: -3 }
+});
+window.DBIndex['Kråkrustning'] = window.DB[0];
+
+const defaultMoney = { 'örtegar':0, skilling:0, daler:0 };
+const store = { current: 'c', data: { c: { inventory: [ { name: 'Kråkrustning', qty: 1 } ], list: [], privMoney: defaultMoney, possessionMoney: defaultMoney } } };
+
+global.store = store;
+window.store = store;
+
+const res = window.calcDefense(15);
+assert.deepStrictEqual(res, [ { name: 'Kråkrustning', value: 12 } ]);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- calculate defense from Kvick minus armor limitations
- show defense values under Kvick in the traits panel
- add unit test for defense computation

## Testing
- `for f in tests/*.test.js; do node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_688f0df33fd483239aedf5d757e85190