### PR TITLE
Compute defense for each armor and unarmored case

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -3,7 +3,7 @@
     const inv = storeHelper.getInventory(store);
     const list = storeHelper.getCurrentList(store);
     const rustLvl = storeHelper.abilityLevel(list, 'Rustmästare');
-    return inv.reduce((out,row)=>{
+    const res = inv.reduce((out,row)=>{
       const entry = invUtil.getEntry(row.name);
       if(!entry || !((entry.taggar?.typ||[]).includes('Rustning'))) return out;
       const tagger = entry.taggar || {};
@@ -23,6 +23,7 @@
       out.push({ name: row.name, value: kvick + limit });
       return out;
     }, []);
+    return res.length ? res : [ { value: kvick } ];
   }
 
   function renderTraits(){
@@ -82,7 +83,9 @@
         extra = `<div class="trait-extra">T\u00e5lighet: ${tal} \u2022 Sm\u00e4rtgr\u00e4ns: ${pain}</div>`;
       } else if (k === 'Kvick') {
         const defs = calcDefense(val);
-        extra = defs.map(d => `<div class="trait-extra">F\u00f6rsvar (${d.name}): ${d.value}</div>`).join('');
+        extra = defs
+          .map(d => `<div class="trait-extra">F\u00f6rsvar${d.name ? ' (' + d.name + ')' : ''}: ${d.value}</div>`)
+          .join('');
       } else if (k === 'Viljestark') {
         const baseMax   = strongGift ? val * 2 : val;
         const threshBase = strongGift ? val : Math.ceil(val / 2);

--- a/tests/defense.test.js
+++ b/tests/defense.test.js
@@ -36,4 +36,9 @@ window.store = store;
 const res = window.calcDefense(15);
 assert.deepStrictEqual(res, [ { name: 'Kråkrustning', value: 12 } ]);
 
+// No armor should still yield a defense value with zero limitation
+store.data.c.inventory = [];
+const res2 = window.calcDefense(15);
+assert.deepStrictEqual(res2, [ { value: 15 } ]);
+
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- calculate defense value for every piece of armor in inventory
- fall back to unarmored defense with zero limitation when no armor is present
- show defense with or without armor name in trait display
- test unarmored defense calculation

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_688f1063665083238fada317882082c2