### PR TITLE
Make Runstav a balanced weapon

### DIFF
--- a/data/lagre-artefakter.json
+++ b/data/lagre-artefakter.json
@@ -244,10 +244,11 @@
   },
   {
     "namn": "Runstav",
-    "taggar": { "typ": ["Lägre Artefakt"] },
+    "taggar": { "typ": ["Lägre Artefakt", "Vapen"], "kvalitet": ["Balanserat"] },
     "nivåer": {
       "Mästare": "Stavmagikernas signum är den personliga runstaven, etsad med elementens runor. Staven avger i ägarens hand en skyddande aura, skydd 1t4, samt utgör också i övrigt grunden för mystikerns krafter."
     },
+    "stat": { "skada": "1T8" },
     "grundpris": { "daler": 12, "skilling": 0, "örtegar": 0 }
   },
   {


### PR DESCRIPTION
## Summary
- make Runstav count as a weapon with balanced quality
- define Runstav weapon stats as 1T8 damage

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_688f12cb8d8c832386743a2ca5ae910b