### PR TITLE
Add defense bonus for balanced weapons

### DIFF
--- a/tests/defense.test.js
+++ b/tests/defense.test.js
@@ -41,4 +41,16 @@ store.data.c.inventory = [];
 const res2 = window.calcDefense(15);
 assert.deepStrictEqual(res2, [ { value: 15 } ]);
 
+// A balanced weapon grants +1 defense even without armor
+window.DB.push({ namn: 'Svärd', taggar: { typ: ['Vapen'] } });
+window.DBIndex['Svärd'] = window.DB[1];
+store.data.c.inventory = [ { name: 'Svärd', qty: 1, kvaliteter: ['Balanserat'] } ];
+const res3 = window.calcDefense(15);
+assert.deepStrictEqual(res3, [ { value: 16 } ]);
+
+// Balanced weapon bonus stacks with armor
+store.data.c.inventory.unshift({ name: 'Kråkrustning', qty: 1 });
+const res4 = window.calcDefense(15);
+assert.deepStrictEqual(res4, [ { name: 'Kråkrustning', value: 13 } ]);
+
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- count weapons with the `Balanserat` quality when calculating defense and grant +1 defense if present
- test defense bonus for balanced weapons with and without armor

## Testing
- `node tests/defense.test.js`
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_688f137bf0c883238222c1996cdf08fc