### PR TITLE
Adjust armor limitations based on qualities

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -525,7 +525,7 @@
             const html = tags.map(t => `<span class="tag">${t}</span>`).join(' ');
             desc += `<div class="tags">${html}</div>`;
           }
-          desc += itemStatHtml(entry);
+          desc += itemStatHtml(entry, row);
           if (row.trait) {
             desc += `<br><strong>Karakt\u00e4rsdrag:</strong> ${row.trait}`;
           }

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -17,8 +17,8 @@
         ...(row.kvaliteter || [])
       ];
       let limit = entry.stat?.['begränsning'] || 0;
-      if(allQ.includes('Smidig')) limit += 2;
-      if(allQ.includes('Otymplig')) limit -= 1;
+      if(allQ.includes('Smidig') || allQ.includes('Smidigt')) limit += 2;
+      if(allQ.includes('Otymplig') || allQ.includes('Otympligt')) limit -= 1;
       if(rustLvl >= 2) limit = 0;
       out.push({ name: row.name, value: kvick + limit });
       return out;

--- a/js/utils.js
+++ b/js/utils.js
@@ -87,15 +87,31 @@
   }
 
   // Returnera HTML med skada/skydd-stats för vapen och rustningar
-  function itemStatHtml(entry) {
+  function itemStatHtml(entry, row) {
     if (!entry) return '';
     const types = entry.taggar?.typ || [];
     if (types.includes('Rustning')) {
       const stats = entry.stat || {};
       const parts = [];
       if (stats.skydd) parts.push(`Skydd: ${stats.skydd}`);
-      if (stats.hasOwnProperty('begr\u00e4nsning'))
-        parts.push(`Begr\u00e4nsning: ${stats['begr\u00e4nsning']}`);
+      if (stats.hasOwnProperty('begr\u00e4nsning')) {
+        let limit = stats['begr\u00e4nsning'];
+        if (row) {
+          const removed = row.removedKval || [];
+          const baseQuals = [
+            ...(entry.taggar?.kvalitet || []),
+            ...splitQuals(entry.kvalitet)
+          ];
+          const baseQ = baseQuals.filter(q => !removed.includes(q));
+          const allQ = [...baseQ, ...(row.kvaliteter || [])];
+          if (allQ.includes('Smidig') || allQ.includes('Smidigt')) limit += 2;
+          if (allQ.includes('Otymplig') || allQ.includes('Otympligt')) limit -= 1;
+          const list = storeHelper.getCurrentList(store);
+          const rustLvl = storeHelper.abilityLevel(list, 'Rustmästare');
+          if (rustLvl >= 2) limit = 0;
+        }
+        parts.push(`Begr\u00e4nsning: ${limit}`);
+      }
       return parts.length ? `<br>${parts.join('<br>')}` : '';
     }
     if (types.includes('Vapen')) {

--- a/tests/defense.test.js
+++ b/tests/defense.test.js
@@ -19,22 +19,41 @@ require('../js/inventory-utils');
 global.invUtil = window.invUtil;
 require('../js/traits-utils');
 
-// Add sample armor to database
+// Add sample armors to database
 window.DB.push({
-  namn: 'Kråkrustning',
+  namn: 'Smidig rustning',
   taggar: { typ: ['Rustning'] },
-  stat: { skydd: '1T6', begränsning: -3 }
+  kvalitet: 'Smidigt',
+  stat: { skydd: '1T4', begränsning: -2 }
 });
-window.DBIndex['Kråkrustning'] = window.DB[0];
+window.DBIndex['Smidig rustning'] = window.DB[0];
+
+window.DB.push({
+  namn: 'Otymplig rustning',
+  taggar: { typ: ['Rustning'] },
+  kvalitet: 'Otympligt',
+  stat: { skydd: '1T4', begränsning: -2 }
+});
+window.DBIndex['Otymplig rustning'] = window.DB[1];
 
 const defaultMoney = { 'örtegar':0, skilling:0, daler:0 };
-const store = { current: 'c', data: { c: { inventory: [ { name: 'Kråkrustning', qty: 1 } ], list: [], privMoney: defaultMoney, possessionMoney: defaultMoney } } };
+const store = { current: 'c', data: { c: { inventory: [ { name: 'Smidig rustning', qty: 1 } ], list: [], privMoney: defaultMoney, possessionMoney: defaultMoney } } };
 
 global.store = store;
 window.store = store;
 
-const res = window.calcDefense(15);
-assert.deepStrictEqual(res, [ { name: 'Kråkrustning', value: 12 } ]);
+// Smidigt should remove the limitation
+let res = window.calcDefense(15);
+assert.deepStrictEqual(res, [ { name: 'Smidig rustning', value: 15 } ]);
+let html = window.itemStatHtml(window.DBIndex['Smidig rustning'], store.data.c.inventory[0]);
+assert(html.includes('Begränsning: 0'));
+
+// Otympligt should increase the limitation by one
+store.data.c.inventory = [ { name: 'Otymplig rustning', qty: 1 } ];
+res = window.calcDefense(15);
+assert.deepStrictEqual(res, [ { name: 'Otymplig rustning', value: 12 } ]);
+html = window.itemStatHtml(window.DBIndex['Otymplig rustning'], store.data.c.inventory[0]);
+assert(html.includes('Begränsning: -3'));
 
 // No armor should still yield a defense value with zero limitation
 store.data.c.inventory = [];


### PR DESCRIPTION
## Summary
- Modify defense calculations to consider Smidig(t) and Otymplig(t) qualities when determining armor limitations.
- Display updated limitation values in inventory entries using character abilities and current qualities.
- Cover limitation effects with unit tests for both positive and negative armor qualities.

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688f135b63a483238a4eeeec9813f5cc