### PR TITLE
Add Robust defense penalties

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -4,6 +4,12 @@
     const list = storeHelper.getCurrentList(store);
     const rustLvl = storeHelper.abilityLevel(list, 'Rustmästare');
 
+    const LEVEL_PENALTY = { Novis: 2, 'Gesäll': 3, 'Mästare': 4 };
+    const robust = list.find(p => p.namn === 'Robust' && p.form !== 'beast');
+    const hamRobust = list.find(p => p.namn === 'Robust' && p.form === 'beast');
+    const robustPenalty = LEVEL_PENALTY[robust?.nivå] || 0;
+    const hamPenalty = LEVEL_PENALTY[hamRobust?.nivå] || 0;
+
     const hasBalancedWeapon = inv.some(row => {
       const entry = invUtil.getEntry(row.name);
       if (!entry || !((entry.taggar?.typ || []).includes('Vapen'))) return false;
@@ -45,6 +51,14 @@
 
     if (hasBalancedWeapon) {
       res.forEach(r => { r.value += 1; });
+    }
+
+    if (robustPenalty) {
+      res.forEach(r => { r.value -= robustPenalty; });
+    }
+
+    if (hamRobust) {
+      res.push({ name: 'Hamnskifte', value: kvick - hamPenalty });
     }
 
     return res;

--- a/tests/defense.test.js
+++ b/tests/defense.test.js
@@ -68,8 +68,23 @@ const res3 = window.calcDefense(15);
 assert.deepStrictEqual(res3, [ { value: 16 } ]);
 
 // Balanced weapon bonus stacks with armor
-store.data.c.inventory.unshift({ name: 'Kråkrustning', qty: 1 });
+store.data.c.inventory.unshift({ name: 'Otymplig rustning', qty: 1 });
 const res4 = window.calcDefense(15);
-assert.deepStrictEqual(res4, [ { name: 'Kråkrustning', value: 13 } ]);
+assert.deepStrictEqual(res4, [ { name: 'Otymplig rustning', value: 13 } ]);
+
+// Robust trait reduces defense
+store.data.c.inventory = [];
+store.data.c.list = [ { namn: 'Robust', taggar: { typ: ['S\u00e4rdrag'] }, nivå: 'Novis' } ];
+const res5 = window.calcDefense(15);
+assert.deepStrictEqual(res5, [ { value: 13 } ]);
+
+// Robust via Hamnskifte adds separate defense value
+store.data.c.inventory = [ { name: 'Smidig rustning', qty: 1 } ];
+store.data.c.list = [ { namn: 'Robust', taggar: { typ: ['Monstruöst särdrag'] }, nivå: 'Novis', form: 'beast' } ];
+const res6 = window.calcDefense(15);
+assert.deepStrictEqual(res6, [
+  { name: 'Smidig rustning', value: 15 },
+  { name: 'Hamnskifte', value: 13 }
+]);
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- decrease defense when Robust trait is present
- compute a separate defense for Robust: Hamnskifte
- cover Robust defense behavior with unit tests

## Testing
- `for f in tests/*.test.js; do node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_688f15b170308323b1dff91bd4841161