### PR TITLE
Add Manteldans novice defense bonus

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -47,6 +47,11 @@
       res.forEach(r => { r.value += 1; });
     }
 
+    const mantleLvl = storeHelper.abilityLevel(list, 'Manteldans');
+    if (mantleLvl >= 1) {
+      res.forEach(r => { r.value += 1; });
+    }
+
     return res;
   }
 

--- a/tests/defense.test.js
+++ b/tests/defense.test.js
@@ -36,6 +36,13 @@ window.DB.push({
 });
 window.DBIndex['Otymplig rustning'] = window.DB[1];
 
+window.DB.push({
+  namn: 'Kråkrustning',
+  taggar: { typ: ['Rustning'] },
+  stat: { skydd: '1T6', begränsning: -3 }
+});
+window.DBIndex['Kråkrustning'] = window.DB[2];
+
 const defaultMoney = { 'örtegar':0, skilling:0, daler:0 };
 const store = { current: 'c', data: { c: { inventory: [ { name: 'Smidig rustning', qty: 1 } ], list: [], privMoney: defaultMoney, possessionMoney: defaultMoney } } };
 
@@ -62,7 +69,7 @@ assert.deepStrictEqual(res2, [ { value: 15 } ]);
 
 // A balanced weapon grants +1 defense even without armor
 window.DB.push({ namn: 'Svärd', taggar: { typ: ['Vapen'] } });
-window.DBIndex['Svärd'] = window.DB[1];
+window.DBIndex['Svärd'] = window.DB[3];
 store.data.c.inventory = [ { name: 'Svärd', qty: 1, kvaliteter: ['Balanserat'] } ];
 const res3 = window.calcDefense(15);
 assert.deepStrictEqual(res3, [ { value: 16 } ]);
@@ -71,5 +78,16 @@ assert.deepStrictEqual(res3, [ { value: 16 } ]);
 store.data.c.inventory.unshift({ name: 'Kråkrustning', qty: 1 });
 const res4 = window.calcDefense(15);
 assert.deepStrictEqual(res4, [ { name: 'Kråkrustning', value: 13 } ]);
+
+// Manteldans Novis should grant +1 defense
+store.data.c.inventory = [];
+store.data.c.list = [ { namn: 'Manteldans', nivå: 'Novis', taggar: { typ: ['Förmåga'] } } ];
+const res5 = window.calcDefense(15);
+assert.deepStrictEqual(res5, [ { value: 16 } ]);
+
+// Manteldans stacks with balanced weapon
+store.data.c.inventory = [ { name: 'Svärd', qty: 1, kvaliteter: ['Balanserat'] } ];
+const res6 = window.calcDefense(15);
+assert.deepStrictEqual(res6, [ { value: 17 } ]);
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- include Manteldans ability bonus in defense calculation
- expand defense tests to cover Manteldans and armor cases

## Testing
- `node tests/defense.test.js`
- `for f in tests/*.test.js; do echo $f; node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688f15d5a0148323b98a5c4b3395f1a1