### PR TITLE
Add shield and Sköldkamp defense bonus

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -3,10 +3,20 @@
     const inv = storeHelper.getInventory(store);
     const list = storeHelper.getCurrentList(store);
     const rustLvl = storeHelper.abilityLevel(list, 'Rustmästare');
+    const shieldLvl = storeHelper.abilityLevel(list, 'Sköldkamp');
+
+    const shieldItem = inv.find(row => {
+      const name = (row.name || '').toLowerCase();
+      return name.includes('sköld') || name === 'bucklare';
+    });
+    const hasShield = !!shieldItem;
+    const canUseShieldSkill = hasShield && (shieldItem.name.toLowerCase().includes('sköld'));
 
     const hasBalancedWeapon = inv.some(row => {
       const entry = invUtil.getEntry(row.name);
       if (!entry || !((entry.taggar?.typ || []).includes('Vapen'))) return false;
+      const ename = (entry.namn || '').toLowerCase();
+      if (ename.includes('sköld') || ename === 'bucklare') return false;
       const tagger = entry.taggar || {};
       const baseQ = [
         ...(tagger.kvalitet || []),
@@ -43,8 +53,14 @@
 
     res = res.length ? res : [ { value: kvick } ];
 
-    if (hasBalancedWeapon) {
-      res.forEach(r => { r.value += 1; });
+    let bonus = 0;
+    if (hasBalancedWeapon) bonus += 1;
+    if (hasShield) {
+      bonus += 1;
+      if (canUseShieldSkill && shieldLvl >= 1) bonus += 1;
+    }
+    if (bonus) {
+      res.forEach(r => { r.value += bonus; });
     }
 
     return res;

--- a/tests/defense.test.js
+++ b/tests/defense.test.js
@@ -53,4 +53,17 @@ store.data.c.inventory.unshift({ name: 'Kråkrustning', qty: 1 });
 const res4 = window.calcDefense(15);
 assert.deepStrictEqual(res4, [ { name: 'Kråkrustning', value: 13 } ]);
 
+// A shield grants +1 defense
+window.DB.push({ namn: 'Stålsköld', taggar: { typ: ['Vapen'], kvalitet: ['Balanserad'] } });
+window.DBIndex['Stålsköld'] = window.DB[2];
+store.data.c.inventory = [ { name: 'Stålsköld', qty: 1 } ];
+store.data.c.list = [];
+const res5 = window.calcDefense(15);
+assert.deepStrictEqual(res5, [ { value: 16 } ]);
+
+// Shieldfighter adds another +1 when Sköldkamp is known
+store.data.c.list = [ { namn: 'Sköldkamp', nivå: 'Novis', taggar: { typ: ['Förmåga'] } } ];
+const res6 = window.calcDefense(15);
+assert.deepStrictEqual(res6, [ { value: 17 } ]);
+
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- account for shields granting +1 defense
- add extra +1 defense when Sköldkamp is at Novis level
- cover shield and Sköldkamp interaction with unit tests

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_688f14a208448323aaa6edb249957fd4