### PR TITLE
Ensure Rustmästare Gesäll removes armor defense penalty

### DIFF
--- a/tests/defense.test.js
+++ b/tests/defense.test.js
@@ -62,6 +62,15 @@ assert.deepStrictEqual(res, [ { name: 'Otymplig rustning', value: 12 } ]);
 html = window.itemStatHtml(window.DBIndex['Otymplig rustning'], store.data.c.inventory[0]);
 assert(html.includes('Begränsning: -3'));
 
+// Rustmästare (Gesäll) removes armor limitation penalty
+store.data.c.inventory = [ { name: 'Kråkrustning', qty: 1 } ];
+store.data.c.list = [ { namn: 'Rustmästare', nivå: 'Gesäll', taggar: { typ: ['Förmåga'] } } ];
+res = window.calcDefense(15);
+assert.deepStrictEqual(res, [ { name: 'Kråkrustning', value: 15 } ]);
+html = window.itemStatHtml(window.DBIndex['Kråkrustning'], store.data.c.inventory[0]);
+assert(html.includes('Begränsning: 0'));
+store.data.c.list = [];
+
 // No armor should still yield a defense value with zero limitation
 store.data.c.inventory = [];
 const res2 = window.calcDefense(15);


### PR DESCRIPTION
## Summary
- add defense test verifying that Rustmästare at Gesäll rank nullifies armor limitation penalties

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688f1ecd8e3483239744f12dc92e585c