### PR TITLE
Enable configurable defense trait

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -37,6 +37,7 @@ const dom  = {
   forgeBtn : $T('partySmith'),
   alcBtn  : $T('partyAlchemist'),
   artBtn  : $T('partyArtefacter'),
+  defBtn  : $T('forceDefense'),
 
   /* traits */
   traits  : $T('traits'),       traitsTot: $T('traitsTotal'),
@@ -296,6 +297,17 @@ function bindToolbar() {
       });
     });
   }
+  if (dom.defBtn) {
+    if (storeHelper.getDefenseTrait(store)) dom.defBtn.classList.add('active');
+    dom.defBtn.addEventListener('click', () => {
+      openDefensePopup(trait => {
+        if (trait === null) return;
+        dom.defBtn.classList.toggle('active', Boolean(trait));
+        storeHelper.setDefenseTrait(store, trait);
+        if (window.renderTraits) renderTraits();
+      });
+    });
+  }
   if (dom.filterUnion) {
     if (storeHelper.getFilterUnion(store)) dom.filterUnion.classList.add('active');
     dom.filterUnion.addEventListener('click', () => {
@@ -391,6 +403,36 @@ function openArtefacterPopup(cb) {
     const lvl = b.dataset.level;
     close();
     cb(lvl);
+  }
+  function onCancel() { close(); cb(null); }
+  function onOutside(e) {
+    if(!pop.querySelector('.popup-inner').contains(e.target)){
+      close();
+      cb(null);
+    }
+  }
+  box.addEventListener('click', onBtn);
+  cls.addEventListener('click', onCancel);
+  pop.addEventListener('click', onOutside);
+}
+
+function openDefensePopup(cb) {
+  const pop  = bar.shadowRoot.getElementById('defensePopup');
+  const box  = bar.shadowRoot.getElementById('defenseOptions');
+  const cls  = bar.shadowRoot.getElementById('defenseCancel');
+  pop.classList.add('open');
+  function close() {
+    pop.classList.remove('open');
+    box.removeEventListener('click', onBtn);
+    cls.removeEventListener('click', onCancel);
+    pop.removeEventListener('click', onOutside);
+  }
+  function onBtn(e) {
+    const b = e.target.closest('button[data-trait]');
+    if (!b) return;
+    const tr = b.dataset.trait;
+    close();
+    cb(tr);
   }
   function onCancel() { close(); cb(null); }
   function onOutside(e) {

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -152,6 +152,13 @@ class SharedToolbar extends HTMLElement {
             </li>
             <li>
               <span class="toggle-desc">
+                <span class="toggle-question">Tvinga försvarskaraktärsdrag?</span>
+                <span class="toggle-note">Välj karaktärsdrag via meny.</span>
+              </span>
+              <button id="forceDefense" class="party-toggle" title="Välj försvarskaraktärsdrag">🛡️</button>
+            </li>
+            <li>
+              <span class="toggle-desc">
                 <span class="toggle-question">Behöver du hjälp?</span>
                 <span class="toggle-note">Öppnar en översikt av alla knappar.</span>
               </span>
@@ -252,6 +259,25 @@ class SharedToolbar extends HTMLElement {
       </div>
       </div>
 
+      <!-- ---------- Popup Försvarskaraktärsdrag ---------- -->
+      <div id="defensePopup">
+        <div class="popup-inner">
+          <h3>Försvarskaraktärsdrag</h3>
+          <div id="defenseOptions">
+            <button data-trait="" class="char-btn">Automatiskt</button>
+            <button data-trait="Diskret" class="char-btn">Diskret</button>
+            <button data-trait="Kvick" class="char-btn">Kvick</button>
+            <button data-trait="Listig" class="char-btn">Listig</button>
+            <button data-trait="Stark" class="char-btn">Stark</button>
+            <button data-trait="Träffsäker" class="char-btn">Träffsäker</button>
+            <button data-trait="Vaksam" class="char-btn">Vaksam</button>
+            <button data-trait="Viljestark" class="char-btn">Viljestark</button>
+            <button data-trait="Övertygande" class="char-btn">Övertygande</button>
+          </div>
+          <button id="defenseCancel" class="char-btn danger">Avbryt</button>
+        </div>
+      </div>
+
       <!-- ---------- Nilas Popup ---------- -->
       <div id="nilasPopup">
         <div class="popup-inner">
@@ -348,7 +374,7 @@ class SharedToolbar extends HTMLElement {
     if (path.some(el => toggles.includes(el.id))) return;
 
     // ignore clicks inside popups so panels stay open
-    const popups = ['qualPopup','customPopup','moneyPopup','masterPopup','alcPopup','smithPopup','artPopup','nilasPopup'];
+    const popups = ['qualPopup','customPopup','moneyPopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','nilasPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));

--- a/js/store.js
+++ b/js/store.js
@@ -44,6 +44,7 @@
             possessionMoney: defaultMoney(),
             possessionRemoved: 0,
             hamnskifteRemoved: [],
+            forcedDefense: '',
             ...cur
           };
           if(!store.data[id].artifactEffects){
@@ -63,6 +64,9 @@
           }
           if(!Array.isArray(store.data[id].hamnskifteRemoved)){
             store.data[id].hamnskifteRemoved = [];
+          }
+          if(store.data[id].forcedDefense === undefined){
+            store.data[id].forcedDefense = '';
           }
           if(store.data[id].nilasPopupShown === undefined){
             store.data[id].nilasPopupShown = false;
@@ -429,6 +433,19 @@
     if (!store.current) return;
     store.data[store.current] = store.data[store.current] || {};
     store.data[store.current].partyArtefacter = level || '';
+    save(store);
+  }
+
+  function getDefenseTrait(store) {
+    if (!store.current) return '';
+    const data = store.data[store.current] || {};
+    return data.forcedDefense || '';
+  }
+
+  function setDefenseTrait(store, trait) {
+    if (!store.current) return;
+    store.data[store.current] = store.data[store.current] || {};
+    store.data[store.current].forcedDefense = trait || '';
     save(store);
   }
 
@@ -946,6 +963,8 @@ function defaultTraits() {
     setPartyAlchemist,
     getPartyArtefacter,
     setPartyArtefacter,
+    getDefenseTrait,
+    setDefenseTrait,
     getArtifactEffects,
     setArtifactEffects,
     getFilterUnion,

--- a/tests/defense-trait.test.js
+++ b/tests/defense-trait.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+
+global.window = {};
+const store = { current: 'c', data: { c: { forcedDefense: '' } } };
+global.store = store;
+const levels = { Novis:1, 'Gesäll':2, 'Mästare':3 };
+global.storeHelper = {
+  abilityLevel: (list, name) => {
+    const it = list.find(x => x.namn === name);
+    return it ? (levels[it.nivå] || 0) : 0;
+  },
+  getDefenseTrait: s => s.data[s.current].forcedDefense || ''
+};
+require('../js/traits-utils');
+const getDefenseTraitName = window.getDefenseTraitName;
+
+// Default to Kvick
+assert.strictEqual(getDefenseTraitName([]), 'Kvick');
+// Forced trait overrides
+store.data.c.forcedDefense = 'Listig';
+assert.strictEqual(getDefenseTraitName([]), 'Listig');
+store.data.c.forcedDefense = '';
+// Ability checks
+assert.strictEqual(getDefenseTraitName([{ namn:'Fint', nivå:'Gesäll' }]), 'Diskret');
+assert.strictEqual(getDefenseTraitName([{ namn:'Sjätte Sinne', nivå:'Gesäll' }]), 'Vaksam');
+assert.strictEqual(getDefenseTraitName([{ namn:'Taktiker', nivå:'Gesäll' }]), 'Listig');
+assert.strictEqual(getDefenseTraitName([{ namn:'Pareringsmästare', nivå:'Novis' }]), 'Träffsäker');
+// Priority: Fint over Pareringsmästare
+assert.strictEqual(getDefenseTraitName([
+  { namn:'Fint', nivå:'Gesäll' },
+  { namn:'Pareringsmästare', nivå:'Novis' }
+]), 'Diskret');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- Calculate defense from Diskret, Vaksam, Listig, or Träffsäker when related abilities are present
- Allow forcing a chosen trait for defense via new filter toggle and popup
- Display defense under the trait used instead of always under Kvick and expose helper for trait selection

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_688f1fe731d08323b8fbebf7e2f5519c