### PR TITLE
Treat shields as weapons

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -221,7 +221,7 @@ function initIndex() {
       if (!inv.length) return alert('Ingen utrustning i inventariet.');
       const elig = inv.filter(it => {
         const tag = (invUtil.getEntry(it.name)?.taggar?.typ) || [];
-        return ['Vapen','Rustning'].some(t => tag.includes(t));
+        return ['Vapen','Sköld','Rustning'].some(t => tag.includes(t));
       });
  if (!elig.length) return alert('Ingen lämplig utrustning att förbättra.');
  invUtil.openQualPopup(elig, iIdx => {
@@ -236,7 +236,7 @@ function initIndex() {
     if (btn.dataset.act==='add') {
       if (isInv(p)) {
         const inv = storeHelper.getInventory(store);
-        const indiv = ['Vapen','Rustning','L\u00e4gre Artefakt'].some(t=>p.taggar.typ.includes(t));
+        const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt'].some(t=>p.taggar.typ.includes(t));
         const rowBase = { name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
         if (p.artifactEffect) rowBase.artifactEffect = p.artifactEffect;
         const addRow = trait => {

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -277,7 +277,7 @@
     const tagger = entry.taggar ?? {};
     const tagTyp = tagger.typ ?? [];
     let base = moneyToO(entry.grundpris || {});
-    const forgeable = ['Vapen','Rustning'].some(t => tagTyp.includes(t));
+    const forgeable = ['Vapen','Sköld','Rustning'].some(t => tagTyp.includes(t));
     const baseQuals = [
       ...(tagger.kvalitet ?? []),
       ...splitQuals(entry.kvalitet)
@@ -344,7 +344,7 @@
       storeHelper.getCurrentList(store), 'Artefaktmakande');
     const artLevel = Math.max(partyArt, skillArt);
 
-    const forgeable = ['Vapen','Rustning'].some(t => tagTyp.includes(t));
+    const forgeable = ['Vapen','Sköld','Rustning'].some(t => tagTyp.includes(t));
     const baseQuals = [
       ...(tagger.kvalitet ?? []),
       ...splitQuals(entry.kvalitet)
@@ -432,7 +432,7 @@
       const basePrice = moneyToO(entry.grundpris || {});
       let base  = basePrice;
       const tagTyp = entry.taggar?.typ || [];
-      const forgeable = ['Vapen','Rustning'].some(t => tagTyp.includes(t));
+      const forgeable = ['Vapen','Sköld','Rustning'].some(t => tagTyp.includes(t));
       const baseQuals = [
         ...(entry.taggar?.kvalitet ?? []),
         ...splitQuals(entry.kvalitet)
@@ -563,8 +563,8 @@
           }
 
           /* — knappar — */
-          const isGear = ['Vapen', 'Rustning', 'L\u00e4gre Artefakt', 'Artefakter'].some(t => tagTyp.includes(t));
-          const allowQual = ['Vapen','Pil/Lod','Rustning','Artefakter'].some(t => tagTyp.includes(t));
+          const isGear = ['Vapen', 'Sköld', 'Rustning', 'L\u00e4gre Artefakt', 'Artefakter'].some(t => tagTyp.includes(t));
+          const allowQual = ['Vapen','Sköld','Pil/Lod','Rustning','Artefakter'].some(t => tagTyp.includes(t));
  const btnRow = isGear
   ? `<button data-act="del" class="char-btn danger">🗑</button>`
   : `<button data-act="del" class="char-btn danger">🗑</button>
@@ -693,7 +693,7 @@
 
       // "+" lägger till qty eller en ny instans
       if (act === 'add') {
-        const indiv = ['Vapen','Rustning','L\u00e4gre Artefakt','Artefakter'].some(t => entry.taggar.typ.includes(t));
+        const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter'].some(t => entry.taggar.typ.includes(t));
         const addRow = trait => {
           const obj = { name: entry.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
           if (trait) obj.trait = trait;
@@ -749,7 +749,7 @@
       // "K+" öppnar popup för att lägga kvalitet
       if (act === 'addQual') {
         const tagTyp = (entry.taggar?.typ || []);
-        if (!['Vapen','Pil/Lod','Rustning','Artefakter'].some(t => tagTyp.includes(t))) return;
+        if (!['Vapen','Sköld','Pil/Lod','Rustning','Artefakter'].some(t => tagTyp.includes(t))) return;
         const qualities = DB.filter(isQual);
         openQualPopup(qualities, qIdx => {
           if (idx >= 0 && qualities[qIdx]) {

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -21,7 +21,7 @@
       const entry = invUtil.getEntry(row.name);
       if (!entry) return;
       const types = entry.taggar?.typ || [];
-      if (!types.includes('Vapen')) return;
+      if (!types.includes('Vapen') && !types.includes('Sköld')) return;
       weaponCount += 1;
       if (types.includes('Sköld')) hasShield = true;
       const tagger = entry.taggar || {};

--- a/js/utils.js
+++ b/js/utils.js
@@ -2,6 +2,7 @@
   const LVL   = ['Novis','Ges\u00e4ll','M\u00e4stare'];
   const EQUIP = [
     'Vapen',
+    'Sköld',
     'Pil/Lod',
     'Rustning',
     'Diverse',
@@ -114,7 +115,7 @@
       }
       return parts.length ? `<br>${parts.join('<br>')}` : '';
     }
-    if (types.includes('Vapen')) {
+    if (types.includes('Vapen') || types.includes('Sköld')) {
       const dmg = entry.stat?.skada;
       return dmg ? `<br>Skada: ${dmg}` : '';
     }

--- a/tests/shield.test.js
+++ b/tests/shield.test.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+
+// Minimal DOM/window stubs
+global.window = {
+  localStorage: { getItem: () => null, setItem: () => {} },
+  DB: [],
+  DBIndex: {},
+};
+global.localStorage = window.localStorage;
+
+global.DB = window.DB;
+global.DBIndex = window.DBIndex;
+
+require('../js/utils');
+global.splitQuals = window.splitQuals;
+require('../js/store');
+global.storeHelper = window.storeHelper;
+global.SBASE = 10; // needed for inventory utils
+global.OBASE = 10;
+require('../js/inventory-utils');
+global.invUtil = window.invUtil;
+require('../js/traits-utils');
+
+// Stub helper methods for forging
+storeHelper.getCurrentList = () => [];
+storeHelper.getPartySmith = () => 'Novis';
+storeHelper.getPartyAlchemist = () => null;
+storeHelper.getPartyArtefacter = () => null;
+storeHelper.abilityLevel = () => 0;
+
+// Add shield entry with only the type 'Sköld'
+window.DB.push({
+  namn: 'Sköld',
+  taggar: { typ: ['Sköld'] },
+  stat: { skada: '1T4' },
+  grundpris: { daler: 3, skilling: 0, 'örtegar': 0 },
+});
+window.DBIndex['Sköld'] = window.DB[0];
+
+const defaultMoney = { 'örtegar':0, skilling:0, daler:0 };
+const store = { current: 'c', data: { c: { inventory: [ { name: 'Sköld', qty: 1 } ], list: [], privMoney: defaultMoney, possessionMoney: defaultMoney } } };
+
+global.store = store;
+window.store = store;
+
+// Shield should benefit from forging discounts like a weapon
+const cost = invUtil.calcEntryCost(window.DBIndex['Sköld']);
+assert.deepStrictEqual(cost, { d:1, s:5, o:0 });
+
+// Shield should provide +1 defense on its own
+const res = window.calcDefense(15);
+assert.deepStrictEqual(res, [ { value: 16 } ]);
+
+console.log('Shield treated as weapon tests passed.');


### PR DESCRIPTION
## Summary
- Let shields be categorized as equipment and display weapon stats
- Handle shields as forgeable gear and allow qualities in the inventory UI
- Count shields as weapons for defense calculations and add regression test

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_688f22bb192883238fcd208873bbf0c9