### PR TITLE
Use Vaksam defense trait with Sixth Sense

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -117,10 +117,20 @@
   function getDefenseTraitName(list) {
     const forced = storeHelper.getDefenseTrait(store);
     if (forced) return forced;
-    if (storeHelper.abilityLevel(list, 'Fint') >= 2) return 'Diskret';
-    if (storeHelper.abilityLevel(list, 'Sjätte Sinne') >= 2) return 'Vaksam';
-    if (storeHelper.abilityLevel(list, 'Taktiker') >= 2) return 'Listig';
-    if (storeHelper.abilityLevel(list, 'Pareringsmästare') >= 1) return 'Tr\u00e4ffs\u00e4ker';
+
+    const ABILITY_TRAITS = [
+      { ability: 'Fint',            level: 2, trait: 'Diskret' },
+      { ability: 'Sjätte Sinne',    level: 2, trait: 'Vaksam' },
+      { ability: 'Taktiker',        level: 2, trait: 'Listig' },
+      { ability: 'Pareringsmästare', level: 1, trait: 'Tr\u00e4ffs\u00e4ker' }
+    ];
+
+    for (const { ability, level, trait } of ABILITY_TRAITS) {
+      if (storeHelper.abilityLevel(list, ability) >= level) {
+        return trait;
+      }
+    }
+
     return 'Kvick';
   }
 

--- a/tests/defense-trait.test.js
+++ b/tests/defense-trait.test.js
@@ -30,5 +30,15 @@ assert.strictEqual(getDefenseTraitName([
   { namn:'Fint', nivå:'Gesäll' },
   { namn:'Pareringsmästare', nivå:'Novis' }
 ]), 'Diskret');
+// Novis levels shouldn't trigger Vaksam
+assert.strictEqual(
+  getDefenseTraitName([{ namn: 'Sjätte Sinne', nivå: 'Novis' }]),
+  'Kvick'
+);
+// Fint has priority over Sjätte Sinne
+assert.strictEqual(getDefenseTraitName([
+  { namn: 'Fint', nivå: 'Gesäll' },
+  { namn: 'Sjätte Sinne', nivå: 'Gesäll' }
+]), 'Diskret');
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- Map Sixth Sense (Sjätte Sinne) to the Vigilant (Vaksam) trait when calculating defense, using a unified ability-to-trait table
- Extend defense trait tests to cover Sixth Sense at both Novis and Gesäll levels and verify priority ordering

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_688f4a988bcc8323b69efcca1cb9501f