### PR TITLE
Add defense trait selector popup and update toggle icon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -898,6 +898,42 @@ select.level {
 }
 #artPopup .popup-inner button { width: 100%; }
 
+/* ---------- Popup för försvarskaraktärsdrag ---------- */
+#defensePopup {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 3000;
+}
+#defensePopup.open { display: flex; }
+#defensePopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem 1.2rem 0 0;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.4rem 2rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+  transform: translateY(100%);
+  transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: .8rem;
+}
+#defensePopup.open .popup-inner { transform: translateY(0); }
+#defensePopup #defenseOptions {
+  display: flex;
+  flex-direction: column;
+  gap: .6rem;
+}
+#defensePopup .popup-inner button { width: 100%; }
+
 /* ---------- Popup f\u00f6r Nilas-fr\u00e5gan ---------- */
 #nilasPopup {
   position: fixed;
@@ -934,6 +970,7 @@ select.level {
 #alcPopup .popup-inner,
 #smithPopup .popup-inner,
 #artPopup .popup-inner,
+#defensePopup .popup-inner,
 #nilasPopup .popup-inner {
   max-height: 100%;
   overflow-y: auto;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -155,7 +155,7 @@ class SharedToolbar extends HTMLElement {
                 <span class="toggle-question">Tvinga försvarskaraktärsdrag?</span>
                 <span class="toggle-note">Välj karaktärsdrag via meny.</span>
               </span>
-              <button id="forceDefense" class="party-toggle" title="Välj försvarskaraktärsdrag">🛡️</button>
+              <button id="forceDefense" class="party-toggle" title="Välj försvarskaraktärsdrag">🏃</button>
             </li>
             <li>
               <span class="toggle-desc">


### PR DESCRIPTION
## Summary
- Change defense trait toggle icon to runner and open trait selector
- Style defense trait selector as slide-up popup

## Testing
- `for f in tests/*.test.js; do node "$f" || break; done`


------
https://chatgpt.com/codex/tasks/task_e_688f4b2d7c68832395690db12742e45b