### PR TITLE
Allow Reses to learn Robust without Dark Blood

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -306,6 +306,7 @@ function initIndex() {
             list.some(x => x.namn === 'Mörkt blod') ||
             (baseRace === 'Troll' && trollTraits.includes(p.namn)) ||
             (baseRace === 'Vandöd' && undeadTraits.includes(p.namn)) ||
+            (baseRace === 'Rese' && p.namn === 'Robust') ||
             (list.some(x => x.namn === 'Blodvadare') && bloodvaderTraits.includes(p.namn)) ||
             ((baseRace === 'Andrik' || bloodRaces.includes('Andrik')) && p.namn === 'Diminutiv') ||
             (hamLvl >= 2 && lvl === 'Novis' && ['Naturligt vapen','Pansar'].includes(p.namn)) ||

--- a/tests/robust-race.test.js
+++ b/tests/robust-race.test.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const code = fs.readFileSync(path.join(__dirname, '../js/index-view.js'), 'utf8');
+const match = code.match(/if \(isMonstrousTrait\(p\)\) {([^]*?)if \(!monsterOk\)/);
+assert(match, 'monstrous trait block not found');
+const fn = new Function('p', 'list', 'lvl', 'isRas', 'storeHelper', match[1] + 'return monsterOk;');
+
+const isRas = x => (x.taggar?.typ || []).includes('Ras');
+const abilityLevel = () => 0;
+
+function canTake(list) {
+  const p = { namn: 'Robust', taggar: { typ: ['Monstruöst särdrag'] } };
+  return fn(p, list, 'Novis', isRas, { abilityLevel });
+}
+
+assert.strictEqual(canTake([{ namn: 'Rese', taggar: { typ: ['Ras'] } }]), true);
+assert.strictEqual(canTake([
+  { namn: 'Människa', taggar: { typ: ['Ras'] } },
+  { namn: 'Mörkt blod' }
+]), true);
+assert.strictEqual(canTake([{ namn: 'Människa', taggar: { typ: ['Ras'] } }]), false);
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- Treat Rese heritage as its own requirement for the Robust trait so characters with the race no longer need Dark Blood
- Add regression test for selecting Robust when meeting either Dark Blood or Rese requirements

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688f4b7795b88323acf773af1b37e4e3