### PR TITLE
Restrict Hamnskifte trait upgrades to Blodvadare

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -315,7 +315,7 @@ function initCharacter() {
         e.target.value = old;
         return;
       }
-      if (storeHelper.hamnskifteNoviceLimit(list, name, ent.nivå)) {
+      if (storeHelper.hamnskifteNoviceLimit(list, ent, ent.nivå)) {
         alert('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
         ent.nivå = old;
         e.target.value = old;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -313,7 +313,7 @@ function initIndex() {
           if (!monsterOk) {
             if (!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')) return;
           }
-          if (storeHelper.hamnskifteNoviceLimit(list, p.namn, lvl)) {
+          if (storeHelper.hamnskifteNoviceLimit(list, p, lvl)) {
             alert('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
             return;
           }
@@ -533,7 +533,7 @@ function initIndex() {
         e.target.value = old;
         return;
       }
-      if (storeHelper.hamnskifteNoviceLimit(list, name, ent.nivå)) {
+      if (storeHelper.hamnskifteNoviceLimit(list, ent, ent.nivå)) {
         alert('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
         ent.nivå = old;
         e.target.value = old;

--- a/js/store.js
+++ b/js/store.js
@@ -565,27 +565,18 @@ function defaultTraits() {
     return LEVEL_IDX[ent?.nivå || ''] || 0;
   }
 
-  function hasOtherMonsterAccess(list, trait) {
-    const baseRace = list.find(isRas)?.namn;
-    const trollTraits = ['Naturligt vapen', 'Pansar', 'Regeneration', 'Robust'];
-    const undeadTraits = ['Gravkyla', 'Skräckslå', 'Vandödhet'];
-    const bloodvaderTraits = ['Naturligt vapen','Pansar','Regeneration','Robust'];
-    if (list.some(x => x.namn === 'Mörkt blod')) return true;
-    if (baseRace === 'Troll' && trollTraits.includes(trait)) return true;
-    if (baseRace === 'Vandöd' && undeadTraits.includes(trait)) return true;
-    if (list.some(x => x.namn === 'Blodvadare') && bloodvaderTraits.includes(trait)) return true;
-    return false;
-  }
-
-  function hamnskifteNoviceLimit(list, trait, level) {
+  function hamnskifteNoviceLimit(list, item, level) {
     const lvl = LEVEL_IDX[level || 'Novis'] || 1;
     if (lvl <= 1) return false;
+    if (item.form !== 'beast') return false;
     const hamlvl = abilityLevel(list, 'Hamnskifte');
-    if (['Naturligt vapen', 'Pansar'].includes(trait) && hamlvl >= 2) {
-      return !hasOtherMonsterAccess(list, trait);
+    const hasBloodvader = list.some(x => x.namn === 'Blodvadare');
+    if (hasBloodvader) return false;
+    if (['Naturligt vapen', 'Pansar'].includes(item.namn) && hamlvl >= 2) {
+      return true;
     }
-    if (['Regeneration', 'Robust'].includes(trait) && hamlvl >= 3) {
-      return !hasOtherMonsterAccess(list, trait);
+    if (['Regeneration', 'Robust'].includes(item.namn) && hamlvl >= 3) {
+      return true;
     }
     return false;
   }

--- a/tests/hamnskifte-limit.test.js
+++ b/tests/hamnskifte-limit.test.js
@@ -28,16 +28,20 @@ global.isMonstrousTrait = window.isMonstrousTrait;
 global.isRas = window.isRas;
 require('../js/store');
 
-function limit(list, name, lvl){
-  return window.storeHelper.hamnskifteNoviceLimit(list, name, lvl);
+function limit(list, item, lvl){
+  return window.storeHelper.hamnskifteNoviceLimit(list, item, lvl);
 }
 
 (function test(){
   const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
-  assert.strictEqual(limit([hamGes], 'Naturligt vapen', 'Gesäll'), true);
-  assert.strictEqual(limit([hamGes, { namn:'Blodvadare', taggar:{typ:['Yrke']} }], 'Naturligt vapen', 'Gesäll'), false);
-  assert.strictEqual(limit([hamGes, { namn:'Mörkt blod', taggar:{typ:['Fördel']} }], 'Naturligt vapen', 'Gesäll'), false);
+  const nvBeast = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
+  assert.strictEqual(limit([hamGes, nvBeast], nvBeast, 'Gesäll'), true);
+  assert.strictEqual(limit([hamGes, nvBeast, { namn:'Blodvadare', taggar:{typ:['Yrke']} }], nvBeast, 'Gesäll'), false);
+  assert.strictEqual(limit([hamGes, nvBeast, { namn:'Mörkt blod', taggar:{typ:['Fördel']} }], nvBeast, 'Gesäll'), true);
   const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
-  assert.strictEqual(limit([hamMas], 'Robust', 'Gesäll'), true);
+  const robBeast = { namn:'Robust', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
+  assert.strictEqual(limit([hamMas, robBeast], robBeast, 'Gesäll'), true);
+  const robBase = { namn:'Robust', taggar:{typ:['Monstruöst särdrag']} };
+  assert.strictEqual(limit([hamMas, robBeast, robBase], robBase, 'Gesäll'), false);
   console.log('All tests passed.');
 })();


### PR DESCRIPTION
## Summary
- Require Blodvadare to raise Hamnskifte-derived beast traits while letting normal traits advance freely
- Pass full trait objects to Hamnskifte limit checks in both views
- Extend tests to cover upgraded restrictions and base Robust example

## Testing
- `for f in tests/*.test.js; do node "$f" || break; done`


------
https://chatgpt.com/codex/tasks/task_e_688f4b4993bc83239928768b96edeed8