### PR TITLE
Handle Hamnskifte trait variants independently

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -69,9 +69,10 @@ function initCharacter() {
 
   const renderSkills = arr=>{
     const groups = [];
+    const hamNames = Object.values(storeHelper.HAMNSKIFTE_NAMES);
     arr.forEach(p=>{
         const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
-        if(multi && !['Naturligt vapen','Pansar','Regeneration','Robust'].includes(p.namn)){
+        if(multi && !['Naturligt vapen','Pansar','Regeneration','Robust', ...hamNames].includes(p.namn)){
           const g = groups.find(x=>x.entry.namn===p.namn);
           if(g) { g.count++; return; }
           groups.push({entry:p, count:1});
@@ -131,7 +132,7 @@ function initCharacter() {
       li.dataset.xp = xpVal;
       const showInfo = compact || hideDetails;
       const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '';
-      li.innerHTML = `<div class="card-title"><span>${p.form === "beast" ? `${p.namn}: Hamnskifte` : p.namn}${badge}</span>${xpHtml}</div>
+      li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span>${xpHtml}</div>
         <div class="tags">${tagsHtml}</div>
         ${lvlSel}
         ${descHtml}

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -6,10 +6,11 @@
 
     const PEN = { Novis: 2, 'Gesäll': 3, 'Mästare': 4 };
     const robustPenalty = list
-      .filter(x => x.namn === 'Robust' && x.form !== 'beast')
+      .filter(x => x.namn === 'Robust')
       .reduce((sum, x) => sum + (PEN[x.nivå] || 0), 0);
+    const hamRobustName = storeHelper.HAMNSKIFTE_NAMES['Robust'];
     const hamRobustPenalty = list
-      .filter(x => x.namn === 'Robust' && x.form === 'beast')
+      .filter(x => x.namn === hamRobustName)
       .reduce((sum, x) => sum + (PEN[x.nivå] || 0), 0);
 
     let hasBalancedWeapon = false;
@@ -105,7 +106,7 @@
 
     let hamRes = [];
     if (hamRobustPenalty) {
-      hamRes = [ { name: 'Robust: Hamnskifte', value: kvick - hamRobustPenalty } ];
+      hamRes = [ { name: hamRobustName, value: kvick - hamRobustPenalty } ];
       if (mantleLvl >= 1) {
         hamRes.forEach(r => { r.value += 1; });
       }

--- a/tests/andrik.test.js
+++ b/tests/andrik.test.js
@@ -12,7 +12,7 @@ const abilityLevel = () => 0;
 
 function canTake(list){
   const p = { namn: 'Diminutiv', taggar: { typ: ['Monstruöst särdrag'] } };
-  return fn(p, list, 'Novis', isRas, { abilityLevel });
+  return fn(p, list, 'Novis', isRas, { abilityLevel, HAMNSKIFTE_BASE: {} });
 }
 
 assert.strictEqual(canTake([{ namn:'Andrik', taggar:{ typ:['Ras'] } }]), true);

--- a/tests/defense.test.js
+++ b/tests/defense.test.js
@@ -173,7 +173,7 @@ assert.deepStrictEqual(res11, [ { value: 16 } ]);
   // Robust: Hamnskifte ignores inventory but allows abilities
   store.data.c.inventory = [ { name: 'Sv\u00e4rd', qty: 1, kvaliteter: ['Balanserat'] } ];
   store.data.c.list = [
-    { namn: 'Robust', niv\u00e5: 'Novis', taggar: { typ: ['S\u00e4rdrag'] }, form: 'beast' },
+    { namn: 'Robust: Hamnskifte', niv\u00e5: 'Novis', taggar: { typ: ['S\u00e4rdrag'] }, form: 'beast' },
     { namn: 'Manteldans', niv\u00e5: 'Novis', taggar: { typ: ['F\u00f6rm\u00e5ga'] } }
   ];
   const res16 = window.calcDefense(15);

--- a/tests/hamnskifte-auto.test.js
+++ b/tests/hamnskifte-auto.test.js
@@ -33,19 +33,20 @@ function traitsFor(level){
   const store = { current: 'c', data: { c: { privMoney: defaultMoney, possessionMoney: defaultMoney } } };
   const list = [ { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå: level } ];
   window.storeHelper.setCurrentList(store, list);
-  return store.data.c.list.filter(x => ['Naturligt vapen','Pansar','Robust','Regeneration'].includes(x.namn)).map(x => x.namn).sort();
+  const names = Object.values(window.storeHelper.HAMNSKIFTE_NAMES);
+  return store.data.c.list.filter(x => names.includes(x.namn)).map(x => x.namn).sort();
 }
 
 assert.deepStrictEqual(traitsFor('Novis'), []);
-assert.deepStrictEqual(traitsFor('Gesäll'), ['Naturligt vapen','Pansar'].sort());
-assert.deepStrictEqual(traitsFor('Mästare'), ['Naturligt vapen','Pansar','Regeneration','Robust'].sort());
+assert.deepStrictEqual(traitsFor('Gesäll'), ['Naturligt vapen: Hamnskifte','Pansar: Hamnskifte'].sort());
+assert.deepStrictEqual(traitsFor('Mästare'), ['Naturligt vapen: Hamnskifte','Pansar: Hamnskifte','Regeneration: Hamnskifte','Robust: Hamnskifte'].sort());
 
 (function testDependents(){
   const store = { current:'c', data:{ c:{ privMoney:defaultMoney, possessionMoney:defaultMoney } } };
   const list = [ { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' } ];
   window.storeHelper.setCurrentList(store, list);
   const deps = window.storeHelper.getDependents(store.data.c.list, 'Hamnskifte').sort();
-  assert.deepStrictEqual(deps, ['Naturligt vapen','Pansar']);
+  assert.deepStrictEqual(deps, ['Naturligt vapen: Hamnskifte','Pansar: Hamnskifte']);
 })();
 
 console.log('All tests passed.');

--- a/tests/hamnskifte-cost.test.js
+++ b/tests/hamnskifte-cost.test.js
@@ -37,10 +37,10 @@ function test(){
     return window.storeHelper.calcUsedXP(list, {});
   }
 
-  const nv = { ...window.DB.find(x => x.namn === 'Naturligt vapen'), form:'beast' };
-  const pan = { ...window.DB.find(x => x.namn === 'Pansar'), form:'beast' };
-  const reg = { ...window.DB.find(x => x.namn === 'Regeneration'), form:'beast' };
-  const rob = { ...window.DB.find(x => x.namn === 'Robust'), form:'beast' };
+  const nv = { ...window.DB.find(x => x.namn === 'Naturligt vapen'), namn:'Naturligt vapen: Hamnskifte', form:'beast' };
+  const pan = { ...window.DB.find(x => x.namn === 'Pansar'), namn:'Pansar: Hamnskifte', form:'beast' };
+  const reg = { ...window.DB.find(x => x.namn === 'Regeneration'), namn:'Regeneration: Hamnskifte', form:'beast' };
+  const rob = { ...window.DB.find(x => x.namn === 'Robust'), namn:'Robust: Hamnskifte', form:'beast' };
   const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga','Mystisk kraft']}, nivå:'Gesäll' };
   const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga','Mystisk kraft']}, nivå:'Mästare' };
 

--- a/tests/hamnskifte-discount.test.js
+++ b/tests/hamnskifte-discount.test.js
@@ -35,9 +35,9 @@ function xpFor(items){
 
 function test(){
   const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
-  const nvGes = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, nivå:'Gesäll', form:'beast' };
+  const nvGes = { ...window.DB.find(x=>x.namn==='Naturligt vapen'), namn:'Naturligt vapen: Hamnskifte', nivå:'Gesäll', form:'beast' };
   const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
-  const regGes = { namn:'Regeneration', taggar:{typ:['Monstruöst särdrag']}, nivå:'Gesäll', form:'beast' };
+  const regGes = { ...window.DB.find(x=>x.namn==='Regeneration'), namn:'Regeneration: Hamnskifte', nivå:'Gesäll', form:'beast' };
 
   assert.strictEqual(xpFor([hamGes, nvGes]), 50);
   assert.strictEqual(xpFor([hamMas, regGes]), 80);

--- a/tests/hamnskifte-form.test.js
+++ b/tests/hamnskifte-form.test.js
@@ -33,10 +33,10 @@ function xpFor(items){
 
 (function test(){
   const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
-  const nvBeast = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
+  const nvBeast = { namn:'Naturligt vapen: Hamnskifte', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
   const nvNorm = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, form:'normal' };
   const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
-  const regBeast = { namn:'Regeneration', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
+  const regBeast = { namn:'Regeneration: Hamnskifte', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
   const regNorm = { namn:'Regeneration', taggar:{typ:['Monstruöst särdrag']}, form:'normal' };
 
   assert.strictEqual(xpFor([hamGes, nvNorm]), 40);

--- a/tests/hamnskifte-limit.test.js
+++ b/tests/hamnskifte-limit.test.js
@@ -28,20 +28,31 @@ global.isMonstrousTrait = window.isMonstrousTrait;
 global.isRas = window.isRas;
 require('../js/store');
 
+const defaultMoney = { "örtegar":0, skilling:0, daler:0 };
+
 function limit(list, item, lvl){
   return window.storeHelper.hamnskifteNoviceLimit(list, item, lvl);
 }
 
 (function test(){
   const hamGes = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Gesäll' };
-  const nvBeast = { namn:'Naturligt vapen', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
+  const nvBeast = { namn:'Naturligt vapen: Hamnskifte', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
   assert.strictEqual(limit([hamGes, nvBeast], nvBeast, 'Gesäll'), true);
   assert.strictEqual(limit([hamGes, nvBeast, { namn:'Blodvadare', taggar:{typ:['Yrke']} }], nvBeast, 'Gesäll'), false);
   assert.strictEqual(limit([hamGes, nvBeast, { namn:'Mörkt blod', taggar:{typ:['Fördel']} }], nvBeast, 'Gesäll'), true);
   const hamMas = { namn:'Hamnskifte', taggar:{typ:['Förmåga']}, nivå:'Mästare' };
-  const robBeast = { namn:'Robust', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
+  const robBeast = { namn:'Robust: Hamnskifte', taggar:{typ:['Monstruöst särdrag']}, form:'beast' };
   assert.strictEqual(limit([hamMas, robBeast], robBeast, 'Gesäll'), true);
-  const robBase = { namn:'Robust', taggar:{typ:['Monstruöst särdrag']} };
+  const robBase = { namn:'Robust', nivå:'Novis', taggar:{typ:['Monstruöst särdrag']} };
   assert.strictEqual(limit([hamMas, robBeast, robBase], robBase, 'Gesäll'), false);
+
+  const store = { current:'c', data:{ c:{ privMoney:defaultMoney, possessionMoney:defaultMoney } } };
+  const list = [hamMas, robBase];
+  window.storeHelper.setCurrentList(store, list);
+  const hamRob = store.data.c.list.find(x=>x.namn==='Robust: Hamnskifte');
+  hamRob.nivå = 'Gesäll';
+  window.storeHelper.setCurrentList(store, store.data.c.list);
+  const base = store.data.c.list.find(x=>x.namn==='Robust');
+  assert.strictEqual(base.nivå, 'Novis');
   console.log('All tests passed.');
 })();

--- a/tests/hamnskifte-stack.test.js
+++ b/tests/hamnskifte-stack.test.js
@@ -41,6 +41,8 @@ function limit(list, name){
   assert.strictEqual(limit([hamMas], 'Regeneration'), 2);
   assert.strictEqual(limit([hamMas], 'Robust'), 2);
   assert.strictEqual(limit([hamMas], 'Vingar'), 1);
+  assert.strictEqual(limit([hamGes], 'Naturligt vapen: Hamnskifte'), 2);
+  assert.strictEqual(limit([hamMas], 'Regeneration: Hamnskifte'), 2);
 
   console.log('All tests passed.');
 })();

--- a/tests/robust-race.test.js
+++ b/tests/robust-race.test.js
@@ -12,7 +12,7 @@ const abilityLevel = () => 0;
 
 function canTake(list) {
   const p = { namn: 'Robust', taggar: { typ: ['Monstruöst särdrag'] } };
-  return fn(p, list, 'Novis', isRas, { abilityLevel });
+  return fn(p, list, 'Novis', isRas, { abilityLevel, HAMNSKIFTE_BASE: {} });
 }
 
 assert.strictEqual(canTake([{ namn: 'Rese', taggar: { typ: ['Ras'] } }]), true);


### PR DESCRIPTION
## Summary
- Map base traits to their Hamnskifte counterparts for lookup and duplication
- Clone required traits with Hamnskifte suffix and manage them as custom entries
- Adjust UI and calculations to treat Hamnskifte variants by name rather than form
- Expand tests to cover Hamnskifte variants and ensure normal traits remain unaffected

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node $f; if [ $? -ne 0 ]; then break; fi; done`

------
https://chatgpt.com/codex/tasks/task_e_688f50c9583c83239b1b5507ef275dab