### PR TITLE
Add sequential IDs to race definitions

### DIFF
--- a/data/ras.json
+++ b/data/ras.json
@@ -1,182 +1,183 @@
 [
   {
-  "namn": "Alv",
-  "beskrivning": "Davokars alver är inte ett folk i egentlig mening utan faktiskt en helig väktarorden. Orden bestod ursprungligen av alver komna från västerns mer jungfruliga trakter, dit människan ännu inte har nått och där alvernas högkultur frodas. Denna orden – av människor känd som Järnpakten – har som uppdrag att förhindra att den ondska som ruvar under Davokars rötter och mossa vaknar igen och sprids i världen.\nHuvuddelen av alverna i Davokar är födda in i pakten och har aldrig varit västerut och kommer aldrig att komma dit; för dem är och förblir västerns alvmarker blott en dröm som aldrig kommer att gå i uppfyllelse. De får redan i späda år höra att deras plikt är här och att de inte är välkomna västerut. De är besmutsade av Davokars mörker och som smittbärare kommer de inte att släppas in i alvernas andra riken. Järnpakten har till och med utvecklat en ceremoni, en initiationsrit för unga alver, där de äldste – ledda av alvfursten Eneánor – gråtande ber nyvakna sommaralver om ursäkt för att de tvingats födas, leva och dö i dödsskuggans skog, Davokar.\nAlvernas läge i Davokar är utsatt, deras antal tynande och deras en gång så starka ledare Furst Eneánor är på väg mot sin själs vinter. Furstens tilltagande oberäknelighet lämnar utrymme för andra oeniga ledare att positionera sig för den stundande maktkampen. Tvistefrågan gäller hur striden mot mörkret ska föras; om det främst är med pilar och spjut eller genom byggandet av allianser.\nDe vårystra älvor som vaknar upp efter sin första dvala träder in i sommaralvens livsfas och det är dessa som utgör stommen i Davokars spetsörade väktarkår: vaksamma jägare rustade med spjut och pilbågar. Många av dem kommer att stupa i strider mot styggelser eller mot tabubrytare bland de alltmer oförsiktiga människorna från söder. De som inte faller i strid når sin andra dvala och även den möts med sammanbitna miner; endast ett fåtal alver vaknar upp ur sin andra dvala, medan merparten tynar bort innan de når nästkommande livsfas.\nJärnpaktens fästen och skogsslott i Davokar ekar av sorgsna stämmors sång, vemodigt klagande över de fallna och borttynade. Alverna blir färre; inte ens utökat bortbytande kan fylla luckorna i deras led med alvtagna människor. Ett glädjeämne är att fler och fler människor frivilligt börjar sluta sig till Järnpakten och optimisterna bland alverna framhåller att det till och med finns ambrier bland dessa.\n",
-  "extra": "**Alviska särdrag, fördelar och nackdelar:** Alviska rollpersoner har särdraget Långlivad. De flesta har dessutom nackdelen Paria, då alver är illa sedda av de flesta människor; ambrier ser dem med avsky och även barbarer är rädda för dem. Många alver har också särdraget Eonernas visdom, vilket införskaffas som andra förmågor.\nAlver som så önskar kan uppträda som bortbytingar, vanligen genom att byta kläder till människoskapade sådana samt imitera mänskliga manér. En person med Lärd till minst gesällnivå kan genomskåda en sådan förklädnad med ett lyckat Listig; en alv som igenkänns som sådan bland människor drabbas av nackdelen Paria.\n\n**Alviska namn:** Vår- och sommaralver ges alla dubbelnamn som följer med individen genom den första dvalan; namn som anspelar på deras karaktär och/eller på förhoppningar om vad denne ska bli under sin krafts dagar. Merparten av de som överlever sin andra dvala väljer att kapa bort en del av sitt namn eller att helt byta, men inte alla. Valet är upp till individen och handlar oftast mer om smak och stil än om någon egentlig funktion. Alvnamn innehåller ofta fler vokaler än konsonanter och bokstaven ”x” är ovanlig, liksom att ett namn har två konsonanter i rad.\n\n**Alviska äventyrare:** Rollpersoner av alvisk härkomst utgörs lämpligen av sommaralver, den andra fasen i den alviska livscykeln. Äldre alver är möjliga att spela, men höstalver passar bättre i kampanjer där övriga rollpersoner är mycket mäktiga, då dessa väsen överskuggar de flesta människor i fråga om personlig makt och insikt i världens djupare mysterier. Alver som rör sig bland människor är mycket ovanliga och har troligen ett starkt motiv för sitt äventyrande.\n\n**Alliansbyggare:** Alven har skickats ut för att bygga relationer till en grupp människor och försöker lära dem om skogens värde och faran med att utforska för ivrigt. Uppdraget kan vara självpåtaget men är mer troligt en order given av en överordnad höstalv.\n\n**Spanare:** Alven är utsänd som kunskapare, för att värdera fiendens styrkor och svagheter inför den strid som med säkerhet kommer. Uppdragsgivare är troligtvis en äldre alv, antingen krigiskt eller diplomatiskt orienterad.\n\n**Exil:** Alver som allvarligt bryter mot gruppens regler är extremt ovanliga men mindre så i det korrumperande Davokar. Kanske är rollpersonen en av dessa. Alternativt är exilen självpåtagen, som en följd av upplevd brist i lojalitet eller heder.\n\n**Hämndsökare:** Alverna lever, jagar och slåss i små enheter med starka band till varandra. Kanske stupade de andra som följd av ett förräderi, medan rollpersonen överlevde av en slump eller genom någon mindre heroisk handling. Alven återvänder inte hem innan förräderiet är hämnat.\n",
-  "sardrag": "Långlivad; Paria; många tar Eonernas visdom (kostar som en förmåga).",
-  "namn_man": [
-    "Alal-Roak",
-    "Dorael-Ri",
-    "Eloan-Eo",
-    "Elori",
-    "Godrai",
-    "Mearoel",
-    "Saran-Ri",
-    "Tel-Keriel",
-    "Kil-Ano"
-  ],
-  "namn_kvinna": [
-    "Ahara-Vei",
-    "Eleanea",
-    "Leiána",
-    "Gaina-Anali",
-    "Keri-Las",
-    "Mael-Melian",
-    "Naelial",
-    "Tara-Kel",
-    "Teara-Téana"
-  ],
-  "taggar": {
-    "typ": [
-      "Ras"
-    ]
-  }
-},
-
-{
-  "namn": "Dvärg",
-  "beskrivning": "Det korta, krumma och seniga folk som människorna kallar dvärgar har en historia dold i dunkel. Om man får utgå från Yndaros dvärgar verkar de inte ens själva vara intresserade av sin historia; de är ett folk på väg, med en längtan framåt, på flykt från ett mörkt förflutet som givit dem sammanhållning men varken ro eller mening. Dvärgarnas arv är familjens helighet, språkets hemligheter och den fasta övertygelsen att världen i övrigt är deras fiende. Gamalga av Kadizar, en lärd med intresse för dvärgarna, lär ha beskrivit det som att ”familjen är deras sköld, språket deras vapen och världen deras slagfält”. Gamalga har också vågat sig på att skissera dvärgarnas ursprung. Efter många fruktlösa samtal med Yndaros dvärgar och långa resor till möjligen lika frustrerade möten i fästet Küam Zamok insåg Gamalga att hon fick bättre svar av alver och troll, och att dessa intygade att de inte mött dvärgar innan Symbaroums fall: sannolikt skapades släktet där. Gamalga sammanfattar sina magra fynd om dvärgarnas ursprung så här:\n”De föddes som maskar i världsormens ruttnade kött och gavs förstånd av Symbars svartkonstnärer, så att de skulle slava bättre. Men dvärgarnas uralstring knöt dem för evigt till världen och dess öde, och i kraft av denna koppling utvecklade de redan under slaveriets ok en kraftfull motkultur som fortfarande präglar dem. Dvärgarnas urmödrar och anfäder byggde ett språk med dolda koder och hemliga dubbelbetydelser, så snåriga att inte ens mästarna förstod vad slavarna sade. Dvärgarna skrev inget, då sådant som kunde läsas också kunde tolkas och dechiffreras av Symbars furstar. Dvärgarnas drömmar förblev deras egna och deras hemliga språk ekade av världens öde. Både troll och alver intygar att det i vissa dvärgars tungomål finns ödeskraft, och antyder också att deras skapare, Symbaroums herrar, lärde sig att hata sina skapelser och med tiden också fruktade dem och deras kraftord. Efter Symbaroums fall är dvärgafolkets krönika en mödosam vandring i dödsskuggans dal, ständigt utsatta och jagade av andra folk och väsen. Numera återfinns ättlingarna till de få överlevande flyktingarna från Symbaroums ruiner på flera platser och deras öden är till synes mycket varierande. Klart är att dvärgarna i Yndaros utgör en tidigare styrande elit från Küam Zamok, utkastade därifrån under en blodig revolution. Det är alltså dvärgiska aristokrater, vana att domdera men inkapabla att själva skapa det allra nödvändigaste, som vi i Yndaros möter som välorganiserade ligister. Mer osäkra uppgifter gör gällande att deras oförmåga att hålla sams har att göra med successionsordningen i det rike de har tvingats fly ifrån, och därmed rätten till en tron de aldrig kommer att få bestiga.”\nYndaros dvärgar är de som ambrierna främst möter och dessa låter ingen utomstående komma dem nära. De kräver inget av världen kring dem, annat än att få leva i fred med sina familjer. Just familjen är dvärgarnas själ och individerna är underordnade familjens vilja – en vilja uttolkad av familjens äldste. Denna extrema sammanhållning ger dem till synes också två sorters moral: den ena strikt kodad och riktad mot familjen, den andra riktad utåt och av dvärgarnas grannar ofta beskriven som en avsaknad av moral, då handlingar mot utomstående inte räknas i relationerna inom familjen. En dvärg är det den gör mot sina meddvärgar, och i någon mån hur dess handlingar utåt påverkar familjen.\nDe yndariska dvärgarnas tungomål är ännu i dag så snårigt av svårdechiffrerade koder, listiga dubbelbetydelser och dunkla idiomatiska uttryck att även dagligt tal i stort sett är obegripligt även för de mest kunniga utomstående. Dvärgarnas tungomål rymmer också en märklig ödestyngd, vilket vissa dvärgar vet att nyttja. Dvärgarnas minnestekniska färdigheter är dessutom långt utvecklade – de driver exempelvis komplexa ”affärsrörelser” i Yndaros helt utan nedtecknade siffror – men också den minneskonstens detaljer är dolda bakom dvärgaspråkets höga murar.\n",
-  "extra": "**Dvärgiska särdrag, fördelar och nackdelar:**\n De flesta rollpersoner av dvärgisk börd har särdraget *Jordnära*, fördelen *Minnesmästare* samt nackdelen *Paria*. Många dvärgar har också den mystiska kraften *Vedergällning*, vilken införskaffas som en förmåga. Just för dvärgar ger denna kraft ingen korruption, varken då den lärs in eller då den används – det gäller enbart för denna kraft och enbart för dvärgar.\n\n**Dvärgars namn:**\nAtt döma av de dvärgar som lever i Yndaros har släktet en förkärlek för hårda namn med många inslag av konsonanter som k, t och r. I övrigt tycks det inte finnas någon skillnad mellan kvinnliga och manliga namn; namnen ärvs inom familjen genom generationer utan hänsyn till kön. Alla dvärgar har även efternamn knutna till sin familj eller ätt, likt Ambrias ädlingar. Yngre dvärgar måste dock förtjäna rätten att använda släktnamnet, företrädesvis genom att göra sina släktingar stolta eller imponerade på något sätt.\n\n**Dvärgiska äventyrare:**\nDvärgar som väljer eller tvingas att lämna sina ätter i Yndaros är ensamma och inte sällan farliga individer. För vissa blir ensamheten starten på sökandet efter en ny familj, definierad på andra sätt än genom blodet och språket. Följande skäl kan driva en dvärgättad rollperson ut i världen:\n\n- **Domedagsdrömmare** – Dvärgen hemsöks av drömmar om domedag och död för sin familj eller för världen i stort. För att utröna drömmarnas sanningshalt, och i bästa fall finna sätt att skydda familjen, lämnar dvärgen gemenskapen och blir en sökare i världen.\n- **Livsskuld** – En utomstående har räddat dvärgens liv utan att kräva något i gengäld. Dvärgen vill återgälda denna handling genom att tjäna livräddaren, vare sig denne vill det eller ej. Detta motiv är allmänt accepterat som anledning att tillfälligt lämna familjen.\n- **Utstött** – Dvärgen har begått illojala handlingar mot sin familj, kanske utmanat familjeöverhuvudet eller ifrågasatt ättens främsta plats i successionsordningen. Straffet blir förvisning, antingen tidsbegränsad eller livslång. För de flesta dvärgar är exil ett straff värre än döden.\n- **Spion** – Dvärgen är i själva verket inte utstött utan spelar rollen för att skaffa hemligheter som familjen behöver. Det kan också handla om ett uppdrag att utföra en olaglig handling, exempelvis att söka efter en rymling som påstår sig ha större rätt till dvärgakronan än rollpersonens familjeöverhuvud.",
-  "sardrag": "Alla rollpersoner av dvärgisk börd har särdraget Jordnära, fördelen Minnesmästare samt nackdelen Paria. Många dvärgar har också den mystiska kraften Vedergällning.",
-  "namn_man": [
-    "Artek",
-    "Bolkor",
-    "Brana",
-    "Dobril",
-    "Dranek",
-    "Dusa",
-    "Jarok",
-    "Lazek",
-    "Margor",
-    "Mirek",
-    "Radmil",
-    "Stana",
-    "Vesnek",
-    "Vlador",
-    "Yaruk"
-  ],
-  "namn_kvinna": [
-    "Artek",
-    "Bolkor",
-    "Brana",
-    "Dobril",
-    "Dranek",
-    "Dusa",
-    "Jarok",
-    "Lazek",
-    "Margor",
-    "Mirek",
-    "Radmil",
-    "Stana",
-    "Vesnek",
-    "Vlador",
-    "Yaruk"
-  ],
-  "taggar": {
-    "typ": [
-      "Ras"
-    ]
-  }
-},
-
-{
-  "namn": "Troll",
-  "beskrivning": "För alla ambrier och de flesta barbarer är troll synonymt med blodig död. Vissa häxor och enstaka ambriska lärde vet bättre och hävdar att det finns ett stort mått av sanning i barbarernas sagor om trollriken under mark, där trollen håller hov och mäktiga sånger framförs i salar prydda med sköna ting frambringade av trollens grova händer. Även de som medger att trollen har en civilisation erkänner dock att troll ovan jord är farliga: troll ger sig inte upp till markytan utan bra skäl därtill, och dessa skäl är ofta blodiga.\nTroll förökar sig inte, den saken sköts av svartalferna. När en svartalf känner dödens andedräkt flåsa dem i nacken söker de sig ner i Davokars underjord. Där faller de ihop och en kokongliknande vävnad växer ut ur deras kroppar för att så småningom omsluta dem helt. Många dör under dvalan men det fåtal som överlever utvecklas till de bestlika varelser som ambrierna kallar rovtroll. Några av dessa har redan som kokonger hittats av andra troll och förts till något rike där de genast tas omhand; merparten kravlar sig dock upp till markytan, nakna och glupande hungriga, redo att äta sig mätta på vadhelst som kommer i deras väg. Även vissa av de senare fångas upp av trollens härskare – härskare som antingen sveper dem i klädnader och uppfostrar dem till civiliserade troll, eller som piskar dem till lydnad och till att bli frontsoldater i deras rövarband på markytan.\nTrollens civilisation är inte heller densamma som mänsklighetens motsvarighet. Ett trolls värde bestäms av vad individen kan tillföra sitt samhälle, vare sig det är krigarens beskydd, hantverkarens vackra ting eller skaldens sånger. De mest drivna och fysiskt potenta trollen mäktar med att karva sig en nisch bland de ledande och tar plats i härskarnas kast – en plats de behåller endast så länge som de med klor och ränker förmår behålla den. Trollen utmanar rutinmässigt varandra till kamp som en del i det sociala spelet. Kampen är ofta fysisk men kan lika gärna handla om vem som kan sjunga längst eller vem som kan skapa den mäktigaste artefakten. De fysiska kamperna är dock mest frekventa och trots att dessa strider är rituella är de inte helt utan dödlig utgång, även om det inte är målet.\nFostran genom fysiska och andliga utmaningar är djupt förankrad i trollens kultur och det ses som grundläggande att odla styrka på både ett personligt och ett kulturellt plan. Tvekamp anses vara det enda sättet att nå denna härdning av kropp och släkte. Ett talesätt bland trollen som fångar detta lyder: ”Om jag knäcker dig blir vårt folk svagare; om jag låter dig komma undan blir du svagare.”\nKapitelmästare Argoi vid Kurun-kapitlet har sammanfattat det på följande sätt: ”Trollens fysisk-moraliska livsstil får ett särskilt blodigt uttryck i mötet med andra folkslag, då det i sådana möten inte längre finns kulturbevarande skäl för trollen att visa nåd. Denna råa slaktarkultur blir tvärt om värre om fienden kapitulerar eller visar någon form av svaghet inför anfallaren, då detta för trollen väcker en särskild sorts avsky. En fiende som visar stridsvilja och mod förtjänar trots allt att respekteras och kan därmed skonas utifrån trollens logik.”\n",
-  "extra": "**Trollens särdrag, fördelar och nackdelar:** Trollättade rollpersoner kan köpa de monstruösa särdragen **Naturligt vapen**, **Pansar**, **Regeneration** och **Robust** som om de vore vanliga förmågor. Troll bär dessutom oftast nackdelen Paria eftersom människor fruktar dem.\n\n**Förklädnad som resa:** Ett troll kan försöka uppträda som resa genom att kapa hornen, byta till människotillverkade kläder och efterlikna resars sävliga rörelsemönster. En person med **Lärd** på minst gesällnivå kan avslöja förklädnaden med ett lyckat **Listig**-slag. Resar har också oftast nackdelen **Paria**, men människor betraktar dem oftast som ofarliga. Om ett troll avslöjas väcker det däremot ofta panik; stadsbor larmar väktare och kallar på trolldräpare.\n\n**Trollens namn:** Släktet gör ingen könsskillnad vid namnval. Varje troll får det namn det förtjänar och kan byta det flera gånger under livet beroende på erfarenheter. Namn skiljer sig mellan yngre och äldre: bokstaven ”x” återfinns ofta i de mäktiga och äldre trollens namn.\n\n**Troll som äventyrare:** Troll är starkt bundna till sina samhällen och behöver mer än vanlig nyfikenhet för att färdas ensamma. Vanliga drivkrafter är:\n- **Artefaktsamlare** – Trollens berömda hantverkskonst har spritt deras skapelser vida omkring, ibland som gåvor, ibland som krigsbyten. Rollpersonen är utsänd för att återbörda sådana trollskapade ting från gravar, symbariska ruiner eller ur ovärdiga tjuvars (ännu en tid) levande händer.\n- **Bildningsresa** – Unga troll ger sig ut på färd innan de tar en fast roll i samhället. Målet är att förstå omvärlden och de krafter som formar den. Tidigare gick resorna oftast till närmaste järnpaktsnäste; numera lockar mötet med människor, särskilt de nyanlända ambrierna, minst lika mycket.",
-  "sardrag": "Rollpersoner av trollätt kan köpa Naturligt vapen, Pansar, Regeneration, Robust som vanliga förmågor. De flesta Troll har nackdelen Paria.",
-  "namn_man": [
-    "Aka",
-    "Aroha",
-    "Erula",
-    "Hibne",
-    "Ogmaka",
-    "Raham",
-    "Riomata",
-    "Skadal",
-    "Verhar",
-    "Aravarx",
-    "Etaxa",
-    "Noxar",
-    "Ognyx",
-    "Rirbax",
-    "Vouax",
-    "Uhux"
-  ],
-  "namn_kvinna": [
-    "Aka",
-    "Aroha",
-    "Erula",
-    "Hibne",
-    "Ogmaka",
-    "Raham",
-    "Riomata",
-    "Skadal",
-    "Verhar",
-    "Aravarx",
-    "Etaxa",
-    "Noxar",
-    "Ognyx",
-    "Rirbax",
-    "Vouax",
-    "Uhux"
-  ],
-  "taggar": {
-    "typ": [
-      "Ras"
-    ]
-  }
-},
-
-{
-  "namn": "Vandöd",
-  "beskrivning": "Något står inte rätt till i världen. Världens skuggor djupnar i takt med den tilltagande korruptionen och naturgivna lagar sviker i denna världens skymningstid. Den vandöda smittan är ett bistert exempel på världens förfall.\nVandöda – i meningen genomkorrumperade väsen med törst på liv – är inget nytt: mörkermästarna som bekämpades i Det stora kriget väckte arméer av dessa gravkalla gengångare och även Davokars kryptor hyser sin beskärda del av hämndlystna odöda.\nEn vandödhet av nytt slag verkar dock sprida sig i Ambria. Människor som dör – eller skulle ha dött – reser sig upp igen. Svartkapporna som i största hemlighet undersöker de oroande ryktena pekar på att staden Yndaros utgör hjärtat i denna vedervärdiga utveckling. Rapporter som skickats till svartkappornas ordensborg innefattar en nedhuggen ligist i Yndaros som klöste sig upp ur sin grav och försvann ut i natten, en av ålder död man som vaknat som ur en dvala och sedan jagats bort från sitt arbete som kanslist då han av rutin återvänt dit, en kvinna av nobel börd som dött i barnsäng och som efter en tid av död rymt från familjens mausoleum och kidnappat sitt levande barn. Samtliga dessa tre exempel har senare också spårats upp, en av dem nedkämpades av templárer, en infångades av svartkapporna för vidare studier och en tredje undgick genom ett svart mirakel att brännas av ett folkuppbåd – alla tre talande öden för vad dessa vandöda riskerar att råka ut för om de upptäcks.\nGemensamt för dessa nya vandöda är att de alla uppvisar tydliga fysiska tecken på att faktiskt vara döda – de är kalla, de blöder inte, äter inte och sover inte – men deras medvetande är intakt, och de förfaller mycket sakta mot en slutlig död århundraden efter sin egentliga dödsdag.\n",
- "extra": "**Vandödas särdrag, fördelar och nackdelar:** Vandöda rollpersoner är odöda och därmed genomkorrumperade redan från start. De behåller sin fria vilja; de är inte ylande styggelser som enbart söker förödelse.\n\n**Fysiologi och behov:**\n- Sover inte.\n- Kan inte äta vanlig mat och andas bara av vana för att kunna tala.\n- Dricker små mängder vätska för att smälta in bland levande.\n- Läker inte skador spontant – återfår *Tålighet* genom att äta färskt, rått kött eller dricka blod (se det monstruösa särdraget *Vandöd* (Novis)).\n\n**Social påverkan:**\n- För att undgå upptäckt krävs ett lyckat [Diskret←Vaksam] vid social interaktion med levande.\n- Elixiret *Skuggtistelextrakt* ersätter slaget helt.\n- Varelser med *Häxsyn* kan alltid avslöja en vandöd med [Vaksam←Diskret]; elixirer hjälper inte, men ritualen *Byta skugga* förvirrar *Häxsyn*.\n- Upptäckta vandöda jagas skoningslöst av häxjägare och svartkappor.\n\n**Särdrag att köpa:**\n- Startar med *Vandöd (I)* och kan utveckla det vidare som en förmåga.\n- Kan införskaffa de monstruösa särdragen *Gravkyla* och *Skräckslå* som om de vore vanliga förmågor.\n\n**Läsningstips:** Odöda beskrivs ingående i grundboken på sid 196. Spelare med vandöda rollpersoner bör läsa det avsnittet, och spelledare bör noga överväga hur dessa regler påverkar spelet.",
-  "sardrag": "Måste köpa Vandödhet (Novis) från start; kan utvecklas. Kan köpa Gravkyla och Skräckslå som vanliga förmågor. Odöd och genomkorrumperad.",
-  "namn_man": [],
-  "namn_kvinna": [],
-  "taggar": {
-    "typ": [
-      "Ras"
-    ]
-  }
-},
-
-{
-  "namn": "Alvtagen människa",
-  "beskrivning": "Davokars alver har såvitt känt alltid praktiserat bortbytande – de stjäl människobarn och lämnar bortbytingar i deras ställe. Barnen som tas kallas alvtagna. Syftet har skiftat genom tiderna: först handlade det om att förstå människor, senare om att uppfostra ambassadörer som kunde leva med barbarerna och förmedla alvernas visdom. Under de senaste seklen har Järnpaktens växande behov av krigare gjort de alvtagna allt vanligare i skogslagens krigsföljen. De jagar och slåss sida vid sida med sommaralver, ersätter stupade bågskyttar och fyller luckorna efter de alver som inte längre vaknar ur sin första dvala. Alverna visste redan att alvtagna är läraktiga och trofasta, men till deras förvåning har några även visat sig kapabla att utveckla genuin visdom – ett faktum många alver har svårt att erkänna. För de flesta är alvtagna snarast trogna husdjur, omöjliga att betrakta som jämlikar.\n\nTrots alvisk fostran förblir de i grunden människor. De talar alviska flytande men kan inte tyda skriften utan förmågan Lärd. Att leva bland de långlivade väktarna präglar dem starkt: de lär sig slå som jägare, överleva i vildmarken och lyda utan knot. Ambrier och barbarer möter dem sällan – och när de gör det anar de sällan bandet till Järnpakten förrän det är för sent.",
-  "extra": "**Alvtagna särdrag, fördelar och nackdelar:** Alvtagna har allt som oftast Vildmarksvana och kan lära sig Jaktinstinkt (kostar som en förmåga). De talar flytande alviska men behöver Lärd för att läsa språket. Mänsklig härkomst ger dem både anpassningsförmåga och mottaglighet för världsliga lockelser.\n\n**Alvtagna namn:** Fosterföräldrarna ger namn som klingar människoaktigt, högst två stavelser, lätta att ropa och rika på vokaler.\n\n**Alvtagna äventyrare:** Alvtagna lämnar skogsgemenskapen av samma skäl som alver – alliansbygge, spaning, exil eller hämnd – men kan dessutom drivas av mer personliga motiv. Nedan följer vanliga drivkrafter:\n\n- **Alliansbyggare**\n  Fosterföräldrarna sänder dem för att knyta vänskap med människor, klaner eller furstar och undervisa i skogens värde samt farorna med alltför ivrig utforskning.\n\n- **Spanare**\n  De kartlägger fiendens styrka, pekar ut svagheter och rapporterar via hemliga mötesplatser inför Järnpaktens kommande sammandrabbningar.\n\n- **Exil**\n  Brusten lojalitet, förbjuden kärlek eller vanära kan leda till självvald eller påtvingad landsflykt – en vandring som söker försoning eller ny identitet.\n\n- **Hämndsökare**\n  Förlusten av en jaktkamrat, eller svek inom de egna leden, driver dem att spåra och skipa rättvisa innan hemkomsten känns möjlig.\n\n- **Rymling**\n  Nyfikenhet, hemlängtan eller upplevd vanskötsel får vissa att fly Järnpaktens stränga ordning och söka egen väg bland människorna.\n\n- **Sökare efter arv**\n  Några vill finna sin mänskliga familj, sina rötter eller en plats där deras dubbla natur accepteras.\n\n- **Äventyrslust**\n  Ren upptäckarglädje lockar dem till städer, ruiner och magiska underverk långt bortom Davokars mörka grenar.",
-  "sardrag": "Inga, men många har fördelen Vildmarksvana; många har dessutom förmågan Jaktinstinkt (kostar som en förmåga).",
-  "namn_man": [
-    "Awan",
-    "Beo",
-    "Eral",
-    "Gaer",
-    "Kael",
-    "Lo",
-    "Mael",
-    "Orel",
-    "Tham",
-    "Tir"
-  ],
-  "namn_kvinna": [
-    "Anga",
-    "Beha",
-    "Erli",
-    "Fera",
-    "Inda",
-    "Lonam",
-    "Una",
-    "Undi",
-    "Vird"
-  ],
-  "taggar": {
-    "typ": [
-      "Ras"
-    ]
-  }
-},
-
+    "id": "ra1",
+    "namn": "Alv",
+    "beskrivning": "Davokars alver är inte ett folk i egentlig mening utan faktiskt en helig väktarorden. Orden bestod ursprungligen av alver komna från västerns mer jungfruliga trakter, dit människan ännu inte har nått och där alvernas högkultur frodas. Denna orden – av människor känd som Järnpakten – har som uppdrag att förhindra att den ondska som ruvar under Davokars rötter och mossa vaknar igen och sprids i världen.\nHuvuddelen av alverna i Davokar är födda in i pakten och har aldrig varit västerut och kommer aldrig att komma dit; för dem är och förblir västerns alvmarker blott en dröm som aldrig kommer att gå i uppfyllelse. De får redan i späda år höra att deras plikt är här och att de inte är välkomna västerut. De är besmutsade av Davokars mörker och som smittbärare kommer de inte att släppas in i alvernas andra riken. Järnpakten har till och med utvecklat en ceremoni, en initiationsrit för unga alver, där de äldste – ledda av alvfursten Eneánor – gråtande ber nyvakna sommaralver om ursäkt för att de tvingats födas, leva och dö i dödsskuggans skog, Davokar.\nAlvernas läge i Davokar är utsatt, deras antal tynande och deras en gång så starka ledare Furst Eneánor är på väg mot sin själs vinter. Furstens tilltagande oberäknelighet lämnar utrymme för andra oeniga ledare att positionera sig för den stundande maktkampen. Tvistefrågan gäller hur striden mot mörkret ska föras; om det främst är med pilar och spjut eller genom byggandet av allianser.\nDe vårystra älvor som vaknar upp efter sin första dvala träder in i sommaralvens livsfas och det är dessa som utgör stommen i Davokars spetsörade väktarkår: vaksamma jägare rustade med spjut och pilbågar. Många av dem kommer att stupa i strider mot styggelser eller mot tabubrytare bland de alltmer oförsiktiga människorna från söder. De som inte faller i strid når sin andra dvala och även den möts med sammanbitna miner; endast ett fåtal alver vaknar upp ur sin andra dvala, medan merparten tynar bort innan de når nästkommande livsfas.\nJärnpaktens fästen och skogsslott i Davokar ekar av sorgsna stämmors sång, vemodigt klagande över de fallna och borttynade. Alverna blir färre; inte ens utökat bortbytande kan fylla luckorna i deras led med alvtagna människor. Ett glädjeämne är att fler och fler människor frivilligt börjar sluta sig till Järnpakten och optimisterna bland alverna framhåller att det till och med finns ambrier bland dessa.\n",
+    "extra": "**Alviska särdrag, fördelar och nackdelar:** Alviska rollpersoner har särdraget Långlivad. De flesta har dessutom nackdelen Paria, då alver är illa sedda av de flesta människor; ambrier ser dem med avsky och även barbarer är rädda för dem. Många alver har också särdraget Eonernas visdom, vilket införskaffas som andra förmågor.\nAlver som så önskar kan uppträda som bortbytingar, vanligen genom att byta kläder till människoskapade sådana samt imitera mänskliga manér. En person med Lärd till minst gesällnivå kan genomskåda en sådan förklädnad med ett lyckat Listig; en alv som igenkänns som sådan bland människor drabbas av nackdelen Paria.\n\n**Alviska namn:** Vår- och sommaralver ges alla dubbelnamn som följer med individen genom den första dvalan; namn som anspelar på deras karaktär och/eller på förhoppningar om vad denne ska bli under sin krafts dagar. Merparten av de som överlever sin andra dvala väljer att kapa bort en del av sitt namn eller att helt byta, men inte alla. Valet är upp till individen och handlar oftast mer om smak och stil än om någon egentlig funktion. Alvnamn innehåller ofta fler vokaler än konsonanter och bokstaven ”x” är ovanlig, liksom att ett namn har två konsonanter i rad.\n\n**Alviska äventyrare:** Rollpersoner av alvisk härkomst utgörs lämpligen av sommaralver, den andra fasen i den alviska livscykeln. Äldre alver är möjliga att spela, men höstalver passar bättre i kampanjer där övriga rollpersoner är mycket mäktiga, då dessa väsen överskuggar de flesta människor i fråga om personlig makt och insikt i världens djupare mysterier. Alver som rör sig bland människor är mycket ovanliga och har troligen ett starkt motiv för sitt äventyrande.\n\n**Alliansbyggare:** Alven har skickats ut för att bygga relationer till en grupp människor och försöker lära dem om skogens värde och faran med att utforska för ivrigt. Uppdraget kan vara självpåtaget men är mer troligt en order given av en överordnad höstalv.\n\n**Spanare:** Alven är utsänd som kunskapare, för att värdera fiendens styrkor och svagheter inför den strid som med säkerhet kommer. Uppdragsgivare är troligtvis en äldre alv, antingen krigiskt eller diplomatiskt orienterad.\n\n**Exil:** Alver som allvarligt bryter mot gruppens regler är extremt ovanliga men mindre så i det korrumperande Davokar. Kanske är rollpersonen en av dessa. Alternativt är exilen självpåtagen, som en följd av upplevd brist i lojalitet eller heder.\n\n**Hämndsökare:** Alverna lever, jagar och slåss i små enheter med starka band till varandra. Kanske stupade de andra som följd av ett förräderi, medan rollpersonen överlevde av en slump eller genom någon mindre heroisk handling. Alven återvänder inte hem innan förräderiet är hämnat.\n",
+    "sardrag": "Långlivad; Paria; många tar Eonernas visdom (kostar som en förmåga).",
+    "namn_man": [
+      "Alal-Roak",
+      "Dorael-Ri",
+      "Eloan-Eo",
+      "Elori",
+      "Godrai",
+      "Mearoel",
+      "Saran-Ri",
+      "Tel-Keriel",
+      "Kil-Ano"
+    ],
+    "namn_kvinna": [
+      "Ahara-Vei",
+      "Eleanea",
+      "Leiána",
+      "Gaina-Anali",
+      "Keri-Las",
+      "Mael-Melian",
+      "Naelial",
+      "Tara-Kel",
+      "Teara-Téana"
+    ],
+    "taggar": {
+      "typ": [
+        "Ras"
+      ]
+    }
+  },
   {
+    "id": "ra2",
+    "namn": "Dvärg",
+    "beskrivning": "Det korta, krumma och seniga folk som människorna kallar dvärgar har en historia dold i dunkel. Om man får utgå från Yndaros dvärgar verkar de inte ens själva vara intresserade av sin historia; de är ett folk på väg, med en längtan framåt, på flykt från ett mörkt förflutet som givit dem sammanhållning men varken ro eller mening. Dvärgarnas arv är familjens helighet, språkets hemligheter och den fasta övertygelsen att världen i övrigt är deras fiende. Gamalga av Kadizar, en lärd med intresse för dvärgarna, lär ha beskrivit det som att ”familjen är deras sköld, språket deras vapen och världen deras slagfält”. Gamalga har också vågat sig på att skissera dvärgarnas ursprung. Efter många fruktlösa samtal med Yndaros dvärgar och långa resor till möjligen lika frustrerade möten i fästet Küam Zamok insåg Gamalga att hon fick bättre svar av alver och troll, och att dessa intygade att de inte mött dvärgar innan Symbaroums fall: sannolikt skapades släktet där. Gamalga sammanfattar sina magra fynd om dvärgarnas ursprung så här:\n”De föddes som maskar i världsormens ruttnade kött och gavs förstånd av Symbars svartkonstnärer, så att de skulle slava bättre. Men dvärgarnas uralstring knöt dem för evigt till världen och dess öde, och i kraft av denna koppling utvecklade de redan under slaveriets ok en kraftfull motkultur som fortfarande präglar dem. Dvärgarnas urmödrar och anfäder byggde ett språk med dolda koder och hemliga dubbelbetydelser, så snåriga att inte ens mästarna förstod vad slavarna sade. Dvärgarna skrev inget, då sådant som kunde läsas också kunde tolkas och dechiffreras av Symbars furstar. Dvärgarnas drömmar förblev deras egna och deras hemliga språk ekade av världens öde. Både troll och alver intygar att det i vissa dvärgars tungomål finns ödeskraft, och antyder också att deras skapare, Symbaroums herrar, lärde sig att hata sina skapelser och med tiden också fruktade dem och deras kraftord. Efter Symbaroums fall är dvärgafolkets krönika en mödosam vandring i dödsskuggans dal, ständigt utsatta och jagade av andra folk och väsen. Numera återfinns ättlingarna till de få överlevande flyktingarna från Symbaroums ruiner på flera platser och deras öden är till synes mycket varierande. Klart är att dvärgarna i Yndaros utgör en tidigare styrande elit från Küam Zamok, utkastade därifrån under en blodig revolution. Det är alltså dvärgiska aristokrater, vana att domdera men inkapabla att själva skapa det allra nödvändigaste, som vi i Yndaros möter som välorganiserade ligister. Mer osäkra uppgifter gör gällande att deras oförmåga att hålla sams har att göra med successionsordningen i det rike de har tvingats fly ifrån, och därmed rätten till en tron de aldrig kommer att få bestiga.”\nYndaros dvärgar är de som ambrierna främst möter och dessa låter ingen utomstående komma dem nära. De kräver inget av världen kring dem, annat än att få leva i fred med sina familjer. Just familjen är dvärgarnas själ och individerna är underordnade familjens vilja – en vilja uttolkad av familjens äldste. Denna extrema sammanhållning ger dem till synes också två sorters moral: den ena strikt kodad och riktad mot familjen, den andra riktad utåt och av dvärgarnas grannar ofta beskriven som en avsaknad av moral, då handlingar mot utomstående inte räknas i relationerna inom familjen. En dvärg är det den gör mot sina meddvärgar, och i någon mån hur dess handlingar utåt påverkar familjen.\nDe yndariska dvärgarnas tungomål är ännu i dag så snårigt av svårdechiffrerade koder, listiga dubbelbetydelser och dunkla idiomatiska uttryck att även dagligt tal i stort sett är obegripligt även för de mest kunniga utomstående. Dvärgarnas tungomål rymmer också en märklig ödestyngd, vilket vissa dvärgar vet att nyttja. Dvärgarnas minnestekniska färdigheter är dessutom långt utvecklade – de driver exempelvis komplexa ”affärsrörelser” i Yndaros helt utan nedtecknade siffror – men också den minneskonstens detaljer är dolda bakom dvärgaspråkets höga murar.\n",
+    "extra": "**Dvärgiska särdrag, fördelar och nackdelar:**\n De flesta rollpersoner av dvärgisk börd har särdraget *Jordnära*, fördelen *Minnesmästare* samt nackdelen *Paria*. Många dvärgar har också den mystiska kraften *Vedergällning*, vilken införskaffas som en förmåga. Just för dvärgar ger denna kraft ingen korruption, varken då den lärs in eller då den används – det gäller enbart för denna kraft och enbart för dvärgar.\n\n**Dvärgars namn:**\nAtt döma av de dvärgar som lever i Yndaros har släktet en förkärlek för hårda namn med många inslag av konsonanter som k, t och r. I övrigt tycks det inte finnas någon skillnad mellan kvinnliga och manliga namn; namnen ärvs inom familjen genom generationer utan hänsyn till kön. Alla dvärgar har även efternamn knutna till sin familj eller ätt, likt Ambrias ädlingar. Yngre dvärgar måste dock förtjäna rätten att använda släktnamnet, företrädesvis genom att göra sina släktingar stolta eller imponerade på något sätt.\n\n**Dvärgiska äventyrare:**\nDvärgar som väljer eller tvingas att lämna sina ätter i Yndaros är ensamma och inte sällan farliga individer. För vissa blir ensamheten starten på sökandet efter en ny familj, definierad på andra sätt än genom blodet och språket. Följande skäl kan driva en dvärgättad rollperson ut i världen:\n\n- **Domedagsdrömmare** – Dvärgen hemsöks av drömmar om domedag och död för sin familj eller för världen i stort. För att utröna drömmarnas sanningshalt, och i bästa fall finna sätt att skydda familjen, lämnar dvärgen gemenskapen och blir en sökare i världen.\n- **Livsskuld** – En utomstående har räddat dvärgens liv utan att kräva något i gengäld. Dvärgen vill återgälda denna handling genom att tjäna livräddaren, vare sig denne vill det eller ej. Detta motiv är allmänt accepterat som anledning att tillfälligt lämna familjen.\n- **Utstött** – Dvärgen har begått illojala handlingar mot sin familj, kanske utmanat familjeöverhuvudet eller ifrågasatt ättens främsta plats i successionsordningen. Straffet blir förvisning, antingen tidsbegränsad eller livslång. För de flesta dvärgar är exil ett straff värre än döden.\n- **Spion** – Dvärgen är i själva verket inte utstött utan spelar rollen för att skaffa hemligheter som familjen behöver. Det kan också handla om ett uppdrag att utföra en olaglig handling, exempelvis att söka efter en rymling som påstår sig ha större rätt till dvärgakronan än rollpersonens familjeöverhuvud.",
+    "sardrag": "Alla rollpersoner av dvärgisk börd har särdraget Jordnära, fördelen Minnesmästare samt nackdelen Paria. Många dvärgar har också den mystiska kraften Vedergällning.",
+    "namn_man": [
+      "Artek",
+      "Bolkor",
+      "Brana",
+      "Dobril",
+      "Dranek",
+      "Dusa",
+      "Jarok",
+      "Lazek",
+      "Margor",
+      "Mirek",
+      "Radmil",
+      "Stana",
+      "Vesnek",
+      "Vlador",
+      "Yaruk"
+    ],
+    "namn_kvinna": [
+      "Artek",
+      "Bolkor",
+      "Brana",
+      "Dobril",
+      "Dranek",
+      "Dusa",
+      "Jarok",
+      "Lazek",
+      "Margor",
+      "Mirek",
+      "Radmil",
+      "Stana",
+      "Vesnek",
+      "Vlador",
+      "Yaruk"
+    ],
+    "taggar": {
+      "typ": [
+        "Ras"
+      ]
+    }
+  },
+  {
+    "id": "ra3",
+    "namn": "Troll",
+    "beskrivning": "För alla ambrier och de flesta barbarer är troll synonymt med blodig död. Vissa häxor och enstaka ambriska lärde vet bättre och hävdar att det finns ett stort mått av sanning i barbarernas sagor om trollriken under mark, där trollen håller hov och mäktiga sånger framförs i salar prydda med sköna ting frambringade av trollens grova händer. Även de som medger att trollen har en civilisation erkänner dock att troll ovan jord är farliga: troll ger sig inte upp till markytan utan bra skäl därtill, och dessa skäl är ofta blodiga.\nTroll förökar sig inte, den saken sköts av svartalferna. När en svartalf känner dödens andedräkt flåsa dem i nacken söker de sig ner i Davokars underjord. Där faller de ihop och en kokongliknande vävnad växer ut ur deras kroppar för att så småningom omsluta dem helt. Många dör under dvalan men det fåtal som överlever utvecklas till de bestlika varelser som ambrierna kallar rovtroll. Några av dessa har redan som kokonger hittats av andra troll och förts till något rike där de genast tas omhand; merparten kravlar sig dock upp till markytan, nakna och glupande hungriga, redo att äta sig mätta på vadhelst som kommer i deras väg. Även vissa av de senare fångas upp av trollens härskare – härskare som antingen sveper dem i klädnader och uppfostrar dem till civiliserade troll, eller som piskar dem till lydnad och till att bli frontsoldater i deras rövarband på markytan.\nTrollens civilisation är inte heller densamma som mänsklighetens motsvarighet. Ett trolls värde bestäms av vad individen kan tillföra sitt samhälle, vare sig det är krigarens beskydd, hantverkarens vackra ting eller skaldens sånger. De mest drivna och fysiskt potenta trollen mäktar med att karva sig en nisch bland de ledande och tar plats i härskarnas kast – en plats de behåller endast så länge som de med klor och ränker förmår behålla den. Trollen utmanar rutinmässigt varandra till kamp som en del i det sociala spelet. Kampen är ofta fysisk men kan lika gärna handla om vem som kan sjunga längst eller vem som kan skapa den mäktigaste artefakten. De fysiska kamperna är dock mest frekventa och trots att dessa strider är rituella är de inte helt utan dödlig utgång, även om det inte är målet.\nFostran genom fysiska och andliga utmaningar är djupt förankrad i trollens kultur och det ses som grundläggande att odla styrka på både ett personligt och ett kulturellt plan. Tvekamp anses vara det enda sättet att nå denna härdning av kropp och släkte. Ett talesätt bland trollen som fångar detta lyder: ”Om jag knäcker dig blir vårt folk svagare; om jag låter dig komma undan blir du svagare.”\nKapitelmästare Argoi vid Kurun-kapitlet har sammanfattat det på följande sätt: ”Trollens fysisk-moraliska livsstil får ett särskilt blodigt uttryck i mötet med andra folkslag, då det i sådana möten inte längre finns kulturbevarande skäl för trollen att visa nåd. Denna råa slaktarkultur blir tvärt om värre om fienden kapitulerar eller visar någon form av svaghet inför anfallaren, då detta för trollen väcker en särskild sorts avsky. En fiende som visar stridsvilja och mod förtjänar trots allt att respekteras och kan därmed skonas utifrån trollens logik.”\n",
+    "extra": "**Trollens särdrag, fördelar och nackdelar:** Trollättade rollpersoner kan köpa de monstruösa särdragen **Naturligt vapen**, **Pansar**, **Regeneration** och **Robust** som om de vore vanliga förmågor. Troll bär dessutom oftast nackdelen Paria eftersom människor fruktar dem.\n\n**Förklädnad som resa:** Ett troll kan försöka uppträda som resa genom att kapa hornen, byta till människotillverkade kläder och efterlikna resars sävliga rörelsemönster. En person med **Lärd** på minst gesällnivå kan avslöja förklädnaden med ett lyckat **Listig**-slag. Resar har också oftast nackdelen **Paria**, men människor betraktar dem oftast som ofarliga. Om ett troll avslöjas väcker det däremot ofta panik; stadsbor larmar väktare och kallar på trolldräpare.\n\n**Trollens namn:** Släktet gör ingen könsskillnad vid namnval. Varje troll får det namn det förtjänar och kan byta det flera gånger under livet beroende på erfarenheter. Namn skiljer sig mellan yngre och äldre: bokstaven ”x” återfinns ofta i de mäktiga och äldre trollens namn.\n\n**Troll som äventyrare:** Troll är starkt bundna till sina samhällen och behöver mer än vanlig nyfikenhet för att färdas ensamma. Vanliga drivkrafter är:\n- **Artefaktsamlare** – Trollens berömda hantverkskonst har spritt deras skapelser vida omkring, ibland som gåvor, ibland som krigsbyten. Rollpersonen är utsänd för att återbörda sådana trollskapade ting från gravar, symbariska ruiner eller ur ovärdiga tjuvars (ännu en tid) levande händer.\n- **Bildningsresa** – Unga troll ger sig ut på färd innan de tar en fast roll i samhället. Målet är att förstå omvärlden och de krafter som formar den. Tidigare gick resorna oftast till närmaste järnpaktsnäste; numera lockar mötet med människor, särskilt de nyanlända ambrierna, minst lika mycket.",
+    "sardrag": "Rollpersoner av trollätt kan köpa Naturligt vapen, Pansar, Regeneration, Robust som vanliga förmågor. De flesta Troll har nackdelen Paria.",
+    "namn_man": [
+      "Aka",
+      "Aroha",
+      "Erula",
+      "Hibne",
+      "Ogmaka",
+      "Raham",
+      "Riomata",
+      "Skadal",
+      "Verhar",
+      "Aravarx",
+      "Etaxa",
+      "Noxar",
+      "Ognyx",
+      "Rirbax",
+      "Vouax",
+      "Uhux"
+    ],
+    "namn_kvinna": [
+      "Aka",
+      "Aroha",
+      "Erula",
+      "Hibne",
+      "Ogmaka",
+      "Raham",
+      "Riomata",
+      "Skadal",
+      "Verhar",
+      "Aravarx",
+      "Etaxa",
+      "Noxar",
+      "Ognyx",
+      "Rirbax",
+      "Vouax",
+      "Uhux"
+    ],
+    "taggar": {
+      "typ": [
+        "Ras"
+      ]
+    }
+  },
+  {
+    "id": "ra4",
+    "namn": "Vandöd",
+    "beskrivning": "Något står inte rätt till i världen. Världens skuggor djupnar i takt med den tilltagande korruptionen och naturgivna lagar sviker i denna världens skymningstid. Den vandöda smittan är ett bistert exempel på världens förfall.\nVandöda – i meningen genomkorrumperade väsen med törst på liv – är inget nytt: mörkermästarna som bekämpades i Det stora kriget väckte arméer av dessa gravkalla gengångare och även Davokars kryptor hyser sin beskärda del av hämndlystna odöda.\nEn vandödhet av nytt slag verkar dock sprida sig i Ambria. Människor som dör – eller skulle ha dött – reser sig upp igen. Svartkapporna som i största hemlighet undersöker de oroande ryktena pekar på att staden Yndaros utgör hjärtat i denna vedervärdiga utveckling. Rapporter som skickats till svartkappornas ordensborg innefattar en nedhuggen ligist i Yndaros som klöste sig upp ur sin grav och försvann ut i natten, en av ålder död man som vaknat som ur en dvala och sedan jagats bort från sitt arbete som kanslist då han av rutin återvänt dit, en kvinna av nobel börd som dött i barnsäng och som efter en tid av död rymt från familjens mausoleum och kidnappat sitt levande barn. Samtliga dessa tre exempel har senare också spårats upp, en av dem nedkämpades av templárer, en infångades av svartkapporna för vidare studier och en tredje undgick genom ett svart mirakel att brännas av ett folkuppbåd – alla tre talande öden för vad dessa vandöda riskerar att råka ut för om de upptäcks.\nGemensamt för dessa nya vandöda är att de alla uppvisar tydliga fysiska tecken på att faktiskt vara döda – de är kalla, de blöder inte, äter inte och sover inte – men deras medvetande är intakt, och de förfaller mycket sakta mot en slutlig död århundraden efter sin egentliga dödsdag.\n",
+    "extra": "**Vandödas särdrag, fördelar och nackdelar:** Vandöda rollpersoner är odöda och därmed genomkorrumperade redan från start. De behåller sin fria vilja; de är inte ylande styggelser som enbart söker förödelse.\n\n**Fysiologi och behov:**\n- Sover inte.\n- Kan inte äta vanlig mat och andas bara av vana för att kunna tala.\n- Dricker små mängder vätska för att smälta in bland levande.\n- Läker inte skador spontant – återfår *Tålighet* genom att äta färskt, rått kött eller dricka blod (se det monstruösa särdraget *Vandöd* (Novis)).\n\n**Social påverkan:**\n- För att undgå upptäckt krävs ett lyckat [Diskret←Vaksam] vid social interaktion med levande.\n- Elixiret *Skuggtistelextrakt* ersätter slaget helt.\n- Varelser med *Häxsyn* kan alltid avslöja en vandöd med [Vaksam←Diskret]; elixirer hjälper inte, men ritualen *Byta skugga* förvirrar *Häxsyn*.\n- Upptäckta vandöda jagas skoningslöst av häxjägare och svartkappor.\n\n**Särdrag att köpa:**\n- Startar med *Vandöd (I)* och kan utveckla det vidare som en förmåga.\n- Kan införskaffa de monstruösa särdragen *Gravkyla* och *Skräckslå* som om de vore vanliga förmågor.\n\n**Läsningstips:** Odöda beskrivs ingående i grundboken på sid 196. Spelare med vandöda rollpersoner bör läsa det avsnittet, och spelledare bör noga överväga hur dessa regler påverkar spelet.",
+    "sardrag": "Måste köpa Vandödhet (Novis) från start; kan utvecklas. Kan köpa Gravkyla och Skräckslå som vanliga förmågor. Odöd och genomkorrumperad.",
+    "namn_man": [],
+    "namn_kvinna": [],
+    "taggar": {
+      "typ": [
+        "Ras"
+      ]
+    }
+  },
+  {
+    "id": "ra5",
+    "namn": "Alvtagen människa",
+    "beskrivning": "Davokars alver har såvitt känt alltid praktiserat bortbytande – de stjäl människobarn och lämnar bortbytingar i deras ställe. Barnen som tas kallas alvtagna. Syftet har skiftat genom tiderna: först handlade det om att förstå människor, senare om att uppfostra ambassadörer som kunde leva med barbarerna och förmedla alvernas visdom. Under de senaste seklen har Järnpaktens växande behov av krigare gjort de alvtagna allt vanligare i skogslagens krigsföljen. De jagar och slåss sida vid sida med sommaralver, ersätter stupade bågskyttar och fyller luckorna efter de alver som inte längre vaknar ur sin första dvala. Alverna visste redan att alvtagna är läraktiga och trofasta, men till deras förvåning har några även visat sig kapabla att utveckla genuin visdom – ett faktum många alver har svårt att erkänna. För de flesta är alvtagna snarast trogna husdjur, omöjliga att betrakta som jämlikar.\n\nTrots alvisk fostran förblir de i grunden människor. De talar alviska flytande men kan inte tyda skriften utan förmågan Lärd. Att leva bland de långlivade väktarna präglar dem starkt: de lär sig slå som jägare, överleva i vildmarken och lyda utan knot. Ambrier och barbarer möter dem sällan – och när de gör det anar de sällan bandet till Järnpakten förrän det är för sent.",
+    "extra": "**Alvtagna särdrag, fördelar och nackdelar:** Alvtagna har allt som oftast Vildmarksvana och kan lära sig Jaktinstinkt (kostar som en förmåga). De talar flytande alviska men behöver Lärd för att läsa språket. Mänsklig härkomst ger dem både anpassningsförmåga och mottaglighet för världsliga lockelser.\n\n**Alvtagna namn:** Fosterföräldrarna ger namn som klingar människoaktigt, högst två stavelser, lätta att ropa och rika på vokaler.\n\n**Alvtagna äventyrare:** Alvtagna lämnar skogsgemenskapen av samma skäl som alver – alliansbygge, spaning, exil eller hämnd – men kan dessutom drivas av mer personliga motiv. Nedan följer vanliga drivkrafter:\n\n- **Alliansbyggare**\n  Fosterföräldrarna sänder dem för att knyta vänskap med människor, klaner eller furstar och undervisa i skogens värde samt farorna med alltför ivrig utforskning.\n\n- **Spanare**\n  De kartlägger fiendens styrka, pekar ut svagheter och rapporterar via hemliga mötesplatser inför Järnpaktens kommande sammandrabbningar.\n\n- **Exil**\n  Brusten lojalitet, förbjuden kärlek eller vanära kan leda till självvald eller påtvingad landsflykt – en vandring som söker försoning eller ny identitet.\n\n- **Hämndsökare**\n  Förlusten av en jaktkamrat, eller svek inom de egna leden, driver dem att spåra och skipa rättvisa innan hemkomsten känns möjlig.\n\n- **Rymling**\n  Nyfikenhet, hemlängtan eller upplevd vanskötsel får vissa att fly Järnpaktens stränga ordning och söka egen väg bland människorna.\n\n- **Sökare efter arv**\n  Några vill finna sin mänskliga familj, sina rötter eller en plats där deras dubbla natur accepteras.\n\n- **Äventyrslust**\n  Ren upptäckarglädje lockar dem till städer, ruiner och magiska underverk långt bortom Davokars mörka grenar.",
+    "sardrag": "Inga, men många har fördelen Vildmarksvana; många har dessutom förmågan Jaktinstinkt (kostar som en förmåga).",
+    "namn_man": [
+      "Awan",
+      "Beo",
+      "Eral",
+      "Gaer",
+      "Kael",
+      "Lo",
+      "Mael",
+      "Orel",
+      "Tham",
+      "Tir"
+    ],
+    "namn_kvinna": [
+      "Anga",
+      "Beha",
+      "Erli",
+      "Fera",
+      "Inda",
+      "Lonam",
+      "Una",
+      "Undi",
+      "Vird"
+    ],
+    "taggar": {
+      "typ": [
+        "Ras"
+      ]
+    }
+  },
+  {
+    "id": "ra6",
     "namn": "Ambrie",
     "beskrivning": "Ambriernas härkomst knyts till samma urstam som barbarernas, men drottningfolket betraktar sig ofta som ett eget släkte. Efter flykten från det ödelagda Alberetor slog de sig ned i Lindaros välbevarade ruiner söder om Davokar. Där byggde de upp ett rike med avancerad byggnadskonst, skriftkultur, penningekonomi och ett tydligt hierarkiskt samhälle. Armén upprätthåller ordningen med hård disciplin och har överläge på slätterna, men i skogens djup jämnas styrkeförhållandena ut. Ambriernas ledning fruktar ett samlat barbaranfall från Karvosti, vilket förklarar rikets försiktiga hållning gentemot Davokar. Sedan slaget år 10 har endast solkyrkans templarer bedrivit regelrätta fälttåg norr om skogskanten; deras stormning av Karvosti år 16 slutade i ett dyrköpt nederlag. Ambrier använder sällan efternamn. Vid särskilda bedrifter kan en person få ett hedersnamn knutet till bragden, som borgmästaren Lasifor Nattbäcka eller skattletaren Lysindra Gyllengripe.",
     "särdrag": "Rollpersoner av drottningfolket har oftast fördelarna Kontaktnät och Privilegierad.",
@@ -211,6 +212,7 @@
     }
   },
   {
+    "id": "ra7",
     "namn": "Barbar",
     "beskrivning": "Barbarfolken lever i självstyrande klaner under hövdingar. Häxorna fungerar som andliga vägvisare genom tabun som bevarar balansen med naturen och varnar för skogens mörka delar. Klanerna strider ibland om gränsmarker men samlas under Storhövdingen på Karvosti vid större tvister. I Davokars snåriga terräng får barbarerna övertag genom lokal kännedom och individuell skicklighet, vilket hittills bromsat ambriernas expansion norrut. Drottningens rådgivare bävar inför möjligheten att Storhövdingen enar folket till krig. Barbarernas namn visar rytmisk växling mellan konsonant och vokal och slutar ofta på -mar, -mon, -var eller -mer för män, medan kvinnonamn vanligen avslutas med -a. J byts nästan alltid mot y, och hårda vokaler dominerar.",
     "särdrag": "Barbarättade rollpersoner har oftast fördelarna Kontaktnät och Vildmarksvana.",
@@ -245,6 +247,7 @@
     }
   },
   {
+    "id": "ra8",
     "namn": "Bortbyting",
     "beskrivning": "Alverna i Davokar byter ibland ut ett människobarn mot ett alviskt substitut. Praktiken har varit känd bland barbarerna så länge häxorna minns och har, efter ambriernas ankomst, även drabbat familjer i Ambria. Den verkliga nyttan spädbarnen fyller hos alverna är okänd, men Ordo Magicas fallkatalog visar att urvalet spänner över hela befolkningen, från slott till koja. Bortbytingar ser helt mänskliga ut som små, men antar före tonåren tydliga alviska drag utan att någonsin bli fullvärdiga alver. De når vuxen form samtidigt som människor, lever länge, men går inte vidare i alvernas livscykel. Detta har gett upphov till två teorier: vissa lärda menar att de är självständiga varelser skapade av alvisk magi, medan andra hävdar att de är äkta alvyngel vars utveckling hindras av uppväxten bland människor. När sanningen avslöjas blir få kvar hos sina familjer. Häxor eller ordensmagiker kan ta hand om dem som hjälpare, men oftare drivs de ut på gatan. Utstötta ur både människosamhället och alvernas krets vandrar de en lång, ensam väg, ofta bittra och svartsynta men ibland lättsinniga och obrydda om andras bekymmer. Vissa tar alviska namn för att återknyta till en förlorad identitet, andra väljer storslagna namn som en trotsig markering, som rännstensmagikern Grimorio Abramelin i Yndaros.",
     "särdrag": "Alla bortbytingar har Långlivad; de flesta har även Förväxling (kostar som en förmåga).",
@@ -279,6 +282,7 @@
     }
   },
   {
+    "id": "ra9",
     "namn": "Rese",
     "beskrivning": "Resar är solitärer som i sällsynta fall vandrar ut ur Davokars djup. De anländer fullvuxna men utan sinne för vardagsliv och måste läras allt utom det allra enklaste. Vittnesmål spänner från komiska anekdoter till skräckhistorier. Skogens häxor uppfostrar ibland resar till vakter och tjänare. Upptäcktsresande rapporterar om utposten vid Jordbäckaträsket där en rese kallad Armstark gräver diken, lyfter tungt och drar plog. I Yndaros slum har svartalfsligor fångat upp resar som indrivare. Södra Davokar talar om spejaren Vitrona och hennes vän, den väldige resen Varnagel, vars äventyr i Symbaroums ruiner skildras i populära visor från Tistla Fäste. Resar tycks sakna egna namn och får smeknamn som anspelar på kroppsstorlek eller det fåordiga lugn som många tolkar som dumhet; Ordo Magica antar att en solitär varelse inte behöver egennamn.",
     "särdrag": "Alla resar har Långlivad och de flesta även Paria; majoriteten har även Robust (kostar som en förmåga).",
@@ -313,6 +317,7 @@
     }
   },
   {
+    "id": "ra10",
     "namn": "Svartalf",
     "beskrivning": "Svartalfernas ursprung är höljt i dunkel, men deras närvaro söder om Davokar märks tydligt. Efter flykten från skogens djup har en stam bosatt sig nära Tistla Fäste och lever rövarliv, något som skapat dåligt rykte hos människorna. Deras hetsiga kynne och märkliga lekar – som ”myssla sko”, ”tämja rese”, ”tukta tistel” och ”Molok, vill du ha dask?” – avskräcker andra släkten. Livet är kort: en svartalf är ungdom vid fem, vuxen vid tio och betraktas som ålderstigen vid tjugo. De flesta återvänder självmant till Davokar innan trettio års ålder; en fyrtioåring är närapå osannolik. Trots rykte och kort liv tillåts de i Tistla Fäste eftersom de utför tungt och smutsigt arbete som att dika sumpmark och tömma latriner. Vid skymning skickas de ut till enkla nattläger av halm och lera. Ett fåtal bryter mönstret: skattletare, lönesoldater och klosterskolans spädalfer som undervisas av tålmodiga munkar. Garm Maskkrälaren är både skolad munk-elev och framgångsrik skattletare, beundrad trots blygsamt namn. Namnkonventionerna varierar mellan stammar; längden hänger ofta ihop med rang, men undantag som Garm visar att regeln inte är absolut.",
     "särdrag": "Alla svartalfer har Kortlivad och majoriteten även Paria; de flesta har Överlevnadsinstinkt (kostar som en förmåga).",
@@ -345,39 +350,40 @@
       ]
     }
   },
-{
-  "namn": "Andrik",
-  "beskrivning": "Av världens alla varelser är andriken sannolikt den mest säregna. Dessa ättlingar till vanliga ankor har med mörkermakt gjorts till en nidbild av andra kulturvarelser, ett faktum som undgått varken övriga släkten eller andrikarna själva. Vem som än skapade andrikarna gjorde det mot världens vilja, och uttryckte genom sin svartkonst ett sällsynt förakt för högre lagar, släktesgränser och allmänt god smak. En genomsnittlig andrik är väl medveten om hur andra ser på släktet och bemöter häcklandet – verkligt eller inbillat – med en hätsk blandning av stursk stolthet, halsstarrig gensträvighet och gråtmild offermentalitet.\nAndrikarna dök först upp i Fristaden väster om Alberetor. Om de anlände med båt eller om de faktiskt skapades i den nära nog laglösa staden är okänt. Klart är i alla fall att de kom för att stanna och tog plats i stadens trasproletariat. Från Fristaden spreds andrikar längs kusten i både östlig och västlig riktning på jakt efter ett värdigare liv. Och när Alberetor evakuerades följde andrikarna även med till Ambria.\nMajoriteten av Ambrias andrikar lever hela sina liv på resande fot, i form av ensamma familjer som bedriver gårdfarihandel eller flera familjer tillsammans som flodhandlare. De mest omtalade är dock de andrikbukanjärer som med snabba segelroddare gör Ambrias vatten osäkra. Hos dessa simfotade härjare frodas idéer om andrikarnas överlägsenhet, då de som senast utvecklade därmed – med piraternas logik – är de mest framstående. De har till och med tagit sig ett nytt namn på sitt släkte, Andrake. Andrakepiraterna är inte många men synnerligen aktiva, och fjäderklädda korsarer är ett prioriterat mål för de ambriska galärer som jagar pirater på rikets vattenvägar. Detta har drivit andrikska fribytare mot rikets utkanter. Inte sällan har de tagit sin tillflykt till svårfunna hamnar i ingenmanslandet i södra Davokar där tät växtlighet och älvarnas många biflöden ger utmärkta betingelser för piratverksamhet.",
-  "extra": "**Andrikars särdrag:**\nAndrikar har ofta särdraget Diminutiv. De flesta har även nackdelarna Labbar och Paria. De kan också införskaffa särdraget Provocerande, vilket kostar som andra förmågor.\n\n**Andrikars namn:**\nAndrikar har en slapp inställning till egennamn, och ger vanligen varandra öknamn baserat på utseende, exempelvis Bredlabb, Enöga, Gråfjäder, Nakenrygg, Ruggen, Svarten, Tuppkam. Hos åtminstone ett par större andrikfamiljer har namnbruket helt övergivits till förmån för ett enklare system med siffror, där lägre tal anger tidigare födsel än högre tal.\n\n**Andrikar som äventyrare:**\nEn andrik som lämnar familjen och sällar sig till äventyrare har sannolikt goda skäl därtill, vanligen tvingande sådana. Troligen är familjen död eller andriken utslängd från gemenskapen på grund av något grovt brott.\nAndrikar med en bakgrund bland handlare är oftast tjuvar, de med piratbakgrund är vanligen krigare. Det finns inga kända fall av andrikar som är mystiker eller ens att de skulle kunna lära sig ritualer. Det finns dock ett rykte som talar om en synsk andrik i Fristaden, en saga som faktiskt givit namn till ett värdshus i staden Kastor, Ankan och spåkulan.",
-  "sardrag": " De kan ta Diminutiv; Labbar; Paria. Många har Provocerande (kostar som en förmåga).",
-  "namn_man": [
-    "Bredlabb",
-    "Enöga",
-    "Gråfjäder",
-    "Nakenrygg",
-    "Ruggen",
-    "Svarten",
-    "Tuppkam",
-    "Ett",
-    "Två",
-    "Tre"
-  ],
-  "namn_kvinna": [
-    "Bredlabb",
-    "Enöga",
-    "Gråfjäder",
-    "Nakenrygg",
-    "Ruggen",
-    "Svarten",
-    "Tuppkam",
-    "Ett",
-    "Två",
-    "Tre"
-  ],
-  "taggar": {
-    "typ": [
-      "Ras"
-    ]
+  {
+    "id": "ra11",
+    "namn": "Andrik",
+    "beskrivning": "Av världens alla varelser är andriken sannolikt den mest säregna. Dessa ättlingar till vanliga ankor har med mörkermakt gjorts till en nidbild av andra kulturvarelser, ett faktum som undgått varken övriga släkten eller andrikarna själva. Vem som än skapade andrikarna gjorde det mot världens vilja, och uttryckte genom sin svartkonst ett sällsynt förakt för högre lagar, släktesgränser och allmänt god smak. En genomsnittlig andrik är väl medveten om hur andra ser på släktet och bemöter häcklandet – verkligt eller inbillat – med en hätsk blandning av stursk stolthet, halsstarrig gensträvighet och gråtmild offermentalitet.\nAndrikarna dök först upp i Fristaden väster om Alberetor. Om de anlände med båt eller om de faktiskt skapades i den nära nog laglösa staden är okänt. Klart är i alla fall att de kom för att stanna och tog plats i stadens trasproletariat. Från Fristaden spreds andrikar längs kusten i både östlig och västlig riktning på jakt efter ett värdigare liv. Och när Alberetor evakuerades följde andrikarna även med till Ambria.\nMajoriteten av Ambrias andrikar lever hela sina liv på resande fot, i form av ensamma familjer som bedriver gårdfarihandel eller flera familjer tillsammans som flodhandlare. De mest omtalade är dock de andrikbukanjärer som med snabba segelroddare gör Ambrias vatten osäkra. Hos dessa simfotade härjare frodas idéer om andrikarnas överlägsenhet, då de som senast utvecklade därmed – med piraternas logik – är de mest framstående. De har till och med tagit sig ett nytt namn på sitt släkte, Andrake. Andrakepiraterna är inte många men synnerligen aktiva, och fjäderklädda korsarer är ett prioriterat mål för de ambriska galärer som jagar pirater på rikets vattenvägar. Detta har drivit andrikska fribytare mot rikets utkanter. Inte sällan har de tagit sin tillflykt till svårfunna hamnar i ingenmanslandet i södra Davokar där tät växtlighet och älvarnas många biflöden ger utmärkta betingelser för piratverksamhet.",
+    "extra": "**Andrikars särdrag:**\nAndrikar har ofta särdraget Diminutiv. De flesta har även nackdelarna Labbar och Paria. De kan också införskaffa särdraget Provocerande, vilket kostar som andra förmågor.\n\n**Andrikars namn:**\nAndrikar har en slapp inställning till egennamn, och ger vanligen varandra öknamn baserat på utseende, exempelvis Bredlabb, Enöga, Gråfjäder, Nakenrygg, Ruggen, Svarten, Tuppkam. Hos åtminstone ett par större andrikfamiljer har namnbruket helt övergivits till förmån för ett enklare system med siffror, där lägre tal anger tidigare födsel än högre tal.\n\n**Andrikar som äventyrare:**\nEn andrik som lämnar familjen och sällar sig till äventyrare har sannolikt goda skäl därtill, vanligen tvingande sådana. Troligen är familjen död eller andriken utslängd från gemenskapen på grund av något grovt brott.\nAndrikar med en bakgrund bland handlare är oftast tjuvar, de med piratbakgrund är vanligen krigare. Det finns inga kända fall av andrikar som är mystiker eller ens att de skulle kunna lära sig ritualer. Det finns dock ett rykte som talar om en synsk andrik i Fristaden, en saga som faktiskt givit namn till ett värdshus i staden Kastor, Ankan och spåkulan.",
+    "sardrag": " De kan ta Diminutiv; Labbar; Paria. Många har Provocerande (kostar som en förmåga).",
+    "namn_man": [
+      "Bredlabb",
+      "Enöga",
+      "Gråfjäder",
+      "Nakenrygg",
+      "Ruggen",
+      "Svarten",
+      "Tuppkam",
+      "Ett",
+      "Två",
+      "Tre"
+    ],
+    "namn_kvinna": [
+      "Bredlabb",
+      "Enöga",
+      "Gråfjäder",
+      "Nakenrygg",
+      "Ruggen",
+      "Svarten",
+      "Tuppkam",
+      "Ett",
+      "Två",
+      "Tre"
+    ],
+    "taggar": {
+      "typ": [
+        "Ras"
+      ]
+    }
   }
-}
 ]


### PR DESCRIPTION
## Summary
- add id fields ra1..ra11 to `data/ras.json` so each race entry has a unique identifier

## Testing
- `jq 'map(.id) | {total: length, unique: (unique | length)}' data/ras.json`
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688f56878cf08323a9676c1adf78c444