### PR TITLE
Add IDs to negative quality data

### DIFF
--- a/data/negativ-kvalitet.json
+++ b/data/negativ-kvalitet.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "neg1",
     "namn": "Trubbigt",
     "beskrivning": "Vapnet saknar skärande eller spetsande egenskaper och använder därför en (1) lägre nivå av effekttärning än andra vapen av sitt slag.",
     "taggar": {
@@ -11,6 +12,7 @@
   },
 
     {
+    "id": "neg2",
     "namn": "Otympligt",
     "beskrivning": "Rustningen är svår att röra sig i och dess begränsning är ett poäng högre än annars; en otymplig lätt rustning har begränsning (−3), en medeltung (−4) och en tung (−5).",
     "taggar": {
@@ -19,6 +21,7 @@
     "negativ": true
   },
   {
+    "id": "neg3",
     "namn": "Långsamt",
     "beskrivning": "Vapnet är framtungt och så pass obalanserat att det är svårt få sving på vapnet liksom att få stopp på det när man väl har anfallit. Att anfalla med vapnet är en hel rundas handling; stridshandling och förflyttning går båda åt till att anfalla. Bäraren kan med andra ord inte förflytta sig in i strid och anfalla i samma runda, men när bäraren väl är på plats kan denne anfalla varje runda.",
     "taggar": {


### PR DESCRIPTION
## Summary
- assign unique IDs `neg1`–`neg3` to negative quality entries

## Testing
- `jq '.[].id' data/negativ-kvalitet.json`
- `jq '[.[].id] as $ids | ($ids | length) == ($ids | unique | length)' data/negativ-kvalitet.json`
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688f567e79548323a04e5038248b36ee