### PR TITLE
Add IDs to mystisk-kvalitet entries

### DIFF
--- a/data/mystisk-kvalitet.json
+++ b/data/mystisk-kvalitet.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "mystiskkv1",
     "namn": "Banevapen",
     "beskrivning": "Vapnet är smitt i hat och härdat i hämndlystnad, med fokus riktat mot en viss familj av varelser: Alver, Flygfän, Gastar, Människor, Reptiler, Spindlar, Styggelser, Troll eller Vilddjur (se sidan 209 i Grundboken). Bortbytingar räknas i detta avseende till alverna, medan resar och svartalfer hör till trollen. Dvärgar är en egen familj. Mot den utvalda familj en gör banevapnet +1t4 i skada. Det glöder också svagt i banefamiljens närhet, vilket ger +1 i Vaksamhet för att upptäcka att fiender ur den familjen finns i närheten.",
     "taggar": {
@@ -9,6 +10,7 @@
     }
   },
   {
+    "id": "mystiskkv2",
     "namn": "Brinnande",
     "beskrivning": "Vapnet glöder och ryker för att flamma upp vid användning. Vapnet gör normal skada vid träff, men målet börjar sedan brinna, 1t4 skada i 1t4 rundor, med start rundan efter initial träff. Målet kan släcka sig genom att spendera en hel runda på att rulla på marken och lyckas med ett Kvick.",
     "taggar": {
@@ -18,6 +20,7 @@
     }
   },
   {
+    "id": "mystiskkv3",
     "namn": "Dundrande",
     "beskrivning": "Vapnet är smitt med stormande och dundrande runor. Varje träff med vapnet ekar med blixtars kraft vilket gör 1t8 dundrande skada, vilket slås separat i förhållande till den vanliga skadan från attacken. Förmågor påverkar inte denna extra dundrande skada. Om något av den dundrande skadan går genom rustning och skadar målet måste offret dessutom klara ett slag i Stark eller förlora en handling på grund av knallens kraft.",
     "taggar": {
@@ -27,6 +30,7 @@
     }
   },
   {
+    "id": "mystiskkv4",
     "namn": "Dödsruna",
     "beskrivning": "Vapnet är smitt med livsförnekande runor och gör 1t4 extra skada mot levande och icke-genomkorrumperade varelser. Dessutom helar dödsenergierna vandöda och andra genomkorrumperade varelser med samma värde.",
     "taggar": {
@@ -36,6 +40,7 @@
     }
   },
   {
+    "id": "mystiskkv5",
     "namn": "Giftdrypande",
     "beskrivning": "Uråldriga gifttekniker gör varje attack till potentiellt förgiftande. När en attack skadar målet tar det också giftskada, 1t4 i skada i 1t4 rundor.",
     "taggar": {
@@ -45,6 +50,7 @@
     }
   },
   {
+    "id": "mystiskkv6",
     "namn": "Helig",
     "beskrivning": "Vapnet eller rustningen är smitt i helig eld och skadar respektive skyddar mot korrumperade varelser. En varelse som skadas måste slå 1t20 och slå över sin korruption, eller ta 1t4 extra i skada. Och i samband med en lyckad attack mot någon iförd en helig rustning måste anfallaren slå över sin korruption med 1t20; är slaget under anfallarens korruption skyddar rustningen 1t4 extra mot angreppet. Genomkorrumperade varelser misslyckas alltid med slaget, liksom helt rena varelser (0 i korruption) alltid lyckas.",
     "taggar": {
@@ -54,6 +60,7 @@
     }
   },
   {
+    "id": "mystiskkv7",
     "namn": "Oheligt",
     "beskrivning": "Vapnet eller rustningen är smitt i svart eld och skadar respektive skyddar mot rena varelser. En varelse som skadas av ett oheligt vapen måste slå 1t20 och slå under sin korruption, eller ta 1t4 extra i skada. Så snart en varelse lyckas med en attack mot någon iförd en ohelig rustning måste anfallaren slå mot sin korruption med 1t20; är slaget över anfallarens korruption skyddar rustningen 1t4 extra mot angreppet. Genomkorrumperade varelser lyckas alltid med slaget, liksom helt rena varelser (0 i korruption) alltid misslyckas.",
     "taggar": {
@@ -63,6 +70,7 @@
     }
   },
   {
+    "id": "mystiskkv8",
     "namn": "Syraosande",
     "beskrivning": "Vapnet är smitt med korrosiva tekniker som gör att vapnet är frätande. Varje träff med vapnet gör 1t4 extra i skada i 1t4 rundor. Syraskadan läggs inte till vapenskadan utan slås separat som en ytterligare träff. Vapnet bärs i en särskild skida eller hylsa för att inte skada användaren. I strid drabbas bäraren själv av syran om anfallsslaget blir 20 och ett andra slag blir över svingarens Träffsäker (eller det karaktärsdrag som ersätter Träffsäker).",
     "taggar": {
@@ -72,6 +80,7 @@
     }
   },
   {
+    "id": "mystiskkv9",
     "namn": "Vedergällande",
     "beskrivning": "Rustningen är smidd med hemliga och hämnande tekniker och osar av syra. Varje träff i närstrid mot rustningen kräver att anfallaren lyckas med ett Kvick, annars träffas anfallaren av syrastänk som gör 1t4 i skada i 1t4 rundor.",
     "taggar": {
@@ -80,8 +89,8 @@
       ]
     }
   },
-  
   {
+    "id": "mystiskkv10",
     "namn": "Hypnotiserande",
     "beskrivning": "Närstridsvapnet är täckt med ristade, rödfärgade runor som när det svingas kan verka hypnotiserande på en närstridsmotståndare. Varje attack som lyckas med en differens på 5 eller bättre innebär att motståndaren förlorar sin nästkommande stridshandling. Förflyttning och reaktioner är fortfarande möjliga.",
     "taggar": {
@@ -91,6 +100,7 @@
     }
   },
   {
+    "id": "mystiskkv11",
     "namn": "Bräckande",
     "beskrivning": "Den klang som uppstår när ett Bräckande närstridsvapen träffar metall inrymmer försvagande harmonier som steg för steg förstör rustningen eller skölden. En rustning får sitt värde i Bepansring sänkt med 1 för varje lyckad träff, medan en sköld löper risk att bli obrukbar vid varje lyckat försvar [1–5 på 1t20] *",
     "taggar": {
@@ -99,5 +109,4 @@
       ]
     }
   }
-
 ]


### PR DESCRIPTION
## Summary
- add sequential `id` fields to each record in `data/mystisk-kvalitet.json`
- ensure IDs are unique and sequential (mystiskkv1..mystiskkv11)

## Testing
- `jq -r '.[].id' data/mystisk-kvalitet.json | sort | uniq -d`
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688f5677bff48323bc0237b2a1c0b033