### PR TITLE
Add unique IDs to drawbacks data

### DIFF
--- a/data/nackdel.json
+++ b/data/nackdel.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "na1",
     "namn": "Nattbajsare",
     "beskrivning": "Vaknar varje natt för att bajsa, vilket kräver att rollpersonen under 10 minuter varje natt måste lämna lägret eller möta gruppens vrede",
     "taggar": {
@@ -8,270 +9,390 @@
       ]
     }
   },
-
   {
+    "id": "na2",
     "namn": "Bestialisk",
     "beskrivning": "Rollpersonen har ett bestialiskt yttre, i form av ett eller ett par iögonfallande drag – jakaarögon, urornebetar, lindormsfjäll på hals och armar eller något annat som väcker rädsla och avsky. Att dölja dragen för den som rollpersonen talar med kräver ett lyckat [Diskret←Vaksam]. Ett misslyckande ger därefter en andra chans att misslyckas med alla Övertygande som avser hjälp eller beskydd; däremot ger det bestialiska yttre en andra chans att lyckas med Övertygande i syfte att hota och skrämma. Personer som rollpersonen hotar, framgångsrikt eller ej, kommer att rapportera rollpersonen som en styggelse till stadsvakt eller motsvarande så snart de får chans därtill.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na3",
     "namn": "Blodtörstig",
     "beskrivning": "Rollpersonen har en stark blodtörst som väcks lätt och är svår att stilla. Blodtörsten väcks om rollpersonen tar skada och leder till att rollpersonen inte skonar några fiender – inte ens de som ger upp. För att kunna skona en fiende krävs en nästan övermäktig ansträngning; det kräver att spelaren offrar en Erfarenhet och lyckas med ett Viljestark.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na4",
     "namn": "Drogberoende",
     "beskrivning": "Rollpersonen har utvecklat ett drogberoende och måste ta en dos av sin drog varje dag eller få abstinenssymtom. Drogen kostar en skilling per dag och kan vara vin, drömsnus, tokrot eller något annat. En alkemist kan tillverka drogen till sig själv eller någon denne bryr sig om för halva priset. Abstinens ger −1 på alla slag under dagen och blir värre för varje dag upp till −5 efter fem dagar. Varje dag av abstinens måste rollpersonen dessutom klara ett [Viljestark –abstinensmodifikationen], om slaget misslyckas överger rollpersonen andra pågående projekt och börja jaga sin dagsdos istället.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na5",
     "namn": "Efterlyst",
     "beskrivning": "Rollpersonen är efterlyst för ett grovt brott, falskt eller sant anklagad. Effekten är att rollpersonen riskerar att bli igenkänd och jagad. En gång per äventyr måste rollpersonen klara ett slag mot Diskret för att inte bli igenkänd.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na6",
     "namn": "Fallandesjuk",
     "beskrivning": "Rollpersonen är drabbad av ett mycket känsligt sinnelag vilket innebär att denne i upphetsat tillstånd kan utsättas för kramper i hela kroppen. Om rollpersonen råkar slå 20 på ett framgångsslag inträffar detta, varpå rollpersonen är utslagen under 1t4 rundor.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na7",
     "namn": "Hederskod",
     "beskrivning": "Rollpersonen har lagt sig till med en strikt uppförandekod som gäller i alla situationer men som särskilt påverkar hur denne uppför sig i strid. Effekten av detta blir att rollpersonen visserligen kan undvika strid men att denne aldrig flyr från en strid som startat. Fienderna måste besegras eller rollpersonen falla i försöken att nedlägga dem.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na8",
     "namn": "Impulsiv",
     "beskrivning": "Rollpersonen handlar först och tänker sedan. Detta medför att så snart spelaren öppnar munnen och säger att rollperson ska göra något så gör denne det – och spelaren får inte ändra sig. Enda sättet att lägga band på rollpersonen är att offra en Erfarenhet eller acceptera en poäng permanent Korruption.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na9",
     "namn": "Mardrömmar",
     "beskrivning": "Rollpersonen plågas av mardrömmar var och varannan natt, antingen som en följd av saker rollpersonen varit med om eller gjort, eller mer diffust, kanske som ett varsel eller som en följd av en släktförbannelse. Varje natt måste rollpersonen klara ett Viljestark för att få ut sin natts vila. Om slaget misslyckats så har rollpersonen inte kunnat sova ordentligt och får -1 på alla slag dagen efter.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na10",
     "namn": "Mystiskt tecken",
     "beskrivning": "Rollpersonen har ett mystiskt tecken någonstans på kroppen, kanske ett födelsemärke eller ett tecken som uppkommit senare i livet; oavsett löper rollpersonen risk att det ska tolkas som ett styggelsemärke. I situationer där det är befogat måste rollpersonen klara ett slag mot [Diskret←Vaksam] eller ådra sig den hötjugeviftande pöbelns eller någon häxjägares ohälsosamma intresse.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
-
   {
+    "id": "na11",
     "namn": "Mörk hemlighet",
     "beskrivning": "Rollpersonen har en mörk hemlighet av något slag, som om den kom ut allvarligt skulle hota rollpersonens anseende eller liv. Kanske var rollpersonen medlem i en korrumperad sekt eller så har rollpersonen mördat någon eller skyddat en mördare och aldrig åkt fast för det. Om hemligheten kommer ut får rollpersonen istället nackdelen Paria eller Efterlyst, beroende på hemlighetens natur. Det finns en risk per äventyr att hemligheten börjar uppdagas; rollpersonen måste slå ett slag mot Diskret varje äventyr, ett slag med en andra chans att lyckas. Misslyckas slaget får någon en ledtråd som leder mot ett avslöjande. Kanske dyker det upp fysiska indicier (exempelvis brev), ett vittne som sett något eller så pratar rollpersonen i sömnen. Det kan vara en spelledarperson eller en rollperson som anar oråd, och det är upp till rollpersonen att agera för att tysta eller mörka det som skett. Notera att en spelledarperson kanske hellre utpressar än avslöjar rollpersonen för rättvisan.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na12",
     "namn": "Protegé",
     "beskrivning": "Rollpersonen dras med en protegé som den måste beskydda. Protegén kan vara ett älskat barn, en åldrad och kär mentor, en själsfrände eller bara en dryg släkting vars väl och ve hänger samman med ett framtida arv för rollpersonen. Protegén hanteras som en spelledarperson och har en talang för att hamna i trubbel. Den saknar värden utöver det som ett svagt motstånd har och får inte heller erfarenhet för äventyr – den är lika mycket en börda över tid som den är från start. Om protegén dör eller försvinner drabbas rollpersonen av andra problem; sorg och ånger i form av nackdelar av lämplig sort. Om rollpersonen skyddade sin protegé av kärlek kan nackdelar som Drogberoende eller Mardrömmar passa, om beskyddet mer handlade om egna fördelar kanske det ger Efterlyst eller Ärkefiende istället – protegéns släktingar glömmer inte rollpersonens svek i första taget.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na13",
     "namn": "Sjuklig",
     "beskrivning": "Rollpersonen har en kronisk sjukdom som gör honom eller henne svag. Vardagen fungerar bra men vid skada eller trauma löper rollpersonen större risk att stryka med. Det betyder att Dödsslagen slås med två tärningar och det sämsta, mest missgynnande resultatet används.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na14",
     "namn": "Sävlig",
     "beskrivning": "Varelsen förflyttar sig osedvanligt långsamt. I sammanhang där en mer exakt angivelse är relevant förflyttar sig varelsen 7 meter per handling. Och i anslutning till regeln om Flykt & jakt (sidan 102) ger särdraget −3 på Kvick.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na15",
     "namn": "Åldrad",
     "beskrivning": "Rollpersonen är till åren kommen och har både bra och dåliga dagar. Om det första framgångsslaget en dag lyckas är det en bra dag och allt fungerar som det ska; om första slaget för dagen misslyckas är det en dålig dag – gikten sätter in, kärlkrampen nyper om hjärteroten eller öronen susar. Oavsett uttryck har rollpersonen −1 på alla slag resten av dagen.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
   {
+    "id": "na16",
     "namn": "Ärkefiende",
     "beskrivning": "Rollpersonen har genom eget agerande eller sitt namn ådragit sig en ärkefiende. Ärkefienden har vigt sitt liv åt att förstöra för – och på sikt förgöra – rollpersonen. Minst en gång per äventyr kommer ärkefiendens påverkan att synas eller anas. Ärkefienden agerar i första hand genom andra; lejer råskinn eller sprider lögner om rollpersonen i hopp om att andra ska göra livet svårt för denne. Exakt vem ärkefienden är, varför denne hatar rollpersonen och vilka resurser ärkefienden förfogar över får spelare och spelledare komma överens om, men det ska vara någon som inte enkelt kan undvikas eller stoppas från vidare framfart.",
     "taggar": {
-      "typ": ["Nackdel"]
+      "typ": [
+        "Nackdel"
+      ]
     }
   },
-{
-  "namn": "Paria",
-  "beskrivning": "Rollpersonen är av ett släkte som är illa ansett av den styrande majoriteten och som diskrimineras mer eller mindre öppet. Enskilda individer i det omgivande samhället kan vara mindre fördomsfulla men generellt försvåras alla sociala interaktioner för varelsen. Däremot tenderar diskriminerade grupper att hålla samman mot omvärlden och ge varandra mycket hjälp. Rollpersonen tvingas slå två gånger för alla sociala utmaningar och måste ta det sämsta utfallet för att avgöra framgång eller misslyckande. Inom den egna gruppen får varelsen istället en andra chans på alla sociala slag och slår endast för situationer där det verkligen är tveksamt om det som efterfrågas alls är möjligt. Till detta kommer även att rollpersonen börjar spelet med endast fem skilling i sin bältesbörs.",
-  "taggar": {
-    "typ": ["Nackdel"],
-    "ark_trad": [""],
-    "test": ["Övertygande"]
-  }
-},
   {
+    "id": "na17",
+    "namn": "Paria",
+    "beskrivning": "Rollpersonen är av ett släkte som är illa ansett av den styrande majoriteten och som diskrimineras mer eller mindre öppet. Enskilda individer i det omgivande samhället kan vara mindre fördomsfulla men generellt försvåras alla sociala interaktioner för varelsen. Däremot tenderar diskriminerade grupper att hålla samman mot omvärlden och ge varandra mycket hjälp. Rollpersonen tvingas slå två gånger för alla sociala utmaningar och måste ta det sämsta utfallet för att avgöra framgång eller misslyckande. Inom den egna gruppen får varelsen istället en andra chans på alla sociala slag och slår endast för situationer där det verkligen är tveksamt om det som efterfrågas alls är möjligt. Till detta kommer även att rollpersonen börjar spelet med endast fem skilling i sin bältesbörs.",
+    "taggar": {
+      "typ": [
+        "Nackdel"
+      ],
+      "ark_trad": [
+        ""
+      ],
+      "test": [
+        "Övertygande"
+      ]
+    }
+  },
+  {
+    "id": "na18",
     "namn": "Prios Förtappad",
     "beskrivning": "Nackdelen går att välja upp till tre gånger. Karaktären har en gång burit Prios välsignelse, men har vänt sig bort från tron eller på annat sätt brutit med prios läror. Karaktären har förlorat sin välsignelse. Karaktären har -1 i försvar mot attacker och effekter från genomkorrumperade varelser.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Nackdel"],
+      "typ": [
+        "Nackdel"
+      ],
       "ark_trad": [],
-      "test": [""]
+      "test": [
+        ""
+      ]
     }
   },
   {
+    "id": "na19",
     "namn": "Fallen Stjärna",
     "beskrivning": "Karaktären har en gång burit Prios välsignelse, men har vänt sig bort från tron eller på annat sätt brutit med prios läror. Ljuset har lämnat karaktären och det är som att det inte längre reflekteras lika starkt från hen, vilket väcker oro, misstro och ibland rent av fientlighet bland de troende. Vid alla sociala interaktioner med prios hängivna eller religiösa auktoriteter får karaktären -1 i övertygande när religiösa frågor diskuteras.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Nackdel"],
+      "typ": [
+        "Nackdel"
+      ],
       "ark_trad": [],
-      "test": ["Övertygande"]
+      "test": [
+        "Övertygande"
+      ]
     }
   },
   {
+    "id": "na20",
     "namn": "Otursförföljd",
     "beskrivning": "Alla varelser har olika förutsättningar för överlevnad, vare sig det är i Davokars djupa skogar, eller bland skattletare i Tista fäste. Vissa har helt enkelt bara mer otur. En karaktär med otursförföljd slår ett kritiskt misslyckande inte bara på 20, utan även på 19.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Nackdel"],
+      "typ": [
+        "Nackdel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "na21",
     "namn": "Fobi",
     "beskrivning": "Rollpersonen har genom omständigheter i sitt förflutna utvecklat en fobi för ett valfritt fenomen, alla situationer som innefattar den valda fobin ger rollpersonen en andra chans att misslyckas med alla sina slag tills källan till fobin avlägsnats. Exempel på fobier skulle kunna vara fobi för folksamlingar, troll, höga höjder eller fåglar.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Nackdel"],
+      "typ": [
+        "Nackdel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "na22",
     "namn": "Svagt sinne",
     "beskrivning": "Karaktären är av ett simpelt sinne och har varken tränat sin psykiska motståndskraft eller kommer från traditioner där man kontinuerligt lär sig om olika magiska krafter som kan påverka ens sinne på olika sätt. Karaktären har -1 i viljestark när det kommer till försvar mot mystiska krafter och ritualer.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Nackdel"],
+      "typ": [
+        "Nackdel"
+      ],
       "ark_trad": [],
-      "test": ["Viljestark"]
+      "test": [
+        "Viljestark"
+      ]
     }
   },
   {
+    "id": "na23",
     "namn": "Lättlurad",
     "beskrivning": "Karaktären har en naiv och öppenhjärtig natur, vilket gör den särskilt mottaglig för andras inflytande och manipulation. Vare sig det handlar om listiga ord, sofistikerade bedrägerier eller enkla lögner har rollpersonen svårt att ifrågasätta andras avsikter. Varje gång karaktären gör ett slag för att genomskåda bluffar, lögner eller på annat sätt avslöja om någon försöker vilseleda den, får spelaren slå två gånger och måste välja det sämsta resultatet.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Nackdel"],
+      "typ": [
+        "Nackdel"
+      ],
       "ark_trad": [],
-      "test": ["Vaksam", "Listig"]
+      "test": [
+        "Vaksam",
+        "Listig"
+      ]
     }
   },
   {
+    "id": "na24",
     "namn": "Mörk skugga",
     "beskrivning": "Karaktären har ett medfött mörker. Dennes skugga är nästintill lika mörk som en styggelses. I övrigt är karaktären opåverkad av skuggan. En gång per äventyr eller så som spelledare bestämmer kommer skuggan att ifrågasättas och karaktären behöver slå ett Övertygande för att undvika att tas för en styggelse.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Nackdel"],
-      "ark_trad": ["Mystiker"],
-      "test": ["Övertygande"]
+      "typ": [
+        "Nackdel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Övertygande"
+      ]
     }
   },
   {
+    "id": "na25",
     "namn": "Klumpeduns",
     "beskrivning": "Karaktären har svårt att röra sig smidigt och är ofta otajmad eller fumlig i sina rörelser. Det kan handla om snubblande steg, vältande muggar eller en förmåga att alltid dra blickarna till sig vid fel tillfälle. När karaktären försöker vara diskret, smyga eller undvika att märkas får karaktären -1 på alla tärningsutslag. Denna nackdel går att införskaffa upp till tre gånger.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Nackdel"],
+      "typ": [
+        "Nackdel"
+      ],
       "ark_trad": [],
-      "test": ["Diskret"]
+      "test": [
+        "Diskret"
+      ]
     }
   },
   {
+    "id": "na26",
     "namn": "Blåögd",
     "beskrivning": "Karaktären talar öppet om sina tankar, känslor och planer utan något socialt filter. Denna ärlighet gör karaktären både lätt att förstå och svår att ogilla, samtidigt som dolda agendor och hemlighetsmakeri känns främmande. Frågor besvaras spontant och sanningsenligt, vilket gör att karaktären har svårt att dölja känslor, avsikter eller viktig information. Om karaktären ställs inför en fråga där det vore klokt att undanhålla sanningen, krävs ett lyckat slag mot Vaksam för att ana oråd och motstå impulsen att avslöja allt.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Nackdel"],
+      "typ": [
+        "Nackdel"
+      ],
       "ark_trad": [],
-      "test": ["Vaksam"]
+      "test": [
+        "Vaksam"
+      ]
     }
   },
   {
+    "id": "na27",
     "namn": "Tveksam stridskonst",
     "beskrivning": "Karaktären har utvecklat en tveksam och räddhågsen stridsteknik och inväntar allierades första drag innan hen själv vågar slår till. Karaktären avvaktar alltså till alla dess allierade agerat innan den gör någonting och hamnar sist i initiativordningen. Nackdelen omöjliggör dessutom för allierade rollpersoner att skjuta på sitt initiativ så att de hamnar efter rollpersonen. Om flera rollpersoner har denna nackdel slår alla spelare en T20 i början av striden och den som slår lägst agerar sist. Om fler än hälften av gruppen har nackdelen så tvekar gruppen i sin helhet så mycket att fienden alltid får agera först.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Nackdel"],
+      "typ": [
+        "Nackdel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "na28",
     "namn": "Mörkt förflutet",
     "beskrivning": "Genom tidigare äventyrs bistra konsekvenser har karaktären fått känna på vad för mörker som ligger runt davokars djup. Karaktären börjar sitt äventyr med en tredjedel av sin korruptionströskel fylld med permanent korruption avrundat uppåt. Så en karaktär med 14 i viljestark har tre korruption, medans en karaktär med 5 viljestark har 1 korruption. Detta gäller även karaktärer som höjt sin korruptionströskel med förmågor och fördelar.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Nackdel"],
-      "ark_trad": ["Mystiker"],
-      "test": ["Viljestark"]
+      "typ": [
+        "Nackdel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Viljestark"
+      ]
     }
   },
-{
+  {
+    "id": "na29",
     "namn": "Korruptionskänslig",
     "beskrivning": "Karaktären tar lättare skada av skuggans lockelser. Korruptionströskeln minskar med -1 per nivå (max -3).",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Nackdel"],
-      "ark_trad": [""],
-      "test": [""]
+      "typ": [
+        "Nackdel"
+      ],
+      "ark_trad": [
+        ""
+      ],
+      "test": [
+        ""
+      ]
     }
   },
   {
+    "id": "na30",
     "namn": "Bräcklig",
     "beskrivning": "Karaktären hanterar smärta sämre. Smärtgränsen minskar med -1 per nivå (max -3).",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Nackdel"],
-      "ark_trad": [""],
-      "test": [""]
+      "typ": [
+        "Nackdel"
+      ],
+      "ark_trad": [
+        ""
+      ],
+      "test": [
+        ""
+      ]
     }
   },
-{
-  "namn": "Mumsare",
-  "beskrivning": "Rollpersonen är antingen storväxt eller rent av korpulent byggd. För att tillgodose rollpersonens aptit kräver det en större mängd mat än vad en ”vanlig” person äter under en dag. Rollpersonen behöver 1,5 portioner varje dag för att äta sig mätt. Om efterfrågan överstiger tillgången och rollpersonen inte kan tillgodose sig själv med tillräckligt mycket mat får rollpersonen -1 på allt hen försöker göra för varje dag i rad utan tillräckligt mycket mat.",
-  "taggar": {
-    "typ": ["Nackdel"],
-    "ark_trad": [],
-    "test": []
+  {
+    "id": "na31",
+    "namn": "Mumsare",
+    "beskrivning": "Rollpersonen är antingen storväxt eller rent av korpulent byggd. För att tillgodose rollpersonens aptit kräver det en större mängd mat än vad en ”vanlig” person äter under en dag. Rollpersonen behöver 1,5 portioner varje dag för att äta sig mätt. Om efterfrågan överstiger tillgången och rollpersonen inte kan tillgodose sig själv med tillräckligt mycket mat får rollpersonen -1 på allt hen försöker göra för varje dag i rad utan tillräckligt mycket mat.",
+    "taggar": {
+      "typ": [
+        "Nackdel"
+      ],
+      "ark_trad": [],
+      "test": []
+    }
+  },
+  {
+    "id": "na32",
+    "namn": "Labbar",
+    "beskrivning": "Varelsen har illa utvecklade händer, och har därmed svårt att utföra finmotoriska handlingar så som att dyrka ett lås eller liknande. Så snart en utmaning kräver fingerfärdighet får varelsen en andra chans att misslyckas.",
+    "taggar": {
+      "typ": [
+        "Nackdel"
+      ]
+    }
   }
-},
-{
-  "namn": "Labbar",
-  "beskrivning": "Varelsen har illa utvecklade händer, och har därmed svårt att utföra finmotoriska handlingar så som att dyrka ett lås eller liknande. Så snart en utmaning kräver fingerfärdighet får varelsen en andra chans att misslyckas.",
-  "taggar": {
-    "typ": [
-      "Nackdel"
-    ]
-  }
-}
-
-
 ]


### PR DESCRIPTION
## Summary
- assign sequential `na` IDs to each drawback entry in `nackdel.json`

## Testing
- `for f in tests/*.test.js; do node $f || break; done`


------
https://chatgpt.com/codex/tasks/task_e_688f567a6e6c83238e469df846c8c80c