### PR TITLE
Add unique IDs to fordel entries

### DIFF
--- a/data/fordel.json
+++ b/data/fordel.json
@@ -1,649 +1,967 @@
 [
   {
+    "id": "ford1",
     "namn": "Arkivarie",
     "beskrivning": "Rollpersonen är tränad i att ordna upp och söka information. Rollpersonen får +1 på alla slag i att göra efterforskningar i arkiv och bibliotek. Arkivarie kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Listig"]
+      "test": [
+        "Listig"
+      ]
     }
   },
   {
+    "id": "ford2",
     "namn": "Arvegods",
     "beskrivning": "Rollpersonen har genom släktleden erhållit ett arvegods. Välj ett valfritt vapen eller en rustning från listorna på hemsidan och gratismarkera det med två gratis kvaliteter som inte är mystiska kvaliteter.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "ford3",
     "namn": "Berättare",
     "beskrivning": "Rollpersonen har berättandets gåva och vare sig det rör sagor, religiösa myter eller burleska historier kommer åhörare att imponeras av dem. Berättaren får +1 på slag i Övertygande då det gäller att väva en trovärdig vision för att imponera på en grupp åhörare. Berättaren är skicklig nog att tjäna daler på sin fördel (se Inkomst av fördelar på sidan 103). Berättare kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Övertygande"]
+      "test": [
+        "Övertygande"
+      ]
     }
   },
   {
+    "id": "ford4",
     "namn": "Besittning",
     "beskrivning": "Rollpersonen har en affärsrörelse av något slag – en liten taverna, en mindre handelsbod eller annan enklare hantverkstjänst som skomakare eller liknande. Andra möjligheter är en teater eller gycklargrupp. Besittningen kan vara stationär på en plats dit rollpersonen ofta återkommer mellan äventyr, eller rörlig i form av en vagn eller liten flodbåt om det passar spelet bättre. En gång per äventyr (lämpligen mellan äventyr) får spelaren slå mot Listig (för hantverk) eller Övertygande (för tjänster). Framgång ger en vinst om 1t10+10 daler, efter att alla omkostnader för affärsrörelsen är betalda. Pengarna läggs till i inventariet automatiskt. Om flera rollpersoner har Besittning kan det utgöra andelar i samma rörelse. Varje rollperson slår då separata slag för sin andel.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Listig", "Övertygande"]
+      "test": [
+        "Listig",
+        "Övertygande"
+      ]
     }
   },
   {
+    "id": "ford5",
     "namn": "Bestars tunga",
     "beskrivning": "Rollpersonen har en förmåga att tala med varelser ur kategorin bestar. Bestar har sina begräsningar men kan svara på frågor om vilka varelser som rör sig eller har rört sig inom ett område, hur många de är (en, två eller många). Bestarna gör inte rollpersonen några tjänster, utan konverserar som de skulle med en likvärdig artfrände.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "ford6",
     "namn": "Bluffmakare",
     "beskrivning": "Rollpersonen är van att med kort varsel vränga sanningen och kan måla med bred pensel när så behövs. Rollpersonen får +1 på slag för Övertygande och Vaksam vid lögner, är alltså både bra på att själv ljuga och att notera när andra ljuger. Lögner är vanligen endast verksamma under en kortare tid och lögnaren bör skynda sig om denne vill dra nytta av lögnen. Bluffmakare kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Övertygande", "Vaksam"]
+      "test": [
+        "Övertygande",
+        "Vaksam"
+      ]
     }
   },
   {
+    "id": "ford7",
     "namn": "Blodhund",
     "beskrivning": "Rollpersonen har ett välutvecklat sinne för att spåra och finna folk, vare sig spåren syns i leran, i ett sovnäste eller bland brev och kvarlämnad utrustning. Rollpersoner får +1 på alla slag för Vaksam och Listig när det gäller att finna och följa spår, eller för att lista ut var någon gömmer sig. Blodhund kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Vaksam", "Listig"]
+      "test": [
+        "Vaksam",
+        "Listig"
+      ]
     }
   },
   {
+    "id": "ford8",
     "namn": "Blodsband",
     "beskrivning": "Rollpersonen har ingått ett mystiskt blodsband med en varelse från ett annat släkte och kan genom sitt blodsband välja att investera erfarenhet (eller förmågor från spelets start) i ett särdrag från släktet i fråga. Det troligaste är att rollpersonen har ingått blodsband med en annan kulturvarelse, men även andra monster och väsen är tänkbara. Historien om hur rollpersonen kommit att ingå blodsbandet är säkerligen intressant och determinerande för hur rollpersonens liv sett ut – och hur rollpersonen ser på livet!",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
-      "ark_trad": ["Mystiker"],
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
       "test": []
     }
   },
   {
+    "id": "ford9",
     "namn": "Bländverk",
     "beskrivning": "Rollpersonen har en mindre mystisk gåva och kan väva momentära bländverk ur tomma luften – eldsflammor som inte bränner kan hoppa mellan dennes händer, små figurer av ljus kan dansa i luften där rollpersonen dragit sin hand, rollpersonen tycks omgiven av hotfulla skuggor och liknande. Dessutom kan rollpersonen väva falska bilder över grus och till synes förvandla dem till skinande mynt. Bländverket lurar ingen över tid då effekten tynar bort efter scenens slut. Med Bländverk kan rollpersonen slå ett Övertygande för att lura någon att acceptera en falsk vara eller betalning med illusoriska mynt, till ett maximalt ”värde” av hundra daler. Dessutom ger Bländverk +1 på Övertygande när rollpersonen hotar eller försöker imponera på någon med sin ”mäktiga magi”.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
-      "ark_trad": ["Mystiker"],
-      "test": ["Övertygande"]
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Övertygande"
+      ]
     }
   },
   {
+    "id": "ford10",
     "namn": "Dubbeltunga",
     "beskrivning": "Dubbeltunga är ett språk utvecklat av Yndaros tjuvgille – en person säger en sak men menar en helt annan. På så sätt kan känsliga konversationer hållas inom hörhåll från obehöriga. Om fler rollpersoner behärskar dubbeltunga kan dessa prata om hemligheter inför andra utan risk att förstås, under förutsättning att åhörarna inte också behärskar dubbeltunga såklart.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
-
   {
-  "namn": "Eldfödd",
-  "beskrivning": "Rollpersonen föddes under glödande himlafenomen eller var den ende som i sin vagga överlevde en förödande brand. Rollpersonen har ett mystiskt skydd mot eld på 1 och har dessutom +1 på alla framgångsslag som rör användande av eller motståndskraft mot eld.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": ["Mystiker"],
-    "test": ["Stark", "Listig", "Vaksam"]
-  }
-},
-{
-  "namn": "Falsk identitet",
-  "beskrivning": "Rollpersonen har en falsk identitet, komplett med kläder, utrustning och papper som styrker den. Identiteten är så pass grundligt skapad att den inte kan genomskådas med mindre än att den som upprättade den (vanligen högt uppsatta personer i rollpersonens egen organisation) röjer den – eller att rollpersonen genom eget handlande avslöjar sig.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Listig"]
-  }
-},
-{
-  "namn": "Falskspelare",
-  "beskrivning": "Rollpersonen är en van fuskare i spel och vet hur man undgår upptäckt. Rollpersonen får genom sitt idoga fuskande +1 på slag för Listig i spel, och för att komma undan måste falskspelaren klara ett [Diskret←Vaksam] mot motspelaren med högst Vaksam. Falskspelaren får också en andra chans att undgå upptäckt med sitt falskspel. Kan kombineras med Taktisk spelare för ytterligare bonus. Falskspelare kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Listig", "Diskret", "Vaksam"]
-  }
-},
-{
-  "namn": "Fingerfärdig",
-  "beskrivning": "Rollpersonen är osedvanligt flink med fingrarna och får +1 på alla slag i Diskret i syfte att stjäla eller gömma föremål på sin person. Fingerfärdig kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Diskret"]
-  }
-},
-{
-  "namn": "Gifttålig",
-  "beskrivning": "Rollpersonen har genom försiktig exponering byggt upp en enastående motståndskraft mot gifter. Gifter drabbar rollpersonen på en nivå lägre än normalt – ett stark gift skadar som ett medelstarkt, ett medelstarkt blir svagt och ett svagt ger bara ett i skada per runda det är verksamt. Verkanstiden påverkas inte, enbart mängden skada per runda. Mot gifter som inte skadar utan har andra negativa effekter får rollpersonen istället en andra chans att lyckas med motståndsslagen.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Stark"]
-  }
-},
-{
-  "namn": "Gröna fingrar",
-  "beskrivning": "Rollpersonen har en mystisk koppling till allt som växer och har +1 på alla framgångsslag som rör faror i skog och mark; det omfattar slag för att orientera i skogen, att hitta mat och skydd samt hitta och undgå naturliga fällor. Bonusen gäller också alla slag för Alkemi. Gröna fingrar kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": ["Mystiker"],
-    "test": ["Listig"]
-  }
-},
-{
-  "namn": "Gömställen",
-  "beskrivning": "Många organisationer och lösare nätverk upprättar regelmässigt gömställen i Ambria och Davokars yttre regioner; ligor, gillen och organisationer som häxor och drottningens jägarkår upprätthåller alla sådana platser för sitt folk. Rollpersonen har kännedom om och tillgång till en rad sådana gömställen knutna till en viss gruppering. Där är det möjligt att ligga lågt samt att ersätta eller plocka upp viktig utrustning, inklusive vapen. När rollpersonen behöver ett gömställe får denne slå ett slag i Listig – ett lyckat slag gör att rollpersonen drar sig till minnes ett gömställe precis i närheten. Platsen är dold, trygg och innehåller utrustning till ett värde av 10 daler; rollpersonen bestämmer vad som finns i gömstället, inklusive kontanta pengar. Den som tar från ett gömställe förväntas ersätta det senare eller i varje fall rapportera vad man tagit och vad det använts till.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Listig"]
-  }
-},
-{
-  "namn": "Husdjur",
-  "beskrivning": "Rollpersonen har ett husdjur av typ vakthund eller jakaar – vilket djur som helst går egentligen bra, så länge det utgör svagt motstånd. Husdjuret är obrottsligt lojalt mot rollpersonen. Husdjuret spelas av spelaren som en andra rollperson i strid eller problemlösning men utvecklas inte med Erfarenhet (för det krävs ritualen Bjära). Om husdjuret dör kan rollpersonen skaffa ett nytt till nästa äventyr.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": []
-  }
-},
-
-{
-  "namn": "Marschvana",
-  "beskrivning": "Efter många och långa mil i militärkolonner eller i skogens djup behöver rollpersonen aldrig slå för att klara av hårda marscher i dödsmarschtempo. Den marschvane läker också naturligt under forcerade marscher. Rollpersonens marschrutin är sådan att även rollpersonens sällskap kan dra nytta av den, och andra rollpersoner i sällskapet får en andra chans att undvika negativa effekter av dödsmarschtempo. Medresenärer får också slå ett Stark för att se om de läker naturligt under forcerad marsch.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Stark"]
-  }
-},
-{
-  "namn": "Medium",
-  "beskrivning": "Rollpersonen växte upp i spökelsers närhet och fann sig ha känsla och öra för dem. Rollpersonen får +1 på alla slag för Vaksam, Viljestark eller Övertygande i syfte att upptäcka, interagera med eller betvinga osaliga andar. Modifikationen gäller också för att motstå andars kontrollförsök eller krafter riktade mot rollpersonen. Medium kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": ["Mystiker"],
-    "test": ["Vaksam", "Viljestark", "Övertygande"]
-  }
-},
-{
-  "namn": "Minnesmästare",
-  "beskrivning": "Varelsen stammar från ett släkte som av tradition inte använder skriftspråk men som istället har utvecklat minnestekniker för att spara och bevara viktig kunskap. Personen minns därför allt den har sett och hört, vilket speltekniskt innebär att spelaren får fråga spelledaren om detaljer som rollpersonen har upplevt under sina tidigare öden och äventyr. Spelledaren måste svara så utförligt som möjligt.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": []
-  }
-},
-{
-  "namn": "Musikant",
-  "beskrivning": "Rollpersonen är musikaliskt talangfull och eventuellt formellt skolad i att sjunga och spela. Musikanten kan ge sig själv eller sin grupp +1 på ett kommande slag i Övertygande; alla gillar en god musiker. Dessutom kan färdigheten faktiskt rädda rollpersonens liv, då en ljuv stämma och välstämda strängars spel kan lugna en upprörd varelse ur bestkategorin; då krävs ett [Övertygande←Viljestark] samt att varken musikanten eller någon annan anfaller besten. Rollpersonen och dennes allierade kan sedan backa undan och finna en annan väg. Musikant kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Övertygande"]
-  }
-},
-{
-  "namn": "Mörkt blod",
-  "beskrivning": "Rollpersonen har mörkt blod i ådrorna, nedärvt från någon paktmakande förfäder eller som en effekt av en förbannelse; kanske är det kort och gott en följd av att ha fötts på fel plats i Davokar vid fel tid. Det mörka blodets arv åtföljs alltid av någon form av fysiskt stigma på bäraren, representerat av nackdelen Bestialisk. Rollpersonen kan skaffa följande monstruösa särdrag som om de var vanliga förmågor: Naturligt vapen, Pansar, Robust, Regeneration, Vingar.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": ["Mystiker"],
-    "test": []
-  }
-},
-{
-  "namn": "Packåsna",
-  "beskrivning": "Rollpersonen är van att bära mycket, tungt och långt. Beräkningen av rollpersonens bärförmåga görs med dennes Stark ×1,5. Se regeln för Bärförmåga på sidan 100 i Spelarens handbok.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Stark"]
-  }
-},
-
-{
-  "namn": "Imitatör",
-  "beskrivning": "Rollpersonen är en skicklig imitatör, vare sig det gäller att föreställa en kategori av personer inom sitt eget släkte eller i direkt imitation av en specifik person. Rollpersonen får +1 på slag mot Diskret i syfte att imitera andra. Om rollpersonen enbart försöker spela en generell kategori ur sitt eget släkte (exempelvis stadsvakt) snarare än en viss person får denne dessutom en andra chans att lyckas med slaget. Att föreställa en specifik representant för ett annat släkte är svårare; imitatören får försöka, dock då med en andra chans att misslyckas på slaget istället. Specifika individer ur andra släkten kan inte imiteras trovärdigt. Imitatör kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Diskret"]
-  }
-},
-{
-  "namn": "Inbrottstjuv",
-  "beskrivning": "Rollpersonen är tränad och erfaren i att passera lås och reglar och får +1 på alla slag i att dyrka lås; slaget slås mot Kvick om det är bråttom eller mot Diskret om det handlar om att göra det utan att personer på andra sidan dörren ska upptäcka intrånget. Diskret slås också för att dölja att låset har dyrkats, ifall någon undersöker det i efterhand. Inbrottstjuv kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Kvick", "Diskret"]
-  }
-},
-{
-  "namn": "Kartograf",
-  "beskrivning": "Rollpersonen har skolats eller på egen hand utvecklat färdighet i kartritande, en efterfrågad konst i dessa utforskandets tider. Rollpersonen får +1 på slag för att orientera sig, både över och under jord. Kartograf kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Listig"]
-  }
-},
-{
-  "namn": "Kommenderande stämma",
-  "beskrivning": "Rollpersonen har en väl övad stämma och kan låta den eka över slagfältets larm. Detta ger +1 på slag för Övertygande i alla lägen då rollpersonen ger direkta order till en individ eller grupp. Kommenderande stämma kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Övertygande"]
-  }
-},
-{
-  "namn": "Manipulatör",
-  "beskrivning": "Rollpersonen är skicklig på att spela på folks känslor medelst smicker, hot eller en kombination därav. Rollpersonen får +1 i Övertygande mot en utvald person under scenen. Manipulationer tar tid att genomföra effektivt, de kräver en scen av känslospel för att nå avsedd verkan. Å andra sidan är de manipulationerna verksamma över en längre tid, den manipulerade anser att känslorna och åsikterna är dess egna och kommer försvara dem långt efter att manipulatören lämnat platsen. Manipulatör kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Övertygande"]
-  }
-},
-{
-  "namn": "Personlig tjänare",
-  "beskrivning": "Rollpersonen har en personlig tjänare. Det kan röra sig om en anställd kalfaktor, livegen kammarpojk eller likande. Tjänaren är lojal mot rollpersonen men annars tämligen blek i termer av förmåga (svagt motstånd). Tjänaren utför enklare sysslor och kan hålla vakt nattetid eller lämna meddelanden men kommer inte att bidra i farliga situationer. Tjänaren spelas av spelledaren och bör förses med en lämplig personlighet.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": []
-  }
-},
-{
-  "namn": "Seglivad",
-  "beskrivning": "Rollpersonen har en seg kropp och en stark själ, vilket gör att hans eller hennes hjärta fortsätter att slå där andra personers organ ger upp. En rollperson med fördelen Seglivad får alltid slå Dödsslagen med två tärningar, varefter denne väljer det mest gynnsamma resultatet.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": []
-  }
-},
-{
-  "namn": "Skräckinjagande",
-  "beskrivning": "Rollpersonen kan konsten att vara hotfull på ett effektivt sätt och verkligen sätta skräck i folk i syfte att få dem att kortsiktigt agera enligt rollpersonens vilja. Rollpersonen får +1 i alla slag i Övertygande som gäller hot, förhör och tvång. Effekten verkar inte bortom stunden, tvärt om kommer offret att tala illa om rollpersonen då denne inte är närvarande. Skräckinjagande kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Övertygande"]
-  }
-},
-{
-  "namn": "Snabbfotad",
-  "beskrivning": "Varelsen förflyttar sig osedvanligt snabbt. I sammanhang där en mer exakt angivelse är relevant förflyttar sig varelsen 13 meter per handling. Och i anslutning till regeln om Flykt & jakt (sidan 102) ger särdraget +3 på Kvick.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Kvick"]
-  }
-},
-{
-  "namn": "Skvallerbytta",
-  "beskrivning": "Rollpersonen har öra och tunga för skvaller och kan samla på sig rykten och också sprida dem vidare till nya miljöer. Rollpersonen får +1 på alla slag för att höra, sprida eller inse faktabasen i alla typer av rykten. Skvallerbytta kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Listig"]
-  }
-},
-{
-  "namn": "Skuggyngel",
-  "beskrivning": "Rollpersonen föddes under en solförmörkelse och alltsedan dess dras skuggor till rollpersonen – och tvärt om. Skuggynglet får +1 på alla slag i Diskret för att smyga och gömma sig. Skuggyngel kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": ["Mystiker"],
-    "test": ["Diskret"]
-  }
-},
-{
-  "namn": "Stigfinnare",
-  "beskrivning": "Rollpersonen har en osviklig känsla för såväl markens spår som väderstreck; såväl under som över mark. Rollpersonen får en andra chans att lyckas med slag för Vaksam i syfte att följa spår och för att hitta fram – eller tillbaka – till en plats.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Vaksam"]
-  }
-},
-{
-  "namn": "Taktisk spelare",
-  "beskrivning": "Rollpersonen får +1 på slag i Listig för att spela hasard eller taktiska spel som schack. Rollpersonen får också +1 på Vaksam för att upptäcka falskspelare. Kan kombineras med Falskspelare för ytterligare bonus. Taktisk spelare kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Listig", "Vaksam"]
-  }
-},
-{
-  "namn": "Teckentydare",
-  "beskrivning": "Rollpersonen har alltid sett tecken andra inte sett och har +1 på alla slag för ritualer som rör ödet eller som ger information: Spådomskonst, Offerrök och Orakelkonst. Teckentydare kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": ["Mystiker"],
-    "test": ["Listig"]
-  }
-},
-{
-  "namn": "Tvillingsjäl",
-  "beskrivning": "Rollpersonen har en tvillingsjäl, antingen i den mer romantiska eller i den syskonliga meningen. Oavsett vilket kan rollpersonen kommunicera enklare meddelanden och känslor telepatiskt med sin tvillingsjäl. De vet ungefär var den andre befinner sig och om denna är i fara eller mår bra. Tvillingsjälen kan vara en för spelet viktig spelledarperson men ännu hellre en annan spelares rollperson; prata med spelgruppen om vad som passar bäst. I det senare fallet räcker det hur som helst med att en av rollpersonerna skaffar fördelen i fråga.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": []
-  }
-},
-{
-  "namn": "Utbrytarkonstnär",
-  "beskrivning": "Rollpersonen har viga leder och har tränat sig i att utnyttja dem maximalt för att ta sig loss eller ta sig genom smala passageer; detta gäller också slag för att ta sig loss från brottargrepp eller andra fasthållningar från fällor, nät och liknande. På sådana slag får rollpersonen en andra chans att lyckas, oavsett vilket karaktärsdrag som slaget slås mot.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": []
-  }
-},
-
-{
-  "namn": "Privilegierad",
-  "beskrivning": "Rollpersonen tillhör en grupp med högt anseende och tydliga fördelar inom sitt eget samhälle, men betraktas som avvikande eller misstänkt utanför detta sammanhang. Inom sitt samhälle får rollpersonen slå två gånger på sociala utmaningar och välja det bästa utfallet. Men i främmande miljöer där den egna gruppen är ovanlig måste rollpersonen istället slå två gånger på sociala utmaningar mot lokalbefolkningen och ta det sämsta resultatet. Rollpersonen börjar spelet med 50 daler i bältesbörsen. Pengarna läggs till i inventariet automatiskt.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": [""]
-  }
-},
-{
-  "namn": "Kontaktnät",
-  "beskrivning": "Rollpersonen har tjänat i en vidsträckt organisation eller färdats vida kring och på så sätt byggt upp ett vidsträckt kontaktnät. Rollpersonen kan med ett lyckat Övertygande dra sig till minnes en kontakt som borde kunna hjälpa till i en specifik fråga eller prekär situation. Kontakten måste inte finnas direkt tillgänglig - det beror på vilka kontaktnätet omfattar. Exempel på fraktioner och folk som kan användas som avgränsning är: Drottningens armé, Drottningens jägarkår, Häxor, Ordo Magica, Prios kyrka, Riddarhusen och Skattletare.",
-  "kan_införskaffas_flera_gånger": false,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Övertygande"]
-  }
-},
-
-{
-  "namn": "Vildmarksvana",
-  "beskrivning": "Personen kan tyda vildmarkens tecken, vet vilka områden som bör undvikas och är van att hitta mat, föda och skydd i ogästvänliga miljöer. Under förflyttningar i vildmark eller ruiner kan personen med ett lyckat Vaksam skörda 1t6 ransoner mat och vatten per dygn, eller 1t10 ransoner om allt fokus läggs på det (ingen förflyttning). Vildmarksvana kan införskaffas flera gånger och då vara användbar i allt ogästvänligare miljöer. Nivå I motsvarar Ljusa Davokar och bergskedjornas ytterområden; nivå II Vilda Davokar och bergens djupa dalar; nivå III Mörka Davokar och Undervärlden (spelledaren avgör). Notera att en person måste ha befunnit sig en längre tid i de mer krävande miljöerna för att få tillgodogöra sig högre nivåer i fördelen.",
-  "kan_införskaffas_flera_gånger": true,
-  "taggar": {
-    "typ": ["Fördel"],
-    "ark_trad": [],
-    "test": ["Vaksam"]
-  }
-},
-
+    "id": "ford11",
+    "namn": "Eldfödd",
+    "beskrivning": "Rollpersonen föddes under glödande himlafenomen eller var den ende som i sin vagga överlevde en förödande brand. Rollpersonen har ett mystiskt skydd mot eld på 1 och har dessutom +1 på alla framgångsslag som rör användande av eller motståndskraft mot eld.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Stark",
+        "Listig",
+        "Vaksam"
+      ]
+    }
+  },
   {
+    "id": "ford12",
+    "namn": "Falsk identitet",
+    "beskrivning": "Rollpersonen har en falsk identitet, komplett med kläder, utrustning och papper som styrker den. Identiteten är så pass grundligt skapad att den inte kan genomskådas med mindre än att den som upprättade den (vanligen högt uppsatta personer i rollpersonens egen organisation) röjer den – eller att rollpersonen genom eget handlande avslöjar sig.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Listig"
+      ]
+    }
+  },
+  {
+    "id": "ford13",
+    "namn": "Falskspelare",
+    "beskrivning": "Rollpersonen är en van fuskare i spel och vet hur man undgår upptäckt. Rollpersonen får genom sitt idoga fuskande +1 på slag för Listig i spel, och för att komma undan måste falskspelaren klara ett [Diskret←Vaksam] mot motspelaren med högst Vaksam. Falskspelaren får också en andra chans att undgå upptäckt med sitt falskspel. Kan kombineras med Taktisk spelare för ytterligare bonus. Falskspelare kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Listig",
+        "Diskret",
+        "Vaksam"
+      ]
+    }
+  },
+  {
+    "id": "ford14",
+    "namn": "Fingerfärdig",
+    "beskrivning": "Rollpersonen är osedvanligt flink med fingrarna och får +1 på alla slag i Diskret i syfte att stjäla eller gömma föremål på sin person. Fingerfärdig kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Diskret"
+      ]
+    }
+  },
+  {
+    "id": "ford15",
+    "namn": "Gifttålig",
+    "beskrivning": "Rollpersonen har genom försiktig exponering byggt upp en enastående motståndskraft mot gifter. Gifter drabbar rollpersonen på en nivå lägre än normalt – ett stark gift skadar som ett medelstarkt, ett medelstarkt blir svagt och ett svagt ger bara ett i skada per runda det är verksamt. Verkanstiden påverkas inte, enbart mängden skada per runda. Mot gifter som inte skadar utan har andra negativa effekter får rollpersonen istället en andra chans att lyckas med motståndsslagen.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Stark"
+      ]
+    }
+  },
+  {
+    "id": "ford16",
+    "namn": "Gröna fingrar",
+    "beskrivning": "Rollpersonen har en mystisk koppling till allt som växer och har +1 på alla framgångsslag som rör faror i skog och mark; det omfattar slag för att orientera i skogen, att hitta mat och skydd samt hitta och undgå naturliga fällor. Bonusen gäller också alla slag för Alkemi. Gröna fingrar kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Listig"
+      ]
+    }
+  },
+  {
+    "id": "ford17",
+    "namn": "Gömställen",
+    "beskrivning": "Många organisationer och lösare nätverk upprättar regelmässigt gömställen i Ambria och Davokars yttre regioner; ligor, gillen och organisationer som häxor och drottningens jägarkår upprätthåller alla sådana platser för sitt folk. Rollpersonen har kännedom om och tillgång till en rad sådana gömställen knutna till en viss gruppering. Där är det möjligt att ligga lågt samt att ersätta eller plocka upp viktig utrustning, inklusive vapen. När rollpersonen behöver ett gömställe får denne slå ett slag i Listig – ett lyckat slag gör att rollpersonen drar sig till minnes ett gömställe precis i närheten. Platsen är dold, trygg och innehåller utrustning till ett värde av 10 daler; rollpersonen bestämmer vad som finns i gömstället, inklusive kontanta pengar. Den som tar från ett gömställe förväntas ersätta det senare eller i varje fall rapportera vad man tagit och vad det använts till.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Listig"
+      ]
+    }
+  },
+  {
+    "id": "ford18",
+    "namn": "Husdjur",
+    "beskrivning": "Rollpersonen har ett husdjur av typ vakthund eller jakaar – vilket djur som helst går egentligen bra, så länge det utgör svagt motstånd. Husdjuret är obrottsligt lojalt mot rollpersonen. Husdjuret spelas av spelaren som en andra rollperson i strid eller problemlösning men utvecklas inte med Erfarenhet (för det krävs ritualen Bjära). Om husdjuret dör kan rollpersonen skaffa ett nytt till nästa äventyr.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": []
+    }
+  },
+  {
+    "id": "ford19",
+    "namn": "Marschvana",
+    "beskrivning": "Efter många och långa mil i militärkolonner eller i skogens djup behöver rollpersonen aldrig slå för att klara av hårda marscher i dödsmarschtempo. Den marschvane läker också naturligt under forcerade marscher. Rollpersonens marschrutin är sådan att även rollpersonens sällskap kan dra nytta av den, och andra rollpersoner i sällskapet får en andra chans att undvika negativa effekter av dödsmarschtempo. Medresenärer får också slå ett Stark för att se om de läker naturligt under forcerad marsch.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Stark"
+      ]
+    }
+  },
+  {
+    "id": "ford20",
+    "namn": "Medium",
+    "beskrivning": "Rollpersonen växte upp i spökelsers närhet och fann sig ha känsla och öra för dem. Rollpersonen får +1 på alla slag för Vaksam, Viljestark eller Övertygande i syfte att upptäcka, interagera med eller betvinga osaliga andar. Modifikationen gäller också för att motstå andars kontrollförsök eller krafter riktade mot rollpersonen. Medium kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Vaksam",
+        "Viljestark",
+        "Övertygande"
+      ]
+    }
+  },
+  {
+    "id": "ford21",
+    "namn": "Minnesmästare",
+    "beskrivning": "Varelsen stammar från ett släkte som av tradition inte använder skriftspråk men som istället har utvecklat minnestekniker för att spara och bevara viktig kunskap. Personen minns därför allt den har sett och hört, vilket speltekniskt innebär att spelaren får fråga spelledaren om detaljer som rollpersonen har upplevt under sina tidigare öden och äventyr. Spelledaren måste svara så utförligt som möjligt.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": []
+    }
+  },
+  {
+    "id": "ford22",
+    "namn": "Musikant",
+    "beskrivning": "Rollpersonen är musikaliskt talangfull och eventuellt formellt skolad i att sjunga och spela. Musikanten kan ge sig själv eller sin grupp +1 på ett kommande slag i Övertygande; alla gillar en god musiker. Dessutom kan färdigheten faktiskt rädda rollpersonens liv, då en ljuv stämma och välstämda strängars spel kan lugna en upprörd varelse ur bestkategorin; då krävs ett [Övertygande←Viljestark] samt att varken musikanten eller någon annan anfaller besten. Rollpersonen och dennes allierade kan sedan backa undan och finna en annan väg. Musikant kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Övertygande"
+      ]
+    }
+  },
+  {
+    "id": "ford23",
+    "namn": "Mörkt blod",
+    "beskrivning": "Rollpersonen har mörkt blod i ådrorna, nedärvt från någon paktmakande förfäder eller som en effekt av en förbannelse; kanske är det kort och gott en följd av att ha fötts på fel plats i Davokar vid fel tid. Det mörka blodets arv åtföljs alltid av någon form av fysiskt stigma på bäraren, representerat av nackdelen Bestialisk. Rollpersonen kan skaffa följande monstruösa särdrag som om de var vanliga förmågor: Naturligt vapen, Pansar, Robust, Regeneration, Vingar.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": []
+    }
+  },
+  {
+    "id": "ford24",
+    "namn": "Packåsna",
+    "beskrivning": "Rollpersonen är van att bära mycket, tungt och långt. Beräkningen av rollpersonens bärförmåga görs med dennes Stark ×1,5. Se regeln för Bärförmåga på sidan 100 i Spelarens handbok.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Stark"
+      ]
+    }
+  },
+  {
+    "id": "ford25",
+    "namn": "Imitatör",
+    "beskrivning": "Rollpersonen är en skicklig imitatör, vare sig det gäller att föreställa en kategori av personer inom sitt eget släkte eller i direkt imitation av en specifik person. Rollpersonen får +1 på slag mot Diskret i syfte att imitera andra. Om rollpersonen enbart försöker spela en generell kategori ur sitt eget släkte (exempelvis stadsvakt) snarare än en viss person får denne dessutom en andra chans att lyckas med slaget. Att föreställa en specifik representant för ett annat släkte är svårare; imitatören får försöka, dock då med en andra chans att misslyckas på slaget istället. Specifika individer ur andra släkten kan inte imiteras trovärdigt. Imitatör kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Diskret"
+      ]
+    }
+  },
+  {
+    "id": "ford26",
+    "namn": "Inbrottstjuv",
+    "beskrivning": "Rollpersonen är tränad och erfaren i att passera lås och reglar och får +1 på alla slag i att dyrka lås; slaget slås mot Kvick om det är bråttom eller mot Diskret om det handlar om att göra det utan att personer på andra sidan dörren ska upptäcka intrånget. Diskret slås också för att dölja att låset har dyrkats, ifall någon undersöker det i efterhand. Inbrottstjuv kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Kvick",
+        "Diskret"
+      ]
+    }
+  },
+  {
+    "id": "ford27",
+    "namn": "Kartograf",
+    "beskrivning": "Rollpersonen har skolats eller på egen hand utvecklat färdighet i kartritande, en efterfrågad konst i dessa utforskandets tider. Rollpersonen får +1 på slag för att orientera sig, både över och under jord. Kartograf kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Listig"
+      ]
+    }
+  },
+  {
+    "id": "ford28",
+    "namn": "Kommenderande stämma",
+    "beskrivning": "Rollpersonen har en väl övad stämma och kan låta den eka över slagfältets larm. Detta ger +1 på slag för Övertygande i alla lägen då rollpersonen ger direkta order till en individ eller grupp. Kommenderande stämma kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Övertygande"
+      ]
+    }
+  },
+  {
+    "id": "ford29",
+    "namn": "Manipulatör",
+    "beskrivning": "Rollpersonen är skicklig på att spela på folks känslor medelst smicker, hot eller en kombination därav. Rollpersonen får +1 i Övertygande mot en utvald person under scenen. Manipulationer tar tid att genomföra effektivt, de kräver en scen av känslospel för att nå avsedd verkan. Å andra sidan är de manipulationerna verksamma över en längre tid, den manipulerade anser att känslorna och åsikterna är dess egna och kommer försvara dem långt efter att manipulatören lämnat platsen. Manipulatör kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Övertygande"
+      ]
+    }
+  },
+  {
+    "id": "ford30",
+    "namn": "Personlig tjänare",
+    "beskrivning": "Rollpersonen har en personlig tjänare. Det kan röra sig om en anställd kalfaktor, livegen kammarpojk eller likande. Tjänaren är lojal mot rollpersonen men annars tämligen blek i termer av förmåga (svagt motstånd). Tjänaren utför enklare sysslor och kan hålla vakt nattetid eller lämna meddelanden men kommer inte att bidra i farliga situationer. Tjänaren spelas av spelledaren och bör förses med en lämplig personlighet.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": []
+    }
+  },
+  {
+    "id": "ford31",
+    "namn": "Seglivad",
+    "beskrivning": "Rollpersonen har en seg kropp och en stark själ, vilket gör att hans eller hennes hjärta fortsätter att slå där andra personers organ ger upp. En rollperson med fördelen Seglivad får alltid slå Dödsslagen med två tärningar, varefter denne väljer det mest gynnsamma resultatet.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": []
+    }
+  },
+  {
+    "id": "ford32",
+    "namn": "Skräckinjagande",
+    "beskrivning": "Rollpersonen kan konsten att vara hotfull på ett effektivt sätt och verkligen sätta skräck i folk i syfte att få dem att kortsiktigt agera enligt rollpersonens vilja. Rollpersonen får +1 i alla slag i Övertygande som gäller hot, förhör och tvång. Effekten verkar inte bortom stunden, tvärt om kommer offret att tala illa om rollpersonen då denne inte är närvarande. Skräckinjagande kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Övertygande"
+      ]
+    }
+  },
+  {
+    "id": "ford33",
+    "namn": "Snabbfotad",
+    "beskrivning": "Varelsen förflyttar sig osedvanligt snabbt. I sammanhang där en mer exakt angivelse är relevant förflyttar sig varelsen 13 meter per handling. Och i anslutning till regeln om Flykt & jakt (sidan 102) ger särdraget +3 på Kvick.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Kvick"
+      ]
+    }
+  },
+  {
+    "id": "ford34",
+    "namn": "Skvallerbytta",
+    "beskrivning": "Rollpersonen har öra och tunga för skvaller och kan samla på sig rykten och också sprida dem vidare till nya miljöer. Rollpersonen får +1 på alla slag för att höra, sprida eller inse faktabasen i alla typer av rykten. Skvallerbytta kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Listig"
+      ]
+    }
+  },
+  {
+    "id": "ford35",
+    "namn": "Skuggyngel",
+    "beskrivning": "Rollpersonen föddes under en solförmörkelse och alltsedan dess dras skuggor till rollpersonen – och tvärt om. Skuggynglet får +1 på alla slag i Diskret för att smyga och gömma sig. Skuggyngel kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Diskret"
+      ]
+    }
+  },
+  {
+    "id": "ford36",
+    "namn": "Stigfinnare",
+    "beskrivning": "Rollpersonen har en osviklig känsla för såväl markens spår som väderstreck; såväl under som över mark. Rollpersonen får en andra chans att lyckas med slag för Vaksam i syfte att följa spår och för att hitta fram – eller tillbaka – till en plats.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Vaksam"
+      ]
+    }
+  },
+  {
+    "id": "ford37",
+    "namn": "Taktisk spelare",
+    "beskrivning": "Rollpersonen får +1 på slag i Listig för att spela hasard eller taktiska spel som schack. Rollpersonen får också +1 på Vaksam för att upptäcka falskspelare. Kan kombineras med Falskspelare för ytterligare bonus. Taktisk spelare kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Listig",
+        "Vaksam"
+      ]
+    }
+  },
+  {
+    "id": "ford38",
+    "namn": "Teckentydare",
+    "beskrivning": "Rollpersonen har alltid sett tecken andra inte sett och har +1 på alla slag för ritualer som rör ödet eller som ger information: Spådomskonst, Offerrök och Orakelkonst. Teckentydare kan införskaffas flera gånger, maximalt tre gånger med +3 i bonus.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Listig"
+      ]
+    }
+  },
+  {
+    "id": "ford39",
+    "namn": "Tvillingsjäl",
+    "beskrivning": "Rollpersonen har en tvillingsjäl, antingen i den mer romantiska eller i den syskonliga meningen. Oavsett vilket kan rollpersonen kommunicera enklare meddelanden och känslor telepatiskt med sin tvillingsjäl. De vet ungefär var den andre befinner sig och om denna är i fara eller mår bra. Tvillingsjälen kan vara en för spelet viktig spelledarperson men ännu hellre en annan spelares rollperson; prata med spelgruppen om vad som passar bäst. I det senare fallet räcker det hur som helst med att en av rollpersonerna skaffar fördelen i fråga.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": []
+    }
+  },
+  {
+    "id": "ford40",
+    "namn": "Utbrytarkonstnär",
+    "beskrivning": "Rollpersonen har viga leder och har tränat sig i att utnyttja dem maximalt för att ta sig loss eller ta sig genom smala passageer; detta gäller också slag för att ta sig loss från brottargrepp eller andra fasthållningar från fällor, nät och liknande. På sådana slag får rollpersonen en andra chans att lyckas, oavsett vilket karaktärsdrag som slaget slås mot.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": []
+    }
+  },
+  {
+    "id": "ford41",
+    "namn": "Privilegierad",
+    "beskrivning": "Rollpersonen tillhör en grupp med högt anseende och tydliga fördelar inom sitt eget samhälle, men betraktas som avvikande eller misstänkt utanför detta sammanhang. Inom sitt samhälle får rollpersonen slå två gånger på sociala utmaningar och välja det bästa utfallet. Men i främmande miljöer där den egna gruppen är ovanlig måste rollpersonen istället slå två gånger på sociala utmaningar mot lokalbefolkningen och ta det sämsta resultatet. Rollpersonen börjar spelet med 50 daler i bältesbörsen. Pengarna läggs till i inventariet automatiskt.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        ""
+      ]
+    }
+  },
+  {
+    "id": "ford42",
+    "namn": "Kontaktnät",
+    "beskrivning": "Rollpersonen har tjänat i en vidsträckt organisation eller färdats vida kring och på så sätt byggt upp ett vidsträckt kontaktnät. Rollpersonen kan med ett lyckat Övertygande dra sig till minnes en kontakt som borde kunna hjälpa till i en specifik fråga eller prekär situation. Kontakten måste inte finnas direkt tillgänglig - det beror på vilka kontaktnätet omfattar. Exempel på fraktioner och folk som kan användas som avgränsning är: Drottningens armé, Drottningens jägarkår, Häxor, Ordo Magica, Prios kyrka, Riddarhusen och Skattletare.",
+    "kan_införskaffas_flera_gånger": false,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Övertygande"
+      ]
+    }
+  },
+  {
+    "id": "ford43",
+    "namn": "Vildmarksvana",
+    "beskrivning": "Personen kan tyda vildmarkens tecken, vet vilka områden som bör undvikas och är van att hitta mat, föda och skydd i ogästvänliga miljöer. Under förflyttningar i vildmark eller ruiner kan personen med ett lyckat Vaksam skörda 1t6 ransoner mat och vatten per dygn, eller 1t10 ransoner om allt fokus läggs på det (ingen förflyttning). Vildmarksvana kan införskaffas flera gånger och då vara användbar i allt ogästvänligare miljöer. Nivå I motsvarar Ljusa Davokar och bergskedjornas ytterområden; nivå II Vilda Davokar och bergens djupa dalar; nivå III Mörka Davokar och Undervärlden (spelledaren avgör). Notera att en person måste ha befunnit sig en längre tid i de mer krävande miljöerna för att få tillgodogöra sig högre nivåer i fördelen.",
+    "kan_införskaffas_flera_gånger": true,
+    "taggar": {
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [],
+      "test": [
+        "Vaksam"
+      ]
+    }
+  },
+  {
+    "id": "ford44",
     "namn": "Prios Barn",
     "beskrivning": "Kan väljas upp till tre gånger. Karaktären är djupt troende och bär Prios ljus med sig även i de mörkaste tider. För varje nivå av denna fördel får karaktären +1 i försvar mot attacker och effekter från genomkorrumperade varelser. Om karaktären bryter med Prios eller går över sin korruptionströskel under spelets gång, blir Prios Barn automatiskt till nackdelen Prios Förtappad av samma grad som Prios Barn är vald till.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
-      "ark_trad": ["Mystiker"],
-      "test": ["Försvar"]
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Försvar"
+      ]
     }
   },
   {
+    "id": "ford45",
     "namn": "Prios Tecken",
     "beskrivning": "Karaktären bär tydliga kännetecken av Prios välsignelse, vilket märks i en utstrålning av ett diskret ljus omkring hen. När karaktären interagerar med personer som är troende får hen +1 på övertygande. Detsamma gäller vid försök att övertyga kättare eller tveksamma om religiösa frågor. Om karaktären vänder sig bort från Prios eller överskrider sin korruptionströskel, ersätts denna fördel med nackdelen Fallen Stjärna.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
-      "ark_trad": ["Mystiker"],
-      "test": ["Övertygande"]
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Övertygande"
+      ]
     }
   },
   {
+    "id": "ford46",
     "namn": "Prisjakt",
     "beskrivning": "Karaktären är uppvuxen bland köpmän och försäljare och lärt sig konsten att förhandla till sig ett bra pris. Vare sig det är att se skavanker på ett fullgott svärd eller ge någon tron om att detta är dennes livs affär har karaktären en otrolig känsla för en bra affär. Prisjakt ger karaktären +1 i övertygande vid förhandlande om pris av vara eller tjänst. Kan införskaffas 3 gånger.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Övertygande"]
+      "test": [
+        "Övertygande"
+      ]
     }
   },
   {
+    "id": "ford47",
     "namn": "Asketisk",
     "beskrivning": "Karaktären och dess kropp är som ett tempel. Genom ett liv som kretsat kring överlevnad och förnödenheterna som möjliggör det, vare sig det är i stadens slum eller långt ute i skogen har karaktären lärt sig att mat är en resurs som används sparsamt. Karaktären behöver bara hälften så mycket mat i dagligt intag. Undantaget om rollpersonen är skadad eller har nedsatt förmåga på något sätt.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "ford48",
     "namn": "Lyckosam",
     "beskrivning": "Karaktärens liv har av outgrundliga anledningar alltid gått bra. Kniviga situationer har löst sig och rätt vindar har blåst. Regnet har slutat ösa ner lagom till att elden ska göras och ja, ett tursamt liv har levts. Karaktären kan en gång per äventyr (eller så ofta som spelledaren tillåter) slå om ett slag där utfallet inte blev som karaktären ville och använda det bästa resultatet. Denna fördel kan bara införskaffas en gång.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "ford49",
     "namn": "Skattöga",
     "beskrivning": "Man skulle nästan kunna tro att personens ögon har färgen av daler. För när det kommer till skattletande så har karaktären ett för att veta precis vart man ska gräva eller leta. När ett slag ska göras på fyndtabellen får karaktären lägga till +1 på utfallet, vilket ökar chansen att hitta något värdefullt eller sällsynt. Denna fördel kan väljas upp till 3 gånger.",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "ford50",
     "namn": "Välutrustad",
     "beskrivning": "En karaktär med välutrustad är ingen nybörjare. Det här är en som varit med ett tag och vet vad som krävs av ett äventyr, alternativt fått information av erfarna skattletare om vad som behövs. Karaktären börjar alla äventyr med i sin packning utöver standard: 3× 10 meter rep, Papper, kritor, 3 facklor, 1 signalhorn. Dessa föremål läggs automatiskt till i inventariet.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "ford51",
     "namn": "Råstyrka",
     "beskrivning": "(Endast tillgänglig för karaktärer med särdraget Robust) Som dom giganterna dom är, kommer därtill oftast och en styrka som om hämtad direkt ur svartekarnas växtkraft i Davokars djup. Karaktären får i alla slag mot Stark utanför strid lägga till +2 för varje nivå i Robust som denne besitter.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Stark"]
+      "test": [
+        "Stark"
+      ]
     }
   },
   {
+    "id": "ford52",
     "namn": "Tvådelad tunga",
     "beskrivning": "Om det så var genom uppväxten eller genom studier så har karaktären lärt sig ett andra språk. Tex Barbariska, Svartalfmål, eller det snirkliga språket av dvärgar. Mer komplicerade språk är undantaget, då det kräver för stor visdom att behärska utan genomgående studier (lärd på gesällnivå eller uppåt).",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "ford53",
     "namn": "Teckenspråk",
     "beskrivning": "Karaktären behärskar ett välutvecklat system av tecken och gester som kan användas för att samtala utan ord. Om två eller fler karaktärer besitter denna fördel kan de kommunicera ljudlöst och diskret på avstånd, så länge de har fri sikt till varandra. Detta gör det möjligt att utbyta information, ge varningar eller koordinera handlingar utan att avslöja sig genom tal.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
       "test": []
     }
   },
   {
+    "id": "ford54",
     "namn": "Kvickfotad",
     "beskrivning": "Karaktären är ovanligt snabb och smidig i sina rörelser, vilket gör det svårt för motståndare med stora, långsamma vapen att träffa. Karaktären får +1 i försvar mot närstridsattacker som utförs med tunga vapen.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Försvar"]
+      "test": [
+        "Försvar"
+      ]
     }
   },
   {
+    "id": "ford55",
     "namn": "Lansvrängare",
     "beskrivning": "Karaktären har lärt sig att utnyttja svagheterna hos motståndare som använder långa vapen, som spjut, lansar eller stavar. Genom att snabbt förflytta sig in på trångt avstånd och störa rytmen hos den som försöker hålla distans, får karaktären +1 i försvar mot närstridsattacker med vapen som har kvaliteten långt.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Försvar"]
+      "test": [
+        "Försvar"
+      ]
     }
   },
   {
+    "id": "ford56",
     "namn": "Hököga",
     "beskrivning": "Genom snabb reaktionsförmåga och god uppsikt är karaktären skicklig på att upptäcka och undvika projektiler och kastvapen. Karaktären får +1 i försvar mot distansattacker såsom pilar, kastspjut eller andra avståndsvapen.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Försvar"]
+      "test": [
+        "Försvar"
+      ]
     }
   },
   {
+    "id": "ford57",
     "namn": "Fäktarmästare",
     "beskrivning": "Karaktären är särskilt bra på att parera och undvika snabba, precisa slag från enhandsvapen. Karaktären får +1 i försvar mot närstridsattacker med ett enhandsvapen.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Försvar"]
+      "test": [
+        "Försvar"
+      ]
     }
   },
   {
+    "id": "ford58",
     "namn": "Virvelväktare",
     "beskrivning": "Med ovanlig kontroll och blick för rörelsemönster kan karaktären läsa och undvika komplexa anfall, även när en fiende slåss med två vapen. Karaktären får +1 i försvar mot närstridsattacker från motståndare som använder två vapen samtidigt.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Försvar"]
+      "test": [
+        "Försvar"
+      ]
     }
   },
   {
+    "id": "ford59",
     "namn": "Stålsatt Vilja",
     "beskrivning": "Karaktären har tränat upp sin mentala motståndskraft och är svår att rubba med mystiska krafter. Vid försvar mot anfall eller påverkan från magi, ritualer eller andra övernaturliga effekter får karaktären +1 på Viljestark.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
-      "ark_trad": ["Mystiker"],
-      "test": ["Viljestark"]
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Viljestark"
+      ]
     }
   },
   {
+    "id": "ford60",
     "namn": "Defensiv hållning",
     "beskrivning": "Karaktären är van att kämpa ur underläge och har utvecklat en naturlig förmåga att skydda sig när oddsen är emot hen. När karaktären möter en motståndare som har övertag, till exempel på grund av position, överraskning eller numerärt överläge, får karaktären +1 i försvar mot deras attacker.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
+      "typ": [
+        "Fördel"
+      ],
       "ark_trad": [],
-      "test": ["Försvar"]
+      "test": [
+        "Försvar"
+      ]
     }
   },
   {
+    "id": "ford61",
     "namn": "Motståndskraft",
     "beskrivning": "Karaktären har tränat sin vilja att utstå mörkrets inflytande. Karaktärens korruptionströskel ökar med +1 per gång fördelen är vald (max +3).",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-      "typ": ["Fördel"],
-      "ark_trad": ["Mystiker"],
-      "test": ["Viljestark"]
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Viljestark"
+      ]
     }
   },
   {
+    "id": "ford62",
     "namn": "Smärttålig",
     "beskrivning": "Karaktären har härdat kropp och sinne att uthärda smärta. Karaktärens smärtgräns ökar med +1 per gång fördelen väljs (max +3).",
     "kan_införskaffas_flera_gånger": true,
     "taggar": {
-        "typ": ["Fördel"],
-        "ark_trad": ["Krigare"],
-        "test": []
-      }
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Krigare"
+      ],
+      "test": []
+    }
   },
   {
+    "id": "ford63",
     "namn": "Hårdnackad",
     "beskrivning": "Karaktären har vant kroppen vid slag, kyla och svält. Karaktärens totala Tålighet ökar med +1.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
-      "ark_trad": ["Krigare"],
-      "test": ["Stark"]
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Krigare"
+      ],
+      "test": [
+        "Stark"
+      ]
     }
   },
   {
+    "id": "ford64",
     "namn": "Själastark",
     "beskrivning": "Karaktären bär en större själslig motståndskraftl mot korruptionens märken. Max korruption ökar med +1. Korruptionströskeln påverkas inte av detta.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
-      "typ": ["Fördel"],
-      "ark_trad": ["Mystiker"],
-      "test": ["Viljestark"]
+      "typ": [
+        "Fördel"
+      ],
+      "ark_trad": [
+        "Mystiker"
+      ],
+      "test": [
+        "Viljestark"
+      ]
     }
   }
-
 ]


### PR DESCRIPTION
## Summary
- add sequential `id` fields (`ford1`..`ford64`) to each entry in `data/fordel.json`
- verify that all IDs are unique

## Testing
- `for t in tests/*.test.js; do node $t; done`
- `node -e 'const fs=require("fs"); const data=JSON.parse(fs.readFileSync("data/fordel.json","utf8")); const ids=data.map(x=>x.id); console.log(ids.length, new Set(ids).size);'`


------
https://chatgpt.com/codex/tasks/task_e_688f56317a1c8323ac3ed810b4793806