### PR TITLE
Add IDs to fallor entries

### DIFF
--- a/data/fallor.json
+++ b/data/fallor.json
@@ -1,5 +1,6 @@
 [
   {
+    "id": "fal1",
     "namn": "Svag Alkemisk mina",
     "taggar": {
       "typ": ["Elixir", "Fälla"]
@@ -10,6 +11,7 @@
     "grundpris": { "daler": 2, "skilling": 0, "örtegar": 0 }
   },
   {
+    "id": "fal2",
     "namn": "Medelstark Alkemisk mina",
     "taggar": {
       "typ": ["Elixir", "Fälla"]
@@ -20,6 +22,7 @@
     "grundpris": { "daler": 4, "skilling": 0, "örtegar": 0 }
   },
   {
+    "id": "fal3",
     "namn": "Stark Alkemisk mina",
     "taggar": {
       "typ": ["Elixir", "Fälla"]
@@ -30,6 +33,7 @@
     "grundpris": { "daler": 8, "skilling": 0, "örtegar": 0 }
   },
   {
+    "id": "fal4",
     "namn": "Svag Mekanisk fälla",
     "taggar": {
       "typ": ["Fälla"]
@@ -40,6 +44,7 @@
     "grundpris": { "daler": 1, "skilling": 0, "örtegar": 0 }
   },
   {
+    "id": "fal5",
     "namn": "Medelstark Mekanisk fälla",
     "taggar": {
       "typ": ["Fälla"]
@@ -50,6 +55,7 @@
     "grundpris": { "daler": 2, "skilling": 0, "örtegar": 0 }
   },
   {
+    "id": "fal6",
     "namn": "Stark Mekanisk fälla",
     "taggar": {
       "typ": ["Fälla"]


### PR DESCRIPTION
## Summary
- assign unique IDs to each fallor dataset entry for consistent referencing

## Testing
- `node -e "const fs=require('fs'); const d=JSON.parse(fs.readFileSync('data/fallor.json','utf8')); const ids=d.map(o=>o.id); console.log(ids); console.log('unique', new Set(ids).size === ids.length);"`
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_688f561e47348323ad2a1261a2094a17