### PR TITLE
Add IDs to dryck.json

### DIFF
--- a/data/dryck.json
+++ b/data/dryck.json
@@ -11,7 +11,8 @@
       "daler": 0,
       "skilling": 0,
       "örtegar": 3
-    }
+    },
+    "id": "dr1"
   },
   {
     "namn": "Vin (stad)",
@@ -25,7 +26,8 @@
       "daler": 0,
       "skilling": 3,
       "örtegar": 0
-    }
+    },
+    "id": "dr2"
   },
   {
     "namn": "Öl (landet)",
@@ -39,7 +41,8 @@
       "daler": 0,
       "skilling": 0,
       "örtegar": 2
-    }
+    },
+    "id": "dr3"
   },
   {
     "namn": "Öl (stad)",
@@ -53,139 +56,337 @@
       "daler": 0,
       "skilling": 2,
       "örtegar": 0
-    }
+    },
+    "id": "dr4"
   },
-
   {
     "namn": "Bordsdricka (svag stut)",
     "beskrivning": "Lättare variant av stut – mild maltig smak till vardagsmat.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 0, "örtegar": 1 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 1
+    },
+    "id": "dr5"
   },
   {
     "namn": "Flaska Blot (glödgat vin)",
     "beskrivning": "Kryddat, värmt rödvin som serveras ångande under kyliga kvällar.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 3, "skilling": 0, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 3,
+      "skilling": 0,
+      "örtegar": 0
+    },
+    "id": "dr6"
   },
   {
     "namn": "Flaska Ludendrank (glödgat vin)",
     "beskrivning": "Sötare glödgat vin smaksatt med kanel och honung.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 2, "skilling": 0, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 2,
+      "skilling": 0,
+      "örtegar": 0
+    },
+    "id": "dr7"
   },
   {
     "namn": "Flaska rödvin",
     "beskrivning": "En enkel rödvinsbutelj av okänd vingård.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 1, "skilling": 0, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 1,
+      "skilling": 0,
+      "örtegar": 0
+    },
+    "id": "dr8"
   },
   {
     "namn": "Flaska vitt vin",
     "beskrivning": "Ljust vin med frisk syra, ursprung ej angivet.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 1, "skilling": 0, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 1,
+      "skilling": 0,
+      "örtegar": 0
+    },
+    "id": "dr9"
   },
   {
     "namn": "Flaska Söderns sluttning",
     "beskrivning": "Fylligt vin från Alberetors soliga terrasser – rik fruktighet och lång eftersmak.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 15, "skilling": 0, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 15,
+      "skilling": 0,
+      "örtegar": 0
+    },
+    "id": "dr10"
   },
   {
     "namn": "Flaska Vearras röda",
     "beskrivning": "Basvin från Vearra – rustik smak, passar till kraftigare rätter.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 2, "skilling": 0, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 2,
+      "skilling": 0,
+      "örtegar": 0
+    },
+    "id": "dr11"
   },
   {
     "namn": "Kanna Vesa",
     "beskrivning": "Blandning av kärnmjölk och getvassla, friskt och omtyckt av alla klaner när man vant sig.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 0, "örtegar": 4 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 4
+    },
+    "id": "dr12"
   },
   {
     "namn": "Stop beckjom",
     "beskrivning": "Barbarernas mustiga öl med kvalitet från fuljom till klanen Zareks bättre brygd.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 0, "örtegar": 1 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 1
+    },
+    "id": "dr13"
   },
   {
     "namn": "Stop stut",
     "beskrivning": "Den vanligaste öltypen i Ambria – enkel och prisvärd.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 0, "örtegar": 3 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 3
+    },
+    "id": "dr14"
   },
   {
     "namn": "Stop Adersel (trippeljäst öl)",
     "beskrivning": "Starkt trippeljäsning ger fyllig maltighet och lång eftersmak.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 8, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 8,
+      "örtegar": 0
+    },
+    "id": "dr15"
   },
   {
     "namn": "Stop Argona (fin stut)",
     "beskrivning": "Stut av högre klass bryggd av ätten Argona – klar, rund smak.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 2, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 2,
+      "örtegar": 0
+    },
+    "id": "dr16"
   },
   {
     "namn": "Stop Hertigens tröst",
     "beskrivning": "Enkel stut som värmer gott efter långa resor.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 1, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 1,
+      "örtegar": 0
+    },
+    "id": "dr17"
   },
   {
     "namn": "Stop Kuruns ära (trippeljäst)",
     "beskrivning": "Kraftig trippeljäsning med fyllig karamellton.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 5, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 5,
+      "örtegar": 0
+    },
+    "id": "dr18"
   },
   {
     "namn": "Stop Urtal (trippeljäst rödöl)",
     "beskrivning": "Rödskimrande öl med kraftfull maltprofil och tre jäsningar.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 3, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 3,
+      "örtegar": 0
+    },
+    "id": "dr19"
   },
   {
     "namn": "Stop Veloum (barbarmust)",
     "beskrivning": "Ljusare öl sort från norr om Karvosti – svagare än beckjom men smakrik.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 2, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 2,
+      "örtegar": 0
+    },
+    "id": "dr20"
   },
   {
     "namn": "Stop Zarekisk beckjom",
     "beskrivning": "Beckjom bryggd av klanen Zarek – den mest uppskattade varianten.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 1, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 1,
+      "örtegar": 0
+    },
+    "id": "dr21"
   },
-  
   {
     "namn": "Fruktte",
     "beskrivning": "Brygd på torkad frukt som ger söt, bärig arom.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 1, "örtegar": 0 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 1,
+      "örtegar": 0
+    },
+    "id": "dr22"
   },
   {
     "namn": "Järnekste",
     "beskrivning": "Piggande te på järneksblad med stram beska.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 0, "örtegar": 8 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 8
+    },
+    "id": "dr23"
   },
   {
     "namn": "Kryddte",
     "beskrivning": "Svart blad samsas med kanel och nejlika i värmande kopp.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 0, "örtegar": 1 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 1
+    },
+    "id": "dr24"
   },
   {
     "namn": "Rökt te",
     "beskrivning": "Te vars blad rökts över tallved, ger kraftig smak och doft.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 0, "örtegar": 4 }
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 4
+    },
+    "id": "dr25"
   },
   {
     "namn": "Örtte",
     "beskrivning": "Mild brygd på ängsörter, lugnande och aromatisk.",
-    "taggar": { "typ": [ "Dryck" ] },
-    "grundpris": { "daler": 0, "skilling": 0, "örtegar": 2 }
-  }]
+    "taggar": {
+      "typ": [
+        "Dryck"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 2
+    },
+    "id": "dr26"
+  }
+]


### PR DESCRIPTION
## Summary
- Add sequential `dr` IDs to every drink entry in `dryck.json` for easier referencing

## Testing
- `jq '.[].id' data/dryck.json | sort | uniq -d`
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_688f5600452c8323a4c16416a0c29d57