### PR TITLE
Use stable entry IDs for character import/export

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -100,7 +100,10 @@ const DATA_FILES = [
 Promise.all(DATA_FILES.map(f => fetch(f).then(r => r.json())))
   .then(arrays => {
     DB = arrays.flat().sort(sortByType);
-    DB.forEach((ent, idx) => { ent.id = idx; });
+    DB.forEach((ent, idx) => {
+      if (ent.id === undefined) ent.id = idx;
+      DB[ent.id] = ent;
+    });
     window.DB = DB;
     DBIndex = {};
     DB.forEach(ent => { DBIndex[ent.namn] = ent; });

--- a/js/store.js
+++ b/js/store.js
@@ -836,7 +836,7 @@ function defaultTraits() {
 
   function expandList(list) {
     return (list || []).map(it => {
-      if (it && typeof it.i === 'number' && window.DB && window.DB[it.i]) {
+      if (it && it.i !== undefined && window.DB && window.DB[it.i]) {
         const base = { ...window.DB[it.i] };
         if (it.l) base.nivå = it.l;
         if (it.t) base.trait = it.t;
@@ -880,7 +880,7 @@ function defaultTraits() {
 
   function expandInventory(inv) {
     return (inv || []).map(row => {
-      if (row && typeof row.i === 'number' && window.DB && window.DB[row.i]) {
+      if (row && row.i !== undefined && window.DB && window.DB[row.i]) {
         const name = window.DB[row.i].namn;
         return {
           name,


### PR DESCRIPTION
## Summary
- Preserve unique entry IDs when loading the database
- Expand exported lists and inventories using ID lookups for compatibility

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_688f59dd489c8323bdfec56425500138