### PR TITLE
Show Sjätte sinne usage notes for Vaksam

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -166,6 +166,8 @@
     const sensCount   = list.filter(p => p.namn === 'Korruptionskänslig').length;
     const hasDarkPast = list.some(p => p.namn === 'Mörkt förflutet');
 
+    const sixthSenseLvl = storeHelper.abilityLevel(list, 'Sjätte sinne');
+
     const defTrait = getDefenseTraitName(list);
     const defs = calcDefense(vals[defTrait]);
 
@@ -195,6 +197,13 @@
         let perm = hasEarth ? (permBase % 2) : permBase;
         if (hasDarkPast) perm += Math.ceil(thresh / 3);
         extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` + `<div class="trait-extra">Maximal korruption: ${maxCor} • Korruptionströskel: ${thresh}</div>`;
+      }
+      if (k === 'Vaksam') {
+        if (sixthSenseLvl >= 3) {
+          extra += `<div class="trait-extra">Används som träffsäker</div>`;
+        } else if (sixthSenseLvl >= 1) {
+          extra += `<div class="trait-extra">Används som träffsäker för attacker med avståndsvapen</div>`;
+        }
       }
       if (k === defTrait) {
         const defHtml = defs.map(d => `<div class="trait-extra">Försvar${d.name ? ' (' + d.name + ')' : ''}: ${d.value}</div>`).join('');


### PR DESCRIPTION
## Summary
- display note for Vaksam when Sjätte sinne is known
- master level uses Vaksam as full Träffsäker, novice level for ranged attacks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f6914424483238ce6389e94b5e56f