### PR TITLE
visa taktikernotering i listig

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -200,6 +200,9 @@
         const defHtml = defs.map(d => `<div class="trait-extra">Försvar${d.name ? ' (' + d.name + ')' : ''}: ${d.value}</div>`).join('');
         extra += defHtml;
       }
+      if (k === 'Listig' && storeHelper.abilityLevel(list, 'Taktiker') >= 3) {
+        extra += '<div class="trait-extra">Används som träffsäker för attacker med allt utom tunga vapen</div>';
+      }
       return `
       <div class="trait" data-key="${k}">
         <div class="trait-name">${k}</div>


### PR DESCRIPTION
## Summary
- visa info om att listig kan fungera som träffsäker med taktiker på mästarnivå

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688f693d1edc8323978dcfd20ad6e67c