### PR TITLE
Display Lönnstöt note for Diskret trait

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -196,6 +196,9 @@
         if (hasDarkPast) perm += Math.ceil(thresh / 3);
         extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` + `<div class="trait-extra">Maximal korruption: ${maxCor} • Korruptionströskel: ${thresh}</div>`;
       }
+      if (k === 'Diskret' && storeHelper.abilityLevel(list, 'Lönnstöt') >= 1) {
+        extra += '<div class="trait-extra">Används som träffsäker för attacker med Övertag</div>';
+      }
       if (k === defTrait) {
         const defHtml = defs.map(d => `<div class="trait-extra">Försvar${d.name ? ' (' + d.name + ')' : ''}: ${d.value}</div>`).join('');
         extra += defHtml;


### PR DESCRIPTION
## Summary
- show a note in the Diskret trait when Lönnstöt is known

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f68be24888323aa4deeb5cb7e5fec