### PR TITLE
Visa dominera-effekt för övertygande

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -196,6 +196,9 @@
         if (hasDarkPast) perm += Math.ceil(thresh / 3);
         extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` + `<div class="trait-extra">Maximal korruption: ${maxCor} • Korruptionströskel: ${thresh}</div>`;
       }
+      if (k === 'Övertygande' && storeHelper.abilityLevel(list, 'Dominera') >= 1) {
+        extra += '<div class="trait-extra">Används som träffsäker för attacker i närstrid</div>';
+      }
       if (k === defTrait) {
         const defHtml = defs.map(d => `<div class="trait-extra">Försvar${d.name ? ' (' + d.name + ')' : ''}: ${d.value}</div>`).join('');
         extra += defHtml;


### PR DESCRIPTION
## Summary
- Lägg till text i rutan Övertygande när förmågan Dominera på Novis-nivå är vald

## Testing
- `npm test` *(misslyckades: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f681eebe483238411cc5de96e9808