### PR TITLE
Disable stacking for monstrous traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Både i index-vyn och i din karaktär visas poster som kort.
 - **↔** finns på artefakter och växlar dess effekt mellan att ge 1 XP eller permanent korruption.
 - **🗑** tar bort posten helt.
 - Monstruösa särdrag som blir gratis via Hamnskifte eller Blodvadare ger ett val mellan Humanoid eller Hamnskifte (−10 XP) när de läggs till.
-- Naturligt vapen, Pansar, Regeneration och Robust kan tas högst två gånger med Hamnskifte (annars en gång) och visas som separata poster.
+- Naturligt vapen, Pansar, Regeneration och Robust kan bara tas en gång och visas som separata poster.
+- Monstruösa särdrag kan inte staplas.
 
 ### 8. Export och import
 Se avsnittet ovan. Exportera kopierar all data för karaktären som en sträng i urklipp. Importera klistrar in en tidigare sträng och återställer karaktären. All data sparas i webblagring så inget backend behövs.

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -69,10 +69,9 @@ function initCharacter() {
 
   const renderSkills = arr=>{
     const groups = [];
-    const hamNames = Object.values(storeHelper.HAMNSKIFTE_NAMES);
     arr.forEach(p=>{
-        const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
-        if(multi && !['Naturligt vapen','Pansar','Regeneration','Robust', ...hamNames].includes(p.namn)){
+        const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
+        if(multi){
           const g = groups.find(x=>x.entry.namn===p.namn);
           if(g) { g.count++; return; }
           groups.push({entry:p, count:1});
@@ -111,7 +110,7 @@ function initCharacter() {
       li.dataset.name=p.namn;
       if(p.trait) li.dataset.trait=p.trait;
       if(p.trait) li.dataset.trait=p.trait;
-      const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
+      const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
         const total = storeHelper.getCurrentList(store).filter(x=>x.namn===p.namn && !x.trait).length;
         const limit = storeHelper.monsterStackLimit(storeHelper.getCurrentList(store), p.namn);
         const badge = g.count>1 ? ` <span class="count-badge">×${g.count}</span>` : '';
@@ -201,7 +200,7 @@ function initCharacter() {
     const before = storeHelper.getCurrentList(store);
     const p = DB.find(x=>x.namn===name) || before.find(x=>x.namn===name);
     if(!p) return;
-    const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !tr;
+    const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !tr;
     let list;
         if(actBtn.dataset.act==='add'){
           if(!multi) return;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -112,7 +112,7 @@ function initIndex() {
         }
       }
       const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
-        const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
+        const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         const count = charList.filter(c => c.namn===p.namn && !c.trait).length;
         const limit = storeHelper.monsterStackLimit(charList, p.namn);
         const badge = multi && count>0 ? ` <span class="count-badge">×${count}</span>` : '';
@@ -376,7 +376,7 @@ function initIndex() {
           });
           return;
         }
-        const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
+        const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         if(multi){
           const cnt = list.filter(x=>x.namn===p.namn && !x.trait).length;
           const limit = storeHelper.monsterStackLimit(list, p.namn);
@@ -451,7 +451,7 @@ function initIndex() {
           }
         }
         let list;
-        const multi = isMonstrousTrait(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
+        const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         if(multi){
           let removed=false;
           list = [];

--- a/js/store.js
+++ b/js/store.js
@@ -647,16 +647,6 @@ function defaultTraits() {
     const base = HAMNSKIFTE_BASE[name] || name;
     const entry = window.DBIndex?.[base];
     if (!entry || !isMonstrousTrait(entry)) return 3;
-    const hamlvl = abilityLevel(list, 'Hamnskifte');
-
-    if (['Naturligt vapen', 'Pansar'].includes(base)) {
-      return hamlvl >= 2 ? 2 : 1;
-    }
-
-    if (['Regeneration', 'Robust'].includes(base)) {
-      return hamlvl >= 3 ? 2 : 1;
-    }
-
     return 1;
   }
 


### PR DESCRIPTION
## Summary
- prevent all monstrous traits from stacking
- handle Hamnskifte-related traits as normal single entries
- document that monstrous traits and Hamnskifte bonuses are non-stackable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f6a3656a883238966a0fafbcfa0f1