### PR TITLE
Matcha XP-negativ färg med övermax drag

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -328,7 +328,7 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
 .exp-counter { font-weight: 500; }
 
 /* Rödmarkering för negativa värden */
-.exp-counter.under { color: #ffb0b0; }
+.exp-counter.under { color: #ff4040; }
 .exp-counter.under span { color: inherit; }
 
 


### PR DESCRIPTION
## Sammanfattning
- Byt färg på negativ erfarenhet till samma röda nyans som används när karaktärsdrag överstiger maxvärden.

## Testning
- `npm test` *(misslyckades: paket saknas)*

------
https://chatgpt.com/codex/tasks/task_e_688f7278432883238f53b12944b88a34