### PR TITLE
Move overview button beside character name

### DIFF
--- a/character.html
+++ b/character.html
@@ -24,16 +24,16 @@
 </head>
 <body data-role="character">
 
-  <!-- Översiktsknapp -->
-  <button id="summaryToggle" class="char-btn icon summary-btn" title="Visa översikt">📋</button>
-
   <h1 class="app-title">ROLLPERSON</h1>
 
   <div id="activeFilters" class="tags"></div>
 
   <!-- Panel för valda förmågor / krafter -->
   <div class="panel">
-    <h2 id="charName" style="margin-top:0;"></h2>
+    <div class="panel-header">
+      <h2 id="charName" style="margin:0;"></h2>
+      <button id="summaryToggle" class="char-btn icon summary-btn" title="Visa översikt">📋</button>
+    </div>
     <ul id="valda" class="card-list"></ul>
   </div>
 

--- a/css/style.css
+++ b/css/style.css
@@ -81,10 +81,7 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 
 /* Knapp för översiktsmeny */
 .summary-btn {
-  position: fixed;
-  top: 1rem;
-  right: 1rem;
-  z-index: 1100;
+  margin-left: auto;
 }
 
 /* Innehåll i översiktspanel */
@@ -174,6 +171,13 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   width: 100%;
   max-width: 520px;
   box-shadow: var(--shadow);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: .8rem;
 }
 
 /* ---------- Input/Select ---------- */


### PR DESCRIPTION
## Summary
- Position the overview toggle next to the character name within the entries panel
- Add flex header styling for character panel

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f72bfa0948323b42893146c9d14eb