### PR TITLE
Annotate action types for abilities and traits

### DIFF
--- a/data/formaga.json
+++ b/data/formaga.json
@@ -12,7 +12,18 @@
       ],
       "test": [
         "Kvick"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Rollpersonen får slå mot Kvick för att undvika att dra på sig frislag från fiender i närstrid. Det gäller både vid passage av fiender eller för att dra sig ur en närstrid med en fiende. Om slaget misslyckas kan spelaren välja att antingen bli kvar eller att förflytta sig i alla fall, och då ådra sig ett frislag på vanligt vis.",
@@ -33,7 +44,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Speciell. Rollpersonen kan använda Listig för att samla in örter och mineraler för att skapa en dos av ett noviselixir. Insamlandet av ingredienser och bryggandet tar en hel dag i ett ordentligt laboratorie och två dagar i fält oavsett om slaget lyckas eller ej. Rollpersonen får också en gång per äventyr slå för att ha förberett ett specifikt elixir upp till novisnivå i förväg, även om hen inte har uttryckt sig ha gjort detta i ett tidigare skede.",
@@ -51,7 +73,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Rollpersonen kan som en fri handling gå in helt för att skada och gör då +1T6 i extra skada med sina närstridsattacker. Nackdelen är att rollpersonen försvarar sig illa. Det karaktärsdrag som Försvar baseras på räknas som 5 avseende Försvar.",
@@ -72,7 +105,18 @@
       ],
       "test": [
         "Övertygande"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Rollpersonen kan med sin överväldigande personlighet dominera en fiende i strid. Rollpersonen kan använda Övertygande istället för Träffsäker i närstrid.",
@@ -90,7 +134,18 @@
       ],
       "ark_trad": [
         "Krigare, Mystiker, Tjuv"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Speciell. Rollpersonen har strävsamt odlat ett av sina karaktärsdrag, vilket ger +1 i Karaktärsdraget.",
@@ -111,7 +166,18 @@
       ],
       "test": [
         "Diskret"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Rollpersonen kan välja att anfalla med Diskret istället för med Träffsäker, när anfallet sker med ett Kort eller Precist närstridsvapen.",
@@ -132,7 +198,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Rollpersonen kan som en fri handling applicera en dos gift eller annat alkemiskt elixir på ett vapen. En dos räcker till en träff med vapnet, sedan måste mer av elixiret appliceras. Ett slag mot [Listig←Stark] behövs för att giftet ska ha effekt; om det lyckas börjar offret ta skada. Hur mycket skada ett gift gör per runda och hur länge det verkar beror på giftets styrka (se sidan 153).",
@@ -150,7 +227,18 @@
       ],
       "ark_trad": [
         "Mystiker, Häxkonst"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Speciell. Häxan har lärt sig grunderna i häxkonsten och vet hur att skydda sig mot de mörkare inslagen i läran. Häxan får ingen permanent korruption av att lära sig häxkonstens krafter till novisnivå, och inte heller av att lära sig häxkonstens ritualer. Däremot har novisen inget skydd mot den temporära korruption som följer av att använda krafter och ritualer.",
@@ -171,7 +259,18 @@
       ],
       "test": [
         "Vaksam"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Rollpersonen får som en fri handling slå [Vaksam←Diskret] för att försöka se en varelses, plats eller ett föremåls tydligaste skugga. Varje försök sker till en kostnad av 1 temporär Korruption.",
@@ -192,7 +291,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Rollpersonen kan utnyttja sin styrka till fullo och använda Stark istället för Träffsäker när den anfaller i närstrid.",
@@ -213,7 +323,18 @@
       ],
       "test": [
         "Övertygande"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Rollpersonens starka personlighet gör att denne får använda Övertygande istället för Viljestark, exempelvis vid användandet av mystiska krafter, dock inte som grund för korruptionströskel.",
@@ -234,7 +355,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Rollpersonen kan med ett lyckat Viljestark ta de slag som träffar en närbelägen allierad. Rollpersonen får ej försvara sig, attackerna träffar automatiskt.",
@@ -255,7 +387,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Rollpersonen har en grundlig skolning; med ett lyckat slag mot Listig kan denne lista ut vad en artefakt har för egenskaper och krafter. På samma sätt kan novisen med ett lyckat Listig översätta en text eller förstå vad som sägs på ett annat mänskligt språk. Att uttala enklare fraser på andra mänskliga språk kräver inget slag, men för att konversera krävs ett lyckat slag i Listig.",
@@ -276,7 +419,18 @@
       ],
       "test": [
         "Diskret"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. En attack per runda som görs i Övertag gör 1T4 extra skada, utöver den extra skada som övertaget redan ger. Rollpersonen kan välja att använda Diskret i stället för Träffsäker för attacker i Övertag. Lönnstöt kan endast göras en gång per runda, oavsett andra förhållanden.",
@@ -297,7 +451,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Rollpersonen är en habil fältskär och kan med ett lyckat slag i Listig ge 1T6 Tålighet tillbaka till patienten, eller 1T8 Tålighet om en örtkur används. Förmågan kan endast användas två gånger per patient och dag.",
@@ -318,7 +483,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Rollpersonen har studerat monster och kan med ett lyckat slag i Listig känna igen och dra sig till minnes styrkor och svagheter för ett monster per runda. Spelledaren berättar för spelaren om varelsens beskrivning och värden.",
@@ -336,7 +512,18 @@
       ],
       "ark_trad": [
         "Krigare, Tjuv"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Rollpersonen har lärt sig att utnyttja sin medfödda stridsförmåga på ett effektivt sätt. Skadan för obeväpnade attacker är 1T6. Om varelsen har särdraget Naturligt vapen ökar skadan istället ett steg från det naturliga vapnets nivå.",
@@ -354,7 +541,18 @@
       ],
       "ark_trad": [
         "Ordensmagi"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Speciell. Ordensmagikern får ingen permanent Korruption av att lära sig ordensmagins krafter till novisnivå, och inte heller av att lära sig ordensmagins ritualer. Däremot har novisen inget skydd mot den temporära Korruption som följer av att använda krafter och ritualer.",
@@ -375,7 +573,18 @@
       ],
       "test": [
         "Träffsäker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Skadan för armborst och bågskytte ökar till 1T12 respektive 1T10, istället för det normala 1T10 och 1T8.",
@@ -396,7 +605,18 @@
       ],
       "test": [
         "Kvick"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Rollpersonen kan utnyttja sin rustning maximalt vilket gör att en högre tärningsnivå används för att slå rustningens skydd: lätt rustning skyddar 1T6, medeltung rustning skyddar 1T8 och tung rustning skyddar 1T10.",
@@ -414,7 +634,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Rollpersonen är van att rida och strida uppsutten på ett riddjur. Rollpersonen vet hur att utnyttja riddjurets tyngd i en kavallerichock och får +1T6 i skada på en närstridsattack när riddjuret förflyttar sig innan attacken.",
@@ -435,7 +666,18 @@
       ],
       "test": [
         "Vaksam"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Rollpersonen har en stark intuition vilket låter denne slå Vaksam istället för Träffsäker vid attacker med avståndsvapen.",
@@ -456,7 +698,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Skadan för vapenhandens attacker ökar med ett steg, alltså till 1T10 om rollpersonen slåss med ett enhandsvapen eller till 1T8 om attackerna sker med ett Kort vapen. Sköldkampsnovisen hanterar också sin sköld effektivare som defensivt verktyg, och får +2 i Försvar istället för det vanliga +1.",
@@ -475,7 +728,18 @@
       "ark_trad": [
         "Krigare",
         "Tjuv"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Rollpersonen kan dra en pil och hugga med den i närstrid som en reaktion på en närstridsattack mot rollpersonen. Rollpersonen måste lyckas med en vanlig närstridsattack mot anfallaren. Attacken gör 1T6 i skada och pilens kvaliteter (om några) räknas in i attacken.",
@@ -493,7 +757,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Rollpersonen får en andra chans att lyckas med frislag till följd av att en fiende bryter närstrid.",
@@ -514,7 +789,18 @@
       ],
       "test": [
         "Träffsäker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Rollpersonen kan använda blixtpulver framställt av en alkemist till att blända en fiende i närstrid. Kräver ett slag mot [Träffsäker←Kvick], en lyckad attack gör 1T4 i blixtskada (rustning skyddar ej) och målet förblindas i 1T4 rundor. Pyroteknikern kan också hantera alkemiska granater och alkemiska minor utan risk för ett katastrofalt misslyckande.",
@@ -535,7 +821,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Rollpersonen behärskar de grundläggande brottargreppen och kan anfalla med dem också mot en väpnad motståndare. Rollpersonen kan brottas med egna vapen i händerna; de behöver inte släppas eller stoppas undan. Angreppet görs som vanligt och om det lyckas har brottaren sin fiende i ett fast grepp. Brottaren kan sedan försöka kasta sin fiende eller bara hålla fast denne; båda alternativen kräver ett [Stark←Stark]. Kastet gör 1T4 i skada, rustning skyddar ej och lämnar fienden liggande på rygg. Alternativet till kast, fasthållningen, gör ingen skada, men fienden är oförmögen att agera förrän brottaren misslyckas med ett [Stark←Stark]. Alla allierade till brottaren har dessutom övertag mot den fasthållne fienden. Brottaren själv kan inte heller agera med mer än att hålla fast, vilket lämnar denne blottad för fiender: de får övertag mot brottaren.",
@@ -556,7 +853,18 @@
       ],
       "test": [
         "Kvick"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Rollpersonen kan med ett lyckat Kvick dra ett vapen som en fri handling och alltså få använda det som vanligt. Alternativt kan rollpersonen med ett lyckat Kvick ladda om ett armborst som en fri handling.",
@@ -577,7 +885,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Stryparnovisen kan anfalla från Övertag och gör med ett lyckat anfallsslag 1T6 i skada per runda, Bepansring skyddar inte. Varelsen som stryps kan dessutom inte agera förrän stryparen avlägsnats; rollpersonen behåller strypgreppet med ett lyckat [Listig←Listig].",
@@ -599,7 +918,18 @@
       "test": [
         "Stark",
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Rollpersonen får en andra chans på slag i Stark och Viljestark för att avbryta pågående effekter av fysisk natur: fällor, gifter och alkemiska effekter. Även energier från mystiska krafter omfattas, så länge som dessa är fysiskt manifesterade i form av eld, syra eller liknande.",
@@ -617,7 +947,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Skadan med långa vapen ökar med ett steg, till 1T10 för spjut och hillebard och till 1T8 för stav.",
@@ -635,7 +976,18 @@
       ],
       "ark_trad": [
         "Krigare, Tjuv"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Rollpersonen har börjat förstå stålkastandets gåta. Skadan för kastvapen ökar till 1T8.",
@@ -656,7 +1008,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Speciell. Svartkonstnären har tagit sina första stapplande steg nedför den mörka magins hala trappa och funnit sätt att inte tappa fotfästet helt. Svartkonstnären kan mildra Korruption. Genom att lyckas med ett Viljestark varje gång svartkonstnären drabbas av Korruption får denne endast en (1) Korruption.",
@@ -677,7 +1040,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Rollpersonen har studerat stridens taktik och genomskådat dess elementa. Rollpersonen kan beräkna sitt initiativ på Listig istället för Kvick.",
@@ -695,7 +1069,18 @@
       ],
       "ark_trad": [
         "Teurgi"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Speciell. Teurgen får ingen permanent Korruption av att lära sig teurgins krafter till novisnivå, och inte heller av att lära sig teurgins ritualer. Däremot har novisen inget skydd mot den temporära Korruption som följer av att använda krafter och ritualer.",
@@ -713,7 +1098,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Rollpersonen hanterar säkert två vapen, ett i varje hand. Novisen slåss med ett enhandsvapen i huvudhanden och ett Kort vapen i andra handen. Rollpersonen gör två anfall mot samma mål, skada 1T8 respektive 1T6. Fienden försvarar sig separat mot de båda anfallen. Som passiv förmåga får novisen också en defensiv bonus på +1 till sitt Försvar, såklart endast då denne hanterar ett vapen i varje hand.",
@@ -731,7 +1127,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Skadan med tunga vapen ökar till 1T12.",
@@ -752,7 +1159,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Rollpersonen kan med ett lyckat Viljestark återhämta 1T4 Tålighet. Upprepade försök får göras, men endast ett lyckat försök per stridsscen räknas.",
@@ -771,7 +1189,18 @@
       ],
       "ark_trad": [
         "Artefaktmakare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Rollpersonen kan med ett lyckat slag i Listig skapa en novisartefakt.",
@@ -786,7 +1215,18 @@
     "taggar": {
       "typ": [
         "Förmåga"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Speciell. Rollpersonen är tränad i att använda en ballista och att på plats konstruera belägringstorn. Rollpersonen kan hantera alkemiska granater och riskerar inte att de detonerar av misstag vilket en otränad användare måste oroa sig för.",
@@ -805,7 +1245,18 @@
       ],
       "ark_trad": [
         "Templár"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Passiv. Rollpersonens mystiska krafter påverkas inte av att bära medeltung rustning. Rustningen begränsar Försvar som vanligt.",
@@ -824,7 +1275,18 @@
       ],
       "ark_trad": [
         "Tjuv"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Reaktiv. I situationer då rollpersonen utsätts för en effekt som kan ge full eller halv skada (exempelvis mot alkemiska granater och vissa mystiska krafter, så som Svavelkaskad) tar rollpersonen halv skada istället för hel och ingen istället för halv. Om rollpersonen exempelvis utsätts för kraften Svavelkaskad, vilken normalt gör 1T12 vid träff och 1T6 vid miss, omvandlas detta till 1T6 skada vid träff och ingen skada alls vid en miss.",
@@ -843,7 +1305,18 @@
       ],
       "ark_trad": [
         "Vredesgardist"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Reaktiv. Rollpersonen drar kraft ur sitt eget spillda blod. När Tålighet når hälften får rollpersonen en andra chans att lyckas med alla anfallsslag i närstrid.",
@@ -864,7 +1337,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Rollpersonen kan med ett lyckat Listig gillra eller desarmera en mekanisk fälla som en stridshandling. Effekten av fällan beror på dess sort, se fällor i kapitlet om Utrustning (sidan 127). Rollpersonen kan också bygga en improviserad fälla, vilket dock tar en hel runda i anspråk. Rollpersonens improviserade fällor gör 1T6 i skada.",
@@ -885,7 +1369,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Reaktiv. Rollpersonen kan med hammarens hjälp krossa fiendens sköld. Vid ett misslyckat angrepp mot en fiende som försvarar sig med sköld (dvs fienden parerar rollpersonens attack) får rollpersonen slå mot [Stark←Kvick]. Lyckas det krossas skölden om den är i trä; om den är i metall slits spännremmarna av och stålskölden slås ut fiendens grepp. Dessutom tar sköldbäraren 1T6 i skada av slagets tyngd.",
@@ -903,7 +1398,18 @@
       ],
       "ark_trad": [
         "Jägare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Speciell. Jägaren utser ett byte inom synhåll och får en andra chans att lyckas med alla avståndsattacker mot det målet. Bytet utses i samband med en attack mot målet, och målet gäller sedan som byte tills det dör eller scenen är slut.",
@@ -924,7 +1430,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Reaktiv. Rollpersonen kan välja att ta emot temporär Korruption som är på väg att drabba en annan person inom synhåll.",
@@ -945,7 +1462,18 @@
       ],
       "test": [
         "Kvick"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Passiv. Rollpersonen kan välja att anfalla med Kvick istället för med Träffsäker för angrepp gjorda med kniv.",
@@ -966,7 +1494,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Passiv. Rollpersonen tål mer stryk än andra och räknar sin Tålighet som [Stark +5]. Detta har ingen påverkan på Smärtgräns, den är densamma som tidigare, Stark/2.",
@@ -985,7 +1524,18 @@
       ],
       "ark_trad": [
         "Gentlemannatjuv"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Passiv. Rollpersonens mantel, eller improviserat tygstycke hållet i en hand, ger +1 Försvar.",
@@ -1003,7 +1553,18 @@
       ],
       "ark_trad": [
         "Symbolism, Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Reaktiv. Runtatueringen ger 1T4 i extra bepansring mot en träffande attack – närhelst runkrigaren så önskar. Rustningseffekten ger nämligen en temporär Korruption per användande. Runkrigaren måste bestämma sig för att aktivera tatueringen samtidigt som eventuellt annat skydd slås. Dessutom skyddar tecknen bäraren mot väder och vind som om de var rejäla kläder.",
@@ -1022,7 +1583,18 @@
       ],
       "ark_trad": [
         "Järnsvuren"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Passiv. Rollpersonen kan dela upp sin förflyttning och göra en del av sin förflyttning före sin stridshandling och en del efter – detta i syfte att utnyttja terrängens skottfält och skydd maximalt. Rollpersonen drar fortfarande på sig frislag av fiender om den uppdelade förflyttningen leder in den järnsvurne på närstridsavstånd.",
@@ -1040,7 +1612,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Rollpersonen kan med ett lyckat Listig göra ett novissmide. Rollpersonen kan också med ett lyckat Listig laga en skadad rustning eller anpassa en rustning för större och mindre varelser. Novissmiden omfattar alla vanliga vapen och rustningar, inklusive dem med kvaliteterna Kort och Långt. Inga andra kvaliteter kan smidas av novissmeden.",
@@ -1058,7 +1641,18 @@
       ],
       "ark_trad": [
         "Jägare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Rollpersonen kan offra sin förflyttningshandling till att skjuta en extra pil, totalt alltså två pilar. Detta kan bara göras om stridshandlingen också är ett bågskott. Skotten slås separat, måste inte gå mot samma mål men kan såklart göra det.",
@@ -1076,7 +1670,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Rollpersonen får en andra chans att lyckas snärja en fiende (kräver ett vapen med kvaliteten Snärjande, se sidan 118).",
@@ -1094,7 +1699,18 @@
       ],
       "ark_trad": [
         "Mystiker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Speciell. Den starka gåvan låter rollpersonen välja en signaturkraft. Signaturkraften väljs bland de mystiska krafter som mystikern besitter och den kraften kostar enbart en temporär Korruption att använda. Om rollpersonen inte behärskar några krafter eller hellre vill använda signaturen på en förmåga som ger korruption kan den istället ge samma effekt där; en gåva knuten till Ritualist (alltså då samtliga ritualer) eller till Häxsyn gör att dessa istället kostar en temporär Korruption att använda. Även särdrag som Eonernas visdom eller Spökvandring kan väljas. Signaturkraften påverkar inte eventuell kostnad i permanent Korruption för att lära sig en kraft utanför en mystisk tradition, enbart mängden temporär korruption som ges vid dess användande.",
@@ -1112,7 +1728,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Reaktiv. Rollpersonen parerar skickligt inkommande attacker och får +1 på Försvar; med den enkla trästaven eller en runstav – snabbare och mer balanserade än de andra vapnen i kategorin – blir bonusen +2 på Försvar.",
@@ -1131,7 +1758,18 @@
       ],
       "ark_trad": [
         "Stavmagiker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Speciell. Stavmagikern binder sin själ i en stav, ristad med elementens fyra runor. Staven binder all korruption som stavmagikern skulle ha fått genom att lära sig stavmagiska krafter. Om stavmagikern redan har permanent korruption när staven binds till mystikern så sänks den permanenta korruptionen med 1T6. Detta kan bara göras en gång, om staven skulle försvinna och måste ersättas sker ingen ytterligare sänkning. Dessutom kan stavmagikern som en fri handling aktivera en elementarruna och göra 1T4 extra skada med staven, vare sig den används tillsammans med stavmagiska krafter eller brukas som närstridsvapen. Stavmagikern väljer mellan eld, blixt, köld eller syra. Att aktivera en elementarruna ger ingen korruption.",
@@ -1149,7 +1787,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Passiv. I rollpersonens händer får ett ledat vapen också kvaliteten Snärjande och kan därmed användas för att snärja en fiende istället för att låta det slå runt försvaret.",
@@ -1167,7 +1816,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Passiv. Rollpersonen har börjat inse fördelarna med att slåss med ett balanserat svärd i ena handen och en parerdolk i andra. Skadan för duellsvärdet ökar till 1T10 istället för normala 1T8.",
@@ -1185,7 +1845,18 @@
       ],
       "ark_trad": [
         "Mystiker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Speciell. Symbolisten har precis börjat förstå runornas makt. Krafttecknen måste ges fysisk form – ristade, målade, broderare, tatuerade – vilket tar lång tid. Novisens krafter tar lika mycket tid som ritualer att färdigställa; en timme. De kan däremot aktiveras som en stridshandling; aktiveringen består av att symbolisten yttrar ett antal utlösande kraftord. Symbolisten måste se symbolen eller vara i dess direkta närhet (närstridsavstånd) för att kunna aktivera den. Symbolisten kan ha maximalt en symbol av varje mystisk kraft förberedd på detta sätt. När en förberedd symbol utlösts måste den laddas igen, som om den gjordes på nytt.",
@@ -1203,7 +1874,18 @@
       ],
       "ark_trad": [
         "Tjuv"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Tjuvknep som ”rännstenskyss” (skallning) eller ”svartalfskram” (skrevspark) kommer naturligt till rollpersonen i pressade lägen. Ett sådant tjuvknep gör 1T6 i skada och om fienden tar skada får rollpersonen också ett frislag mot målet.",
@@ -1221,7 +1903,18 @@
       ],
       "ark_trad": [
         "Jägare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Rollpersonen kan ägna hela sin runda (stridshandling och förflyttning) till att sikta noga och träffa ett mycket litet mål på fienden; skjuta ett vapen ur handen, skjuta fast en kroppsdel i närliggande vägg eller träd – eller sikta på ögonen och förblinda fienden. Attacken slås som vanligt och om den träffar och skadar så inträffar också extraeffekten; ett vapen tappas och måste plockas upp igen, en pil som skjuter fast en fiende i en vägg måste dras ut eller brytas av, och en träff nära ögonen förblindar fienden tillfälligt. Fienden måste oavsett spendera en stridshandling på att åtgärda problemet.",
@@ -1240,7 +1933,18 @@
       ],
       "ark_trad": [
         "Trollsång"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Speciell. Trollsångaren får ingen permanent korruption av att lära sig trollsånger till novisnivå men har inget skydd mot temporär korruption när den använder sina krafter. Trollsångens tradition innehåller inga ritualer. Däremot får trollsångaren en andra chans att lyckas med ett slag per scen för att påverka ett sinne (alltså där motståndaren försvarar sig med Viljestark). Omslaget kan inte användas för att skapa eller upprätthålla en kedja av förtrollningar.",
@@ -1258,7 +1962,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Det allra första en yxkonstnär lär sig är att stöta med yxans kortända, för att med smärta distrahera motståndare inför kommande krafthugg. Stöten gör 1T6 i skada och ett lyckat [Träffsäker←Viljestark] bedövar den fienden; om fienden bedövas får yxkonstnären direkt ett frislag mot målet.",
@@ -1279,7 +1994,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Rollpersonen kan med ett lyckat Stark bli av med 1T4 temporär korruption. Upprepade försök får göras, men endast ett lyckat försök per scen räknas.",
@@ -1297,7 +2023,18 @@
       ],
       "ark_trad": [
         "Mystiker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. När effekten av en mystisk kraft har bestämts, får rollpersonen kalla på de djupare resonanser som vilar under ytan. Genom att omfamna ett stänk av korruption (1 temporär korruption), kan rollpersonen slå om effekttärningarna och välja det mest gynnsamma resultatet.",
@@ -1315,7 +2052,18 @@
       ],
       "ark_trad": [
         "Krigare"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Attackera med en piska i en hand och ett enhandsvapen i den andra. Om en attack med piskan träffar får rollpersonen en fri attack med enhandsvapnet, oavsett om piskan gör skada eller inte.",
@@ -1336,7 +2084,15 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Tvåhandssvärd får kvaliteten Långt i novisens händer, och kan därmed användas tillsammans med förmågan Stångverkan.",
@@ -1356,7 +2112,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Förflyttning"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Förflyttning. Iförd minst medeltung rustning får rollpersonen +1T6 Bepansring mot alla attacker som träffar under förflyttningens gång.",
@@ -1377,7 +2144,18 @@
       ],
       "test": [
         "Träffsäker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Karaktären är van vid att lugna sig, sikta och andas rätt. Genom att avstå från sin förflyttningshandling får hen en andra chans att träffa med sitt anfall under samma runda.",
@@ -1399,7 +2177,18 @@
       ],
       "test": [
         "Träffsäker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Karaktären kan med precision träffa och avleda inkommande attacker i närstrid. Karaktären får använda Träffsäker som grund för Försvar i strid, så länge de håller ett närstridsvapen eller har förmågan Naturlig krigare.",
@@ -1421,7 +2210,18 @@
       ],
       "test": [
         "Träffsäker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: reaktiv När rollpersonen skadar en måltavla får hen med ett lyckat slag mot “Träffsäker” också placera ett “Målmärke” på offret. Offret räknas som målmärkt till slutet av rollpersonens nästa runda. Varje lyckad attack mot målet ger +1 skada. Endast ett mål kan vara målmärkt åt gången av rollpersonen och målmärkningen tappas om det går en hel runda utan lyckade anfall från rollpersonen.",

--- a/data/monstruost-sardrag.json
+++ b/data/monstruost-sardrag.json
@@ -12,7 +12,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Ett offer måste slå [Viljestark←Viljestark] eller backa undan under sina handlingar tills det lyckas med ett nytt slag.",
@@ -27,7 +38,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Den frätande attacken är svag och gör 1t6 i skada i 1t6 rundor.",
@@ -42,7 +64,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Det frätande blodet är svagt och gör 1t6 i skada i 1t6 rundor.",
@@ -60,7 +93,18 @@
       ],
       "test": [
         "Listig, Träffsäker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. De sega trådarna i fångstnätet tvingar alla som passerar att slå [Kvick←Listig] eller fastna i trådarna. Att komma loss kräver sedan ett lyckat [Stark←Listig], ett slag per runda. En fångad varelse får inte förflytta sig och får två chanser att misslyckas med alla handlingar, om ett av slagen misslyckas fallerar försöket.",
@@ -78,7 +122,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Giftet är svagt och gör 1t4 i skada i 1t4 rundor.",
@@ -93,7 +148,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsens naturliga vapen gör 1t6 alternativ skada, Bepansring skyddar ej.",
@@ -108,7 +174,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsen passerar fysiska barriärer utan problem men kan inte korsa vatten ens på broar, med båt eller i luften. Anden tar halv skada av vapenattacker. Alkemiska effekter på vapen, liksom mystiska krafter ger full skada. Magiska vapen ger också full skada.",
@@ -126,7 +203,18 @@
       ],
       "test": [
         "Listig"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Giftet är svagt och gör 1t4 i skada i 1t4 rundor.",
@@ -144,7 +232,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Varelsen sprider gravens paralyserade kyla omkring sig; rollpersoner på närstridsavstånd paralyseras om de misslyckas med Viljestark. Ett slag slås per runda, lyckas rollpersonen får den agera som vanligt. En rollperson som bryter gravkylan kan inte drabbas igen under samma scen.",
@@ -159,7 +258,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsens attacker osar av korruption och smittar den som skadas av attacken. Ett offer som tar minst 1 i skada av attacken får också 1t4 temporär korruption.",
@@ -174,7 +284,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Anden kan manifestera sig fysiskt och får då agera som om den hade en fysisk kropp i en runda. Om 1 rundas förflyttning räcker för att korsa vatten kan anden göra det. Andens obeväpnade eller naturliga vapen kan användas under rundan och den tar skada av allt som skadar fysiska varelser.",
@@ -189,7 +310,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsens naturliga vapen gör 1t6 i skada istället för 1t4.",
@@ -204,7 +336,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsen har ett naturligt skydd på 1t4.",
@@ -219,7 +362,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsen regenererar 1t4 Tålighet per runda.",
@@ -237,7 +391,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Speciell. Svärm tar halv skada av alla attacker. Om svärm skadas och går ner till mindre än hälften av sin Tålighet kommer de ingående delarnas överlevnadsinstinkt att ta över och dess flockinstinkt dra med sig resten av svärm på flykt. Mentala angrepp (där svärm försvarar sig med Viljestark) påverkar hela svärm.",
@@ -255,7 +420,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Varelsens blick tvingar offret att klara [Viljestark←Viljestark] eller förlora båda sina nästkommande handlingar.",
@@ -270,7 +446,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Den vandöde påverkas inte av gifter eller sjukdomar, men tar skada av fysiska effekter som vanligt med undantag av att Smärtgräns inte används (smärta och chock påverkar inte den vandöde). Den vandöde läker inte naturligt och påverkas inte av alkemiska läkeelixir utan måste äta rått kött (levande eller nyligen dödat) eller dricka blod för att läka, varje poäng Tålighet som konsumeras läker 2 Tålighet på den vandöde.",
@@ -285,7 +472,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsen kan flyga under sin förflyttning och alltså undgå fria attacker vid passage över en fiende.",
@@ -310,7 +508,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. När varelsen träffar med en stridshandling en får denne genast göra ett frislag mot en fiende inom räckhåll, oavsett om den första handlingen gav skada eller inte.",
@@ -328,7 +537,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Varelsen kan trollbinda och bita sitt offer, [Viljestark←Viljestark], i samma stridshandling. Blodsugaren sörplar sedan i sig blod, 1T4 Tålighet per runda, rustning skyddar ej. Offret får varje runda, på sitt initiativ, försöka bryta transen [Viljestark←Viljestark]. Skada på blodsugaren kan också bryta transen, [Viljestark –Skada].",
@@ -346,7 +566,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Varelsens attacker kan fälla omkull fiender som tar skada. Offret undviker att falla om det lyckas med ett slag mot [Stark←Stark], där varje nivå i särdraget Robust ger +2 i Stark för både anfallare och försvarare.",
@@ -377,7 +608,18 @@
       ],
       "test": [
         "Träffsäker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Varelsen frustar fram en kaskad mot ett mål. Om offret lyckas med ett slag mot [Kvick←Träffsäker] gör kaskaden 1T6 i skada; om slaget misslyckas blir skadan 1T12.",
@@ -392,7 +634,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Varelsens dödskamp låter den göra ett frislag mot en fiende inom närstridsavstånd, som en reaktion på attacken som dödade den.",
@@ -407,7 +660,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Varelsen kan simulera ett av de listade särdragen till motsvarande nivå Novis.",
@@ -425,7 +689,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. En gång per scen kan frammanaren med ett lyckat Viljestark kalla en daemonisk Inkräktare till platsen.",
@@ -443,7 +718,18 @@
       ],
       "test": [
         "Vaksam"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsen kan med halverad hastighet förflytta sig under marken och därmed undgå alla fria attacker som annars uppkommer vid passage av eller närmande till en fiende.",
@@ -481,7 +767,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsen åtföljs av en följeslagare, vars motståndsnivå är två steg lägre än varelsens.",
@@ -499,7 +796,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Varelsen får utföra två attacker mot en fiende, en med varje klo. Om båda attackerna träffar kan varelsen försöka gripa tag om offret, vilket händer om offret misslyckas med [Stark←Stark]. Ett greppat offer kan agera som vanligt frånsett att det kan inte förflytta sig. Offret hålls fast under rundan det greppas och dras mot varelsen rundan efter om offret misslyckas med [Stark←Stark]. Lyckas offret kommer det loss.",
@@ -517,7 +825,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Varelsen kan besätta ett offer den berör, exempelvis efter ett lyckat anfall som ger skada. Offret måste slå [Viljestark←Viljestark]; om det misslyckas blir offret slav under andens vilja, och kan fås att utföra vilka handlingar som helst utom att ta sitt eget liv. Efter första dygnet slår offret ett andra motståndsslag; om det misslyckas varar effekten i en vecka, varefter ännu ett slag slås. Misslyckas även det sitter besattheten i en månad. Och när den månaden har passerat slås det sista slaget som om det misslyckas innebär att besattheten blir permanent. Besattheten kan dock brytas när som helst genom ett lyckat utförande av ritualen Exorcism.",
@@ -532,7 +851,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Vid dödsögonblicket lösgör sig eller manifesteras en varelse för att hämnas innehavaren av särdraget. Hämnarens motståndsnivå är två steg lägre än den dödes.",
@@ -547,7 +877,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Parasitens infestering kräver ett lyckat anfall som gör skada. Därefter behöver parasiten en hel runda för att tränga in i värdkroppen. Under den rundan kan offret eller en allierad offra en stridshandling för att avlägsna parasiten – ger 1T8 i skada på värden, eller 1T4 med ett lyckat slag mot Listig. Att ta bort en parasit som väl har trängt in kräver ett lyckat Listig med förmågan Medicus; varje försök ger offret 1T10 i skada. (Ignorerar Bepansring)",
@@ -575,7 +916,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Varelsen kan stjäla korruption från styggelsesmittade offer, genom att äta dess kött eller suga i sig dess blod. Offret måste vara fogligt, antingen medvetslöst, fasthållet, drogat eller på annat sätt oförmöget att göra motstånd. Offret tar 1T8 i skada per runda (rustning skyddar ej) medan korruptionssamlaren suger i sig 1T4 poäng permanent korruption, vilka därmed försvinner från offret. Varelsen kan som en reaktiv handling spendera en poäng insamlad korruption per runda, på något av följande:\n– Ge en fiende en andra chans att misslyckas med ett motståndsslag mot en av korruptionssamlarens förmågor, krafter eller särdrag\n– Ge en fiende en andra chans att misslyckas med Försvar mot en av korruptionssamlarens attacker\n– Ge en fiende en andra chans att misslyckas med en attack mot korruptionssamlaren\n– Tvinga en fiende att slå en andra gång på ett effektslag, och ta det sämre utfallet",
@@ -593,7 +945,18 @@
       ],
       "test": [
         "Vaksam"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Med ett lyckat slag mot Vaksam kan varelsen upptäcka utbrott av korruption i närområdet (cirka femhundra meter åt alla håll, om exakthet behövs). Små utbrott (1 poäng temporär korruption) kan upptäckas med -7 på karaktärsdraget; vid 2 poäng modifieras karaktärsdraget med –5; vid 3 poäng med ±0; vid 4 poäng eller mer med +5. En framgång innebär att varelsen känner av utbrottet och blir varse om riktningen till platsen där det uppstod.",
@@ -611,7 +974,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Förflyttning"
+        ],
+        "Gesäll": [
+          "Förflyttning"
+        ],
+        "Mästare": [
+          "Förflyttning"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Förflyttning. Alla som står i varelsens väg under förflyttningen måste klara [Stark←Stark] eller ta 1T4 i skada (rustning skyddar som vanligt) och ramla omkull där de står. Särdraget Robust och Särdraget Väldig ger 1T4 extra i skada som ökar i tärningsgrad per nivå (1T4, 1T8, 1T12). Det ger även +2, +4, +6 i bonus på Stark vid både användandet av och försvar mot Krossande framfart. Om ett offer lyckas med sitt slag avbryts den krossande framfarten. Fiender med förmågan Akrobatik kan välja att försvara sig med [Kvick← Stark] och då ducka undan, men i så fall avbryts inte framfarten vid ett lyckat Försvar.",
@@ -630,7 +1004,18 @@
       "test": [
         "Träffsäker",
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. När varelsen träffar med sitt naturliga vapen och gör skada kan den välja att försöka hålla fast offret. För att undvika att fångas måste offret klara [Kvick←Träffsäker]. Om målet blir fasthållet måste det klara [Stark←Stark] för att komma loss, eller ta 1T4 i skada varje runda medan det sakta krossas (Bepansring ignoreras). En fasthållen fiende får inte agera, men å andra sidan förlorar också varelsen en stridshandling per runda och fasthållet offer.",
@@ -648,7 +1033,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Monstrets Tålighet beräknas på dess Stark x 1,5 (avrundat uppåt).",
@@ -666,7 +1062,18 @@
       ],
       "test": [
         "Vaksam"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsen förnimmer de svagaste vibrationer i mark och luft, och kan upptäcka varelser bakom bastanta väggar och stängda dörrar eller genom metertjocka lager av jord. Den som försöker undgå upptäckt måste lyckas med ett slag mot [Diskret←Vaksam].",
@@ -681,7 +1088,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Alla som försöker påverka eller skada varelsen med mystiska krafter måste slå framgångsslaget två gånger och lyckas med båda för att kraften ska ta effekt.",
@@ -696,7 +1114,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsen har två extremiteter eller huvuden och kan agera med dem separat. Varelsen har två stridshandlingar per runda.",
@@ -734,7 +1163,18 @@
       ],
       "test": [
         "Diskret"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Varelsen kan göra sig osynlig och blir då omöjlig att attackera med direkta attacker. För att angripa med areaattacker så som alkemiska granater och liknande måste angriparen lyckas med ett [Vaksam← Diskret]; detsamma gäller för att träffa monstret med improviserade vapen för att avslöja det – sand, damm, mjöl eller liknande som gör varelsen delvis synlig under resten av striden. Att attackera en delvis synlig varelse kräver först ett slag mot [Vaksam← Diskret]; om det slaget lyckas sker attacken som vanligt.",
@@ -749,7 +1189,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Vid varje attack som ger skada slår offret ett slag mot Stark. Om slaget lyckas blir offret omtöcknat och får två chanser att misslyckas med framgångsslag och reaktiva handlingar under en runda; om slaget misslyckas kan offret bara utföra reaktiva handlingar och då med två chanser att misslyckas.",
@@ -764,7 +1215,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Attacken har skadevärde 4.",
@@ -783,7 +1245,18 @@
       "test": [
         "Träffsäker",
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Varelsen reser sina rötter som en mur ur marken, bred nog för att det ska ta två förflyttningshandlingar att runda den, alternativt för att blockera en grottöppning eller liknande. Muren går att hugga sönder, enligt reglerna för Skada på byggnader i Spelarens handbok (sidan 106). Rotmuren har Tålighet 10, Brytpunkt 5 och Skydd 1T10. Rotmuren finns kvar under hela scenen om inte varelsen väljer att flytta den med en ny aktiv handling eller om den raseras. I det senare fallet kan varelsen inte framkalla en ny Rotmur förrän ett dygn senare.",
@@ -798,7 +1271,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsen kan när som helst välja att dra ihop sig under sina ryggsköldar – skyddsvärdet för dess naturliga pansar dubbleras men den får inte utföra några aktiva handlingar under rundan.",
@@ -813,7 +1297,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Alla som befinner sig inom närstridsavstånd från varelsen drabbas av 1T4 i skada varje runda (ignorerar Bepansring).",
@@ -831,7 +1326,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. När monstret gör skada med ett bett hålls offret fast till nästa runda; det får agera som vanligt frånsett att det inte får förflytta sig. Nästa runda kan monstret försöka sluka målet. Offret slår ett slag mot [Stark← Stark], där särdraget Robust ger +2 i bonus per nivå, för både slukaren och dess offer. Om slaget lyckas sliter sig offret loss från fasthållningen, men om det misslyckas sväljs denne och hamnar i monstrets buk – en ohälsosam miljö som gör 1T4 i skada per runda, rustning skyddar ej.",
@@ -846,7 +1352,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Varje varelse som skadas av monstrets naturliga vapen måste klara ett slag mot Stark eller smittas av en svag sjukdom.",
@@ -861,7 +1378,18 @@
     "taggar": {
       "typ": [
         "Monstruöst särdrag"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Passiv"
+        ],
+        "Gesäll": [
+          "Passiv"
+        ],
+        "Mästare": [
+          "Passiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Passiv. Varelsens båda handlingar går åt när den attackerar; den kan alltså inte förflytta sig och attackera under samma runda. I gengäld träffar dess attacker med en kraft som vanlig rustning har svårt att skydda mot – målet slår för Bepansring två gånger och det lägsta utfallet gäller.",
@@ -879,7 +1407,18 @@
       ],
       "test": [
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Förflyttning"
+        ],
+        "Gesäll": [
+          "Förflyttning"
+        ],
+        "Mästare": [
+          "Förflyttning"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Förflyttning. Varelsen kan ta ett väldigt skutt och landa en förflyttning från startpunkten (ca 12 meter). Den drabbas inte av frislag från fiender som den landar vid eller passerar, men undgår inte frislag om hoppet innebär att den bryter närstrid.",
@@ -897,7 +1436,18 @@
       ],
       "test": [
         "Träffsäker"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Varelsen frustar fram en eldkaskad mot ett mål. Om varelsen lyckas med [Träffsäker←Kvick] gör kaskaden 1T12 i skada. Om slaget misslyckas blir skadan 1T6.",

--- a/data/mystisk-kraft.json
+++ b/data/mystisk-kraft.json
@@ -13,7 +13,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan med ett lyckat [Viljestark←Viljestark] skingra en pågående effekt på en varelse, även på sig själv under förutsättning att mystikern är i stånd att använda magi. Det är den påverkande mystikerns Viljestark som används som motstånd.",
@@ -35,7 +46,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Mystikern kallar andar till sin hjälp och dessa transparenta skepnader anfaller en fiende. Fienden misslyckas automatiskt med alla slag för koncentration gällande mystiska krafter; alla andra framgångsslag får en andra chans att misslyckas. Mystikern måste klara ett Viljestark varje runda för att vidmakthålla andarnas hjälp.",
@@ -57,7 +79,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Runornas kraft ger 1T4 extra i skydd tills mystikern misslyckas med ett Viljestark eller tappar koncentrationen [Viljestark – Skada]. Skyddstärningen slås separat vid varje träff och adderas till målets rustning, om någon.",
@@ -78,7 +111,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kallar med ett lyckat Viljestark upp en vägg av virvlande flammor alldeles framför sig (närstridsavstånd). Väggen är bred nog för att täcka de flesta korridorer och dela av de flesta rum. I större salar och utomhus krävs dubbel förflyttning för att komma runt brandväggen men den går då också att flyga över med en enkel förflyttning.  \nVäggen går att passera igenom med vanlig förflyttning men alla som gör det tar 1T12 i brinnande skada. Mindre brännbara objekt som pilar och lod bränns sönder om de skjuts genom brandväggen. Det går att kalla upp brandväggen på en grupp av fiender som då automatiskt tar skada, förutsatt att dessa befinner sig på linje framför mystikern. Brandväggen finns kvar tills mystikern misslyckas med ett Viljestark, ett slag per runda.",
@@ -101,7 +145,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern tar kontrollen över en varelse med [Viljestark←Viljestark]. Kontrollen kräver koncentration och pågår tills mystikern bryter koncentrationen eller misslyckas med [Viljestark←Viljestark]. Svårighetsgraden ökar för varje runda: mystikerns Viljestark får en kumulativ modifikation −1 för varje runda efter den första. Den kontrollerade varelsen kan endast utföra en (1) handling per runda och kan inte använda aktiva eller reaktionsförmågor/krafter under effekten. Om den kontrollerade varelsen tar skada måste mystikern slå [Viljestark←Skada]; vid misslyckande bryts kontrollen.",
@@ -123,7 +178,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Mystikern låter sitt vapen dansa och använder Viljestark istället för både Träffsäker (anfall) och Kvick (försvar). I övrigt gäller samma regler som i närstrid. Novisen måste fokusera på vapnet når det slåss, vilket inte tillåter att mystikern använder andra krafter eller förmågor medan vapnet dansar.",
@@ -145,7 +211,18 @@
       "test": [
         "Viljestark",
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Varje fiende i närheten skadas om mystikern lyckas med [Viljestark←Stark]. Skadan är 1T4 per runda, rustning skyddar ej. Effekten fortsätter tills mystikern misslyckas med ett Viljestark eller tappar koncentrationen [Viljestark – Skada].",
@@ -165,7 +242,18 @@
       "ark_trad": [
         "Pyromantiker"
       ],
-      "test": []
+      "test": [],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Reaktiv. När eldsjälen träffas i närstrid slår flammor ut och skadar angriparen, 1T6 skada, rustning skyddar som vanligt. Mystikern tar dessutom mindre skada av eld, 1T6 extra skydd mot just eld.",
@@ -187,7 +275,18 @@
       "test": [
         "Övertygande",
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Fri. Rollpersonen kan med ett lyckat [Övertygande←Viljestark] påtvinga varje skadad fiende en andra chans att misslyckas med framgångsslag så länge sången pågår. Ett slag slås per skadad fiende.",
@@ -208,7 +307,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Symbolen utlöser en kedja av förblindande energi, den fiende som står närmast symbolen drabbas först [Viljestark←Viljestark]; om fienden förblindas görs ett försök att förblinda nästa fiende och så vidare tills en fiende klarar sig undan förblindning. Effekten varar en runda, sedan återkommer synen till samtliga drabbade.",
@@ -229,7 +339,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Symbolen utlöser en kedja av fördrivande energi, den fiende som står närmast symbolen drabbas först [Viljestark←Viljestark]; om fienden fördrivs görs ett försök att fördriva nästa fiende och så vidare tills en fiende klarar sig undan fördrivning. Varelser som fördrivs måste lämna platsen så snabbt de kan och får inte återvända under scenen.",
@@ -251,7 +372,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. En gång per runda kan mystikers mörka blick göra så att en fiende automatiskt får en andra chans att misslyckas med sina framgångsslag mot mystikern (slå två gånger, misslyckas ena slaget fallerar försöket). Effekten pågår tills mystikern misslyckas med ett Viljestark.",
@@ -272,7 +404,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan med ett lyckat [Viljestark←Viljestark] förvirra en fiende så att denne inte vet vad den gör. Slå 1T6 varje runda fram till att mystikern tappar koncentrationen eller misslyckas med [Viljestark←Viljestark]: 1–2, offret står stilla och blinkar dumt; 3–4, offret anfaller sin närmaste allierade; 5–6, offret anfaller sin närmaste fiende. Om det är oklart vem som är närmast så slås en tärning för att se vem det blir.",
@@ -294,7 +437,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Rollpersonen river upp en tillfällig reva i världsväven och kastar med ett lyckat [Viljestark←Viljestark] ut en fiende ur världen under en runda. Fienden återvänder nästa runda på rollpersonens initiativ och på samma plats – ångande av ovärldens dimma, med 1T4 i skada (rustning skyddar ej), samt med 1T4 temporär korruption. Ett misslyckat försök drar automatiskt in en vredgad styggelse genom såret i världsväven.",
@@ -315,7 +469,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan genom ett lyckat Viljestark anta formen av en liten best (däggdjur eller kräldjur), en praktisk form för flykt eller spaning men verkningslös i strid. Mystikern behåller sina karaktärsdrag men får en andra chans att lyckas med alla slag för Diskret och Kvick. Dessutom får fiender inte slå frislag mot mystikern i bestform, vare sig hon drar sig ur närstrid eller passerar en fiende. Mystikern behöver inte slå för Viljestark för att stanna i formen men måste klara ett Viljestark för att komma ur den. Mystikern räknas som en best under förvandlingen. Om mystikern utsätts för krafter som påverkar bestar kan hon välja att stanna i bestform och alltså påverkas av kraften, eller välja att avbryta effekten och återgå till sin ursprungliga form.",
@@ -337,7 +502,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan med ett lyckat Viljestark och beröring hela 1T6 Tålighet hos målet. Kraften fungerar också på mystikern själv.",
@@ -358,7 +534,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan med ett lyckat Viljestark sända ut en aura av heliga energier som skadar styggelser och odöda. Skada är 1T6, Bepansring skyddar ej. Effekten påverkar varelser inom synavstånd från mystikern och pågår tills denne misslyckas med Viljestark eller tappar koncentrationen. Mystikern kan undanta allierade styggelser eller vandöda från effekten.",
@@ -379,7 +566,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Fri. Rollpersonen ger sig själv och sina allierade +1 på antingen Listig, Viljestark eller Övertygande (den allierade väljer vilket karaktärsdrag som får bonusen) så länge sången varar.",
@@ -398,7 +596,18 @@
       "ark_trad": [
         "Teurgi"
       ],
-      "test": []
+      "test": [],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Helig eld omsluter novisens närstridsvapen och ger +1T4 i skada, eller +1T6 om motståndaren är en styggelse eller en odöd. Effekten varar under hela scenen.",
@@ -419,7 +628,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktion. Mystikern kan en gång per runda med ett lyckat Viljestark korrigera verkligheten och därigenom få slå om ett misslyckat Försvar.",
@@ -441,7 +661,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Mystikern skapar 1T4 illusionskopior av sig själv med ett lyckat Viljestark. Om en illusionskopia träffas upphör denna att finnas. Areaeffekter träffar mystikern som vanligt och skingrar alla illusionskopior.",
@@ -464,7 +695,18 @@
       "test": [
         "Viljestark",
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern planterar larver inne i fiendens kropp, vilka sedan äter sig ut. 1T4 i skada per runda, Bepansring skyddar ej. Effekten är automatisk första rundan och pågår tills mystikern misslyckas med [Viljestark←Stark].",
@@ -486,7 +728,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Mystikern renar 1T4 temporär korruption från en varelse inom synhåll. Eventuella överskjutande poäng läker istället fysisk skada på varelsen. Kraften kan användas på livgivaren själv.",
@@ -507,7 +760,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Rollpersonen kastar med ett lyckat [Viljestark←Kvick] ut en svart blixt mot en fiende. Om anfallet lyckas träffas målet av blixten och tar 1T6 i skada, rustning skyddar ej. Målet fångas dessutom och kan inte agera förrän det lyckas bryta sig ur kraften, vilket kräver ett lyckat Viljestark (ett slag slås per runda efter den första) eller att mystikern tappar koncentrationen [Viljestark –Skada].",
@@ -528,7 +792,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan sjunka ner i jorden med ett lyckat Viljestark. Där är mystikern osårbar men också oförmögen att agera. Mystikern måste slå ett lyckat Viljestark varje runda för att stanna i naturens trygga famn. Om det misslyckas återförs mystikern till markytan.",
@@ -550,7 +825,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan med ett lyckat [Viljestark←Viljestark] tyna bort ur en varelses sinnesvärld. Mystikern förblir osynlig för den varelsen tills mystikern gör en attack eller tar skada på något sätt.",
@@ -571,7 +857,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan med ett lyckat Viljestark sända ut en aura av oheliga energier som skadar kulturvarelser och bestar inom synhåll. Skada är 1T6 och Bepansring skyddar ej. Effekten påverkar alla kulturvarelser och bestar oavsett om de är allierade med denne eller ej och pågår tills mystikern misslyckas med Viljestark eller tappar koncentrationen [Viljestark -Skada].",
@@ -593,7 +890,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Mystikern tvingar en fiende att slå 1T20 mot sin korruption. Ett misslyckande ger varelsen kraftiga smärtor vilket förlamar den under en hel runda. Genomkorrumperade varelser tar istället automatiskt 1T6 skada, bepansring skyddar ej.",
@@ -615,7 +923,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Reaktiv. Mystikerns klarsyn gör att denne får slå ett [Viljestark←Viljestark] för att genomskåda varje illusion, transformation eller annan effekt som döljer sakers sanna form inom synhåll. Illusioner som genomskådas upplöses, transformationer kvarstår men mystikern ser det som finns bakom dem.",
@@ -637,7 +956,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Sfären låter mystikern välja att parera med Viljestark istället för med Kvick. Sfären skyddar mot närstrids och avståndsattacker men inte mot mystiska krafter. Endast förflyttning är förenligt med sfären – inte ens de ersättande handlingarna som vanligtvis kan utföras istället för förflyttning är möjliga med bibehållen sfär.",
@@ -659,7 +989,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Reaktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Reaktiv. Mystikern gör en närstridsattack som vanligt och tillsammans med den en sinnesstöt, riktad mot fiendens förmåga att försvara sig. Rollpersonen får en andra chans att lyckas med angreppet.",
@@ -681,7 +1022,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ],
+        "Novis": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Hel runda. Med ett lyckat Viljestark träder mystikern in i spökform. Denna immateriella form varar under en förflyttning (ca 10 meter), vilket gör att mystikern kan passera även de tjockaste murar, eller för den delen kan röra sig genom sina fiender på ett slagfält. Attacker mot mystikern ignoreras, om de inte sker med mystiska krafter eller artefakter – dessa ger då halv skada. Förflyttningen är det enda mystikern kan göra på sin runda, och efter förflyttningen återtar mystikern sin fysiska form.",
@@ -703,7 +1055,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Mystikern kastar sin stav och kan slå mot Viljestark istället för mot Träffsäker för att träffa. Staven gör 1T8 i skada. Effekten av en eventuell elementarenergi från förmågan Stavmagi tillkommer.",
@@ -724,7 +1087,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. En varelse träffas; slå 1T4 mot målets totala korruption. Är utfallet lika med eller lägre än korruptionsvärdet helas varelsen med slagets värde, om det är över tar varelsen slagets utfall i temporär korruption.",
@@ -746,7 +1120,18 @@
       "test": [
         "Viljestark",
         "Kvick"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern slår ut med en svavelosande eldkaskad mot ett mål. Om mystikern lyckas med [Viljestark←Kvick] gör kaskaden 1T12 i skada. Om slaget misslyckas blir skadan 1T6.",
@@ -770,7 +1155,18 @@
         "Kvick",
         "Träffsäker",
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan kasta material från omgivningen som vapen eller använda samma material som sköld. Om det används för anfall slås [Viljestark←Kvick] för träff och skadan är 1T8. Om materialet används som tillfällig sköld används [Viljestark←Träffsäker] för att Parera fysiska attacker och [Viljestark←Viljestark] om det är fråga om en magisk projektil. Skyddet förstörs av en träff.",
@@ -792,7 +1188,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Rollpersonen kan med ett lyckat Viljestark kliva ut ur världen och återkomma igen inom en dubbel förflyttnings avstånd. Mystikern tar 1T4 skada av resan i Bortomvärlden, rustning skyddar ej. Teleporteringen ger inte fiender rätt till frislag även om den görs i närstrid. Mystikern måste se platsen för återkomsten när kraften utförs, det går inte att kliva rakt in i okänd mark. Misslyckas försöket kommer istället en vredgad daemon in genom revan.",
@@ -813,7 +1220,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Om mystikern lyckas med [Viljestark←Viljestark] förvandlas målet till en harmlös best (däggdjur eller kräldjur, mystikern väljer). Effekten kräver koncentration och fortsätter tills mystikern bryter koncentrationen eller misslyckas med en kontroll [Viljestark←Viljestark]. Svårigheten ökar för varje runda efter den första: mystikerns Viljestark får en kumulativ modifikation −1 så länge effekten hålls. Om den förvandlade varelsen tar skada måste mystikern omedelbart slå [Viljestark←Skada]; vid misslyckande bryts effekten. Den förvandlade varelsen behåller värden och passiva egenskaper från sina monstruösa särdrag men saknar alla förmågor/krafter, kan inte göra attacker, reaktioner eller använda föremål.",
@@ -832,7 +1250,18 @@
       "ark_trad": [
         "Svartkonst"
       ],
-      "test": []
+      "test": [],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Svartkonstnären tänder en illvillig flamma kring sitt närstridsvapen, vilken gör 1T4 extra i skada.",
@@ -853,7 +1282,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern styr med ett Viljestark det heliga ljuset mot ett mål, vilket ger 1T6 i brännskada. Om målet är en styggelse eller en vandöd blir skadan 1T10.",
@@ -875,7 +1315,18 @@
       "test": [
         "Viljestark",
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kan med ett lyckat Viljestark levitera sig själv och sväva över slagfältet utom räckhåll för fiendens närstridsvapen. Mystikern kan förflytta sig motsvarande ett steg per runda när denne leviterar. Avståndsattacker och flygande fiender är fortfarande ett problem. Mystikern stannar i luften tills koncentrationen bryts eller tills scenen är över. Om koncentrationen bryts faller mystikern ned till marken och tar 1T6 i skada, Bepansring skyddar ej.",
@@ -896,7 +1347,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern förtrollar ett knippe (upp till fem) pilar med ett lyckat Viljestark. Pilarna svävar sedan bredvid mystikern under resten av scenen och kan avfyras en per runda som en fri handling (en pil kan skjutas samma runda som kraften aktiveras). Pilarna träffar osvikligt sitt mål. Om pilen som används har en kvalitet eller speciella egenskaper läggs dessa till effekten av pilen. Pilen gör 1T6 skada.",
@@ -917,7 +1379,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Med ett lyckat Viljestark låter sig mystikern omslutas av en värmande hetta. Värmen skyddar som 1T4 extra Bepansring. Styggelser eller vandöda som anfaller mystikern i närstrid tar dessutom 1T4 i skada av värmen, Bepansring skyddar ej. Den välsignade skölden varar scenen ut.",
@@ -939,7 +1412,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Mystikern kan med ett lyckat Viljestark dra skadans ande till sig från en skadad varelse inom synhåll. Det helar målet 1T6 Tålighet och mystikern tar själv lika mycket i skada.",
@@ -961,7 +1445,18 @@
       "test": [
         "Viljestark",
         "Stark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Aktiv. Mystikern kallar snärjande rankor ur jorden och kan snärja en fiende med ett lyckat Viljestark. Den snärjda varelsen kan inte röra sig men kan använda avståndsvapen och besvärjelser. Varelsen är snärjd tills mystikern misslyckas med [Viljestark←Stark].",
@@ -983,7 +1478,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Mystikern låter sig omslingras av växtlighet vilket ger 1T4 extra bepansring, 1T6 om mystikern dessutom står still under rundan.",
@@ -1005,7 +1511,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Reaktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Rollpersonen kan uttala domedagsord över en fiende och slå [Viljestark←Viljestark]; ett lyckat försök gör att oturen samlas tjock runt målet. Alla som anfaller fienden får en andra chans att lyckas med sina anfallsslag under resten av scenen. Endast en fiende i taget kan bindas till undergång med vedergällningens kraft; att byta mål är en ny stridshandling.",
@@ -1027,7 +1544,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Mystikern kan kalla en svag best till sin sida, som hjälp i strid mot andra fiender.",
@@ -1048,7 +1576,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Fri. Rollpersonen ger sig själv och sina allierade +1 på antingen Kvick, Stark eller Träffsäker (den allierade väljer vilket karaktärsdrag som får bonusen) så länge sången varar.",
@@ -1069,7 +1608,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Symbolen utlöser en kedja av ilande plågor; det offer som står närmast symbolen drabbas först [Viljestark←Viljestark]; om den drabbas slås ett slag för nästa fiende och så vidare tills någon kan stå emot kraftens energier. Effekten varar en runda och innebär att offren inte kan utföra några aktiva handlingar.",
@@ -1090,7 +1640,18 @@
       ],
       "test": [
         "Viljestark"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Aktiv"
+        ],
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Aktiv. Symbolen väcker en otyglad stridslust hos en kedja av varelser; det offer som står närmast symbolen drabbas först [Viljestark←Viljestark]; om den drabbas slås ett slag för nästa fiende och så vidare tills någon kan stå emot kraftens energier. Effekten varar en runda och innebär att offret genast attackerar den person som råkar stå närmast, vän eller fiende.",

--- a/data/sardrag.json
+++ b/data/sardrag.json
@@ -13,7 +13,18 @@
       ],
       "ras": [
         "Bortbyting"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Rollpersonen kan med ett lyckat Viljestark anta en falsk skepnad; form, utseende, röst och kläder av en annan varelse, dock ej av en specifik individ. Bortbytingen kan behålla skenverket under en scen, sedan tynar illusionen bort. Varje person som rollpersonen pratar med genomskådar skenverket om rollpersonen inte lyckas med ett [Diskret←Vaksam].",
@@ -55,12 +66,24 @@
     "beskrivning": "Endast tillgänglig för Resar och Troll. Rollpersonen är av ett släkte som till naturen är storvuxet och som ofta fortsätter att växa under hela sin levnad. Men variationer förekommer: vissa växer snabbt, andra långsamt, och somliga knappt alls.",
     "taggar": {
       "typ": [
-        "Särdrag",  "Monstruöst särdrag"
+        "Särdrag",
+        "Monstruöst särdrag"
       ],
       "ras": [
         "Rese",
         "Troll"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Speciell"
+        ],
+        "Gesäll": [
+          "Speciell"
+        ],
+        "Mästare": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Speciell. Rollpersonen är cirka två meter lång och råstark. En sådan tornande siluett är lättare att träffa i strid vilket balanseras med en påtaglig stryktålighet. Rollpersonen kan endast använda lätt rustning, vilken måste måttbeställas och därför kostar dubbelt så mycket. I gengäld ignorerar rollpersonen 1T4 skada per träff, i tillägg till eventuell rustning. Till detta kommer att rollpersonen kan ge 1T4 extra i skada med en närstridsattack per runda, men också att dess Försvar baseras på [Kvick −2].",
@@ -78,7 +101,18 @@
       ],
       "ras": [
         "Svartalf"
-      ]
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Reaktiv"
+        ],
+        "Mästare": [
+          "Fri"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Fri. Rollpersonens explosiva överlevnadsinstinkt ger en extra förflyttning en gång per scen.",
@@ -99,7 +133,18 @@
       ],
       "ras": [
         "Alv"
-      ]
+      ],
+      "handling": {
+        "Gesäll": [
+          "Aktiv"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ],
+        "Novis": [
+          "Speciell"
+        ]
+      }
     },
     "nivåer": {
       "Novis": "Handling: Hel runda. Rollpersonen försjunker i en kort trans och får efter ett lyckat Viljestark tillfälligt tillgång till valfri förmåga på novisnivå, undantaget mystiska traditioner samt förmågorna Ritualist och Mystisk kraft. Insikten håller i sig innevarande scen, därefter bleknar den bort.",
@@ -121,25 +166,35 @@
     }
   },
   {
-  "id": "sa8",
-  "namn": "Provocerande",
-  "beskrivning": "Varelsen har en fallenhet för att provocera alla den möter, så till den grad att den kan dra nytta av detta i strid. För fiender som redan är bärsärkarasande (förmågan Bärsärk) behöver inget slag slås i syfte att uppnå nivåernas effekter, det lyckas automatiskt. Fiender med förmågan Ståndaktig får däremot slå motståndsslag varje runda för att försöka återfå fattningen.",
-  "taggar": {
-    "typ": [
-      "Särdrag"
-    ],
-    "test": [
-      "Viljestark"
-    ],
-    "ras": [
-      "Andrik"
-    ]
-  },
-  "nivåer": {
-    "Novis": "Handling: Fri. Med ett lyckat [Viljestark←Listig] kan varelsen få en fiende att bli orimligt provocerad. Om det lyckas får varelsen en andra chans att lyckas med alla slag där den försöker undgå att påverkas av fiendens handlingar (exempelvis Försvar). Endast en fiende i taget kan bringas ur fattningen på detta sätt. Effekten kvarstår under resten av scenen utan ytterligare slag, men om varelsen vill provocera en annan fiende krävs ett nytt slag.",
-    "Gesäll": "Handling: Fri. Som I, men fienden blir också oförsiktig mot anfall. Om slaget mot [Viljestark←Listig] lyckas får varelsen dessutom en andra chans att lyckas med framgångsslag mot fienden.",
-    "Mästare": "Handling: Aktiv. Varelsen är en mästerlig retsticka och kan med ett lyckat slag mot Listig bringa en hel grupp av fienden ur balans. Lyckas slaget blir samtliga fiender högröda av överilad ilska och varelsen får en andra chans på Försvar, motståndsslag och anfall mot samtliga fiender under resten av scenen."
+    "id": "sa8",
+    "namn": "Provocerande",
+    "beskrivning": "Varelsen har en fallenhet för att provocera alla den möter, så till den grad att den kan dra nytta av detta i strid. För fiender som redan är bärsärkarasande (förmågan Bärsärk) behöver inget slag slås i syfte att uppnå nivåernas effekter, det lyckas automatiskt. Fiender med förmågan Ståndaktig får däremot slå motståndsslag varje runda för att försöka återfå fattningen.",
+    "taggar": {
+      "typ": [
+        "Särdrag"
+      ],
+      "test": [
+        "Viljestark"
+      ],
+      "ras": [
+        "Andrik"
+      ],
+      "handling": {
+        "Novis": [
+          "Fri"
+        ],
+        "Gesäll": [
+          "Fri"
+        ],
+        "Mästare": [
+          "Aktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Novis": "Handling: Fri. Med ett lyckat [Viljestark←Listig] kan varelsen få en fiende att bli orimligt provocerad. Om det lyckas får varelsen en andra chans att lyckas med alla slag där den försöker undgå att påverkas av fiendens handlingar (exempelvis Försvar). Endast en fiende i taget kan bringas ur fattningen på detta sätt. Effekten kvarstår under resten av scenen utan ytterligare slag, men om varelsen vill provocera en annan fiende krävs ett nytt slag.",
+      "Gesäll": "Handling: Fri. Som I, men fienden blir också oförsiktig mot anfall. Om slaget mot [Viljestark←Listig] lyckas får varelsen dessutom en andra chans att lyckas med framgångsslag mot fienden.",
+      "Mästare": "Handling: Aktiv. Varelsen är en mästerlig retsticka och kan med ett lyckat slag mot Listig bringa en hel grupp av fienden ur balans. Lyckas slaget blir samtliga fiender högröda av överilad ilska och varelsen får en andra chans på Försvar, motståndsslag och anfall mot samtliga fiender under resten av scenen."
+    }
   }
-}
-
 ]


### PR DESCRIPTION
## Summary
- tag each ability, mystical power, trait and monstrous trait with action type per Novis/Gesäll/Mästare level

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f78bcbc088323894d94f9df15fae6