### PR TITLE
feat: show conflicts for active abilities

### DIFF
--- a/character.html
+++ b/character.html
@@ -46,6 +46,15 @@
     <div id="summaryContent" class="summary-content"></div>
   </aside>
 
+  <!-- Konfliktpanel för aktiva handlingar -->
+  <aside id="conflictPanel">
+    <header class="inv-header">
+      <h2>Kan ej användas samtidigt som</h2>
+      <button class="char-btn icon" id="conflictClose">✕</button>
+    </header>
+    <ul id="conflictList" class="card-list"></ul>
+  </aside>
+
   <!-- Gemensam toolbar + paneler (inventarie, egenskaper, filter) -->
   <shared-toolbar></shared-toolbar>
 

--- a/css/style.css
+++ b/css/style.css
@@ -209,6 +209,7 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
   display: flex;
   flex-direction: column;
   gap: .45rem;
+  position: relative;
 }
 .card-title {
   display: flex;
@@ -217,11 +218,19 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
   font-size: 1.34rem;
   font-weight: 600;
 }
+.card-title .title-actions {
+  display: flex;
+  align-items: center;
+  gap: .4rem;
+}
 .xp-cost {
   font-size: .9rem;
   color: var(--subtxt);
   font-weight: 500;
-  margin-left: .8rem;
+}
+.conflict-btn {
+  padding: .2rem .5rem;
+  font-size: 1.1rem;
 }
 .card-desc  { font-size: 1.15rem; }
 .card.compact .card-desc { display: none; }
@@ -454,7 +463,8 @@ select.level {
 #traitsPanel,
 #yrkePanel,
 #infoPanel,
-#summaryPanel {
+#summaryPanel,
+#conflictPanel {
   position: fixed;
   top: 0;
   right: -100%;
@@ -477,6 +487,7 @@ select.level {
 #filterPanel { max-width: 360px; }
 #traitsPanel { max-width: 360px; }
 #summaryPanel{ max-width: 360px; }
+#conflictPanel { max-width: 360px; }
 #yrkePanel   { max-width: 360px; font-size: 1.2rem; line-height: 1.6; }
 #infoPanel   { max-width: 360px; font-size: 1.1rem; line-height: 1.5; }
 #yrkePanel p { margin: 0 0 1rem; }
@@ -488,7 +499,8 @@ select.level {
 #traitsPanel.open,
 #yrkePanel.open,
 #infoPanel.open,
-#summaryPanel.open {
+#summaryPanel.open,
+#conflictPanel.open {
   right: 0;
 }
 
@@ -497,6 +509,7 @@ select.level {
   #filterPanel { max-width: 460px; }
   #traitsPanel { max-width: 460px; }
   #summaryPanel{ max-width: 460px; }
+  #conflictPanel{ max-width: 460px; }
   #yrkePanel   { max-width: 520px; }
   #infoPanel   { max-width: 520px; }
 }

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -14,6 +14,10 @@ function initCharacter() {
   const summaryClose = document.getElementById('summaryClose');
   const summaryContent = document.getElementById('summaryContent');
 
+  const conflictPanel = document.getElementById('conflictPanel');
+  const conflictClose = document.getElementById('conflictClose');
+  const conflictList = document.getElementById('conflictList');
+
   function renderSummary(){
     const list = storeHelper.getCurrentList(store);
     const inv = storeHelper.getInventory(store);
@@ -122,6 +126,15 @@ function initCharacter() {
   document.addEventListener('click',e=>{
     if(!summaryPanel.contains(e.target) && e.target!==summaryBtn){
       summaryPanel.classList.remove('open');
+    }
+  });
+
+  conflictClose.addEventListener('click',()=>conflictPanel.classList.remove('open'));
+  document.addEventListener('click',e=>{
+    if(conflictPanel.classList.contains('open') &&
+      !conflictPanel.contains(e.target) &&
+      !e.target.closest('.conflict-btn')){
+      conflictPanel.classList.remove('open');
     }
   });
 
@@ -244,10 +257,14 @@ function initCharacter() {
       const xpVal = storeHelper.calcEntryXP(p, storeHelper.getCurrentList(store));
       const xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
       const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
+      const hasActive = p.taggar?.handling?.[p.nivå]?.includes('Aktiv');
+      const conflictBtn = hasActive
+        ? `<button class="char-btn icon conflict-btn" data-name="${p.namn}">💔</button>`
+        : '';
       li.dataset.xp = xpVal;
       const showInfo = compact || hideDetails;
       const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '';
-      li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span>${xpHtml}</div>
+      li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span><span class="title-actions">${xpHtml}${conflictBtn}</span></div>
         <div class="tags">${tagsHtml}</div>
         ${lvlSel}
         ${descHtml}
@@ -299,6 +316,17 @@ function initCharacter() {
 
   /* ta bort & nivåbyte */
   dom.valda.addEventListener('click',e=>{
+    const conflictBtn = e.target.closest('.conflict-btn');
+    if(conflictBtn){
+      const current = conflictBtn.dataset.name;
+      const others = storeHelper.getCurrentList(store)
+        .filter(x=>x.namn!==current && x.taggar?.handling?.[x.nivå]?.includes('Aktiv'));
+      conflictList.innerHTML = others.length
+        ? others.map(x=>`<li class="card">${x.namn}</li>`).join('')
+        : '<li class="card">Inga konflikter.</li>';
+      conflictPanel.classList.add('open');
+      return;
+    }
     const infoBtn=e.target.closest('button[data-info]');
     if(infoBtn){
       const html=decodeURIComponent(infoBtn.dataset.info||'');


### PR DESCRIPTION
## Summary
- add slide-in conflict panel listing other active abilities
- show conflict button on abilities that require an active action
- style conflict panel and button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f83d58fdc8323b85f2b44d67e2b86