### PR TITLE
Show conflict levels in compact view

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -23,16 +23,20 @@ function initCharacter() {
   function conflictEntryHtml(p){
     const compact = storeHelper.getCompactEntries(store);
     const maxIdx = LVL.indexOf(p.nivå || LVL[0]);
+    const lvlTags = LVL.filter((l, i) => i <= maxIdx && p.taggar?.handling?.[l]?.includes('Aktiv'));
     const lvlHtml = LVL.filter((_, i) => i <= maxIdx)
       .map(l => p.taggar?.handling?.[l]?.includes('Aktiv')
         ? `<dt>${l}</dt><dd>${formatText(p.nivåer?.[l] || '')}</dd>`
         : '')
       .filter(Boolean)
       .join('');
+    const tagHtml = compact && lvlTags.length
+      ? `<div class="tags">${lvlTags.map(l=>`<span class="tag">${l}</span>`).join('')}</div>`
+      : '';
     const desc = (!compact && lvlHtml)
       ? `<div class="card-desc"><dl class="levels">${lvlHtml}</dl></div>`
       : '';
-    return `<li class="card${compact ? ' compact' : ''}"><div class="card-title"><span>${p.namn}</span></div>${desc}</li>`;
+    return `<li class="card${compact ? ' compact' : ''}"><div class="card-title"><span>${p.namn}</span></div>${tagHtml}${desc}</li>`;
   }
 
   function renderConflicts(list){
@@ -348,7 +352,7 @@ function initCharacter() {
       conflictAbility.textContent = currentName;
       conflictLevels.innerHTML = curLvls.map(l=>`<span class="tag">${l}</span>`).join('');
       const others = storeHelper.getCurrentList(store)
-        .filter(x=>x.namn!==currentName && x.taggar?.handling?.[x.nivå]?.includes('Aktiv'));
+        .filter(x=>x.namn!==currentName && LVL.some((l, i) => i <= LVL.indexOf(x.nivå || LVL[0]) && x.taggar?.handling?.[l]?.includes('Aktiv')));
       renderConflicts(others);
       conflictPanel.classList.add('open');
       return;


### PR DESCRIPTION
## Summary
- Display active levels for conflicting abilities even in compact view via level tags.
- Ensure conflict list detects any abilities with active levels up to the current rank.

## Testing
- `node --check js/character-view.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f8f257f708323be3837f4ec0b16ae