### PR TITLE
docs: describe conflict button

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -338,6 +338,7 @@ class SharedToolbar extends HTMLElement {
             <strong>K+</strong> låter dig l\u00e4gga till en kvalitet till föremålet från en lista.<br>
             <strong>K🆓</strong> markerar den kostande kvaliteten längst till vänster som gratis.<br>
             <strong>🆓</strong> Gör ett föremål gratis, går att använda flera gånger för en stack av föremål.<br>
+            <strong>💔</strong> visar vilka andra aktiva f\u00f6rm\u00e5gor som inte kan anv\u00e4ndas samtidigt.<br>
             <strong>↔</strong> v\u00e4xlar artefaktens effekt mellan att kosta 1 erfarenhet eller att ge en permanent korruption.<br>
             <strong>🗑</strong> tar bort posten helt.
           </p>


### PR DESCRIPTION
## Summary
- document 💔 conflict button in help panel

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f91472c448323ad63fc65d40f3ae0