### PR TITLE
Display active levels in conflict menu

### DIFF
--- a/character.html
+++ b/character.html
@@ -49,11 +49,9 @@
   <!-- Konfliktpanel för aktiva handlingar -->
   <aside id="conflictPanel">
     <header class="inv-header">
-      <h2>Kan ej användas samtidigt som</h2>
+      <h2 id="conflictTitle">Kan ej användas samtidigt som</h2>
       <button class="char-btn icon" id="conflictClose">✕</button>
     </header>
-    <p id="conflictAbility"></p>
-    <div id="conflictLevels" class="tags"></div>
     <ul id="conflictList" class="card-list"></ul>
   </aside>
 

--- a/css/style.css
+++ b/css/style.css
@@ -232,15 +232,6 @@ input:focus, select:focus { outline: none; border-color: var(--accent); }
   padding: .2rem .5rem;
   font-size: 1.1rem;
 }
-
-#conflictAbility {
-  font-weight: 600;
-  margin: 0 0 .5rem;
-}
-
-#conflictLevels {
-  margin: 0 0 1rem;
-}
 .card-desc  { font-size: 1.15rem; }
 .card.compact .card-desc { display: none; }
 

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -17,8 +17,7 @@ function initCharacter() {
   const conflictPanel = document.getElementById('conflictPanel');
   const conflictClose = document.getElementById('conflictClose');
   const conflictList = document.getElementById('conflictList');
-  const conflictAbility = document.getElementById('conflictAbility');
-  const conflictLevels = document.getElementById('conflictLevels');
+  const conflictTitle = document.getElementById('conflictTitle');
 
   function conflictEntryHtml(p){
     const compact = storeHelper.getCompactEntries(store);
@@ -349,10 +348,13 @@ function initCharacter() {
       const current = storeHelper.getCurrentList(store).find(x=>x.namn===currentName);
       const idx = LVL.indexOf(current?.nivå || LVL[0]);
       const curLvls = LVL.filter((l, i) => i <= idx && current?.taggar?.handling?.[l]?.includes('Aktiv'));
-      conflictAbility.textContent = currentName;
-      conflictLevels.innerHTML = curLvls.map(l=>`<span class="tag">${l}</span>`).join('');
+      const lvlWord = curLvls.length === 1 ? 'nivån' : 'nivåerna';
+      const levelsText = curLvls.length ? ` på ${lvlWord} [${curLvls.join(', ')}]` : '';
+      conflictTitle.textContent = `${currentName}${levelsText} kan ej användas samtidigt som:`;
       const others = storeHelper.getCurrentList(store)
-        .filter(x=>x.namn!==currentName && LVL.some((l, i) => i <= LVL.indexOf(x.nivå || LVL[0]) && x.taggar?.handling?.[l]?.includes('Aktiv')));
+        .filter(x => x.namn !== currentName && LVL.some((l, i) =>
+          i <= LVL.indexOf(x.nivå || LVL[0]) && x.taggar?.handling?.[l]?.includes('Aktiv')
+        ));
       renderConflicts(others);
       conflictPanel.classList.add('open');
       return;


### PR DESCRIPTION
## Summary
- show ability name and active levels in conflict panel header
- remove unused conflict ability and level DOM elements and CSS

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f91ae7b0083239224b1e45c474787