### PR TITLE
Handle lowercase Sjätte Sinne when picking defense trait

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -120,14 +120,16 @@
     if (forced) return forced;
 
     const ABILITY_TRAITS = [
-      { ability: 'Fint',            level: 2, trait: 'Diskret' },
-      { ability: 'Sjätte Sinne',    level: 2, trait: 'Vaksam' },
-      { ability: 'Taktiker',        level: 2, trait: 'Listig' },
+      { ability: 'Fint', level: 2, trait: 'Diskret' },
+      { ability: ['Sjätte Sinne', 'Sjätte sinne'], level: 2, trait: 'Vaksam' },
+      { ability: 'Taktiker', level: 2, trait: 'Listig' },
       { ability: 'Pareringsmästare', level: 1, trait: 'Tr\u00e4ffs\u00e4ker' }
     ];
 
     for (const { ability, level, trait } of ABILITY_TRAITS) {
-      if (storeHelper.abilityLevel(list, ability) >= level) {
+      const abilities = Array.isArray(ability) ? ability : [ability];
+      const highest = abilities.reduce((max, a) => Math.max(max, storeHelper.abilityLevel(list, a)), 0);
+      if (highest >= level) {
         return trait;
       }
     }


### PR DESCRIPTION
## Summary
- Check both `Sjätte Sinne` and `Sjätte sinne` ability levels before switching defense trait to Vaksam
- Support arrays of ability variants in defense trait selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689047f02a2483238712488087224209