### PR TITLE
Add character duplication button and store helper

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,7 @@ const dom  = {
   /* toolbar / panel */
   charSel : $T('charSelect'),   delBtn : $T('deleteChar'),
   newBtn  : $T('newCharBtn'),   xpOut  : $T('xpOut'),
+  dupBtn  : $T('duplicateChar'),
   exportBtn: $T('exportChar'),  importBtn: $T('importChar'),
   xpIn    : $T('xpInput'),      xpSum  : $T('xpSummary'),
   clrBtn  : $T('clearFilters'),
@@ -221,6 +222,15 @@ function bindToolbar() {
       store.current = charId;
 
       storeHelper.save(store);      // sparas nu korrekt
+      location.reload();
+    }
+
+    /* Duplicera rollperson ---------------------------------- */
+    if (id === 'duplicateChar') {
+      if (!store.current) return alert('Ingen rollperson vald.');
+      const newId = storeHelper.duplicateCharacter(store, store.current);
+      store.current = newId;
+      storeHelper.save(store);
       location.reload();
     }
 

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -92,6 +92,7 @@ class SharedToolbar extends HTMLElement {
 
         <div class="char-btn-row">
           <button id="newCharBtn" class="char-btn">Ny rollperson</button>
+          <button id="duplicateChar" class="char-btn">Duplicera</button>
           <button id="deleteChar" class="char-btn danger">Ta bort rollperson</button>
           <button id="exportChar" class="char-btn">Exportera</button>
           <button id="importChar" class="char-btn">Importera</button>
@@ -307,6 +308,7 @@ class SharedToolbar extends HTMLElement {
           <h3>Filtermenyn</h3>
           <p>
             <strong>Ny rollperson</strong> skapar en ny karakt\u00e4r.<br>
+            <strong>Duplicera</strong> kopierar vald karakt\u00e4r.<br>
             <strong>Ta bort rollperson</strong> raderar vald karakt\u00e4r.<br>
             <strong>Exportera</strong> kopierar karakt\u00e4ren som en delbar kod.<br>
             <strong>Importera</strong> \u00e5terst\u00e4ller en sparad karakt\u00e4r från kopierad kod.<br>

--- a/js/store.js
+++ b/js/store.js
@@ -392,6 +392,18 @@
     save(store);
   }
 
+  function duplicateCharacter(store, sourceId) {
+    if (!sourceId) return null;
+    const src = store.characters.find(c => c.id === sourceId);
+    if (!src) return null;
+    const newId = 'rp' + Date.now();
+    const name = `${src.name} (kopia)`;
+    store.characters.push({ id: newId, name });
+    store.data[newId] = JSON.parse(JSON.stringify(store.data[sourceId] || {}));
+    save(store);
+    return newId;
+  }
+
   function deleteCharacter(store, charId) {
     if (!charId) return;
     store.characters = store.characters.filter(c => c.id !== charId);
@@ -1007,6 +1019,7 @@ function defaultTraits() {
     resetPossessionRemoved,
     getHamnskifteRemoved,
     setHamnskifteRemoved,
+    duplicateCharacter,
     deleteCharacter,
     deleteAllCharacters,
     getDependents,


### PR DESCRIPTION
## Summary
- Add "Duplicera" button to filter panel for duplicating characters
- Handle duplicateChar action in main.js to copy current character
- Implement storeHelper.duplicateCharacter to clone character data

## Testing
- `npm test` *(fails: no package.json)*
- `npm run lint` *(fails: no package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68905e561bac8323b112d2449f1d2046