### PR TITLE
Add character rename feature

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -224,6 +224,17 @@ function bindToolbar() {
       location.reload();
     }
 
+    /* Byt namn på rollperson -------------------------------- */
+    if (id === 'renameChar') {
+      if (!store.current) return alert('Ingen rollperson vald.');
+      const char = store.characters.find(c => c.id === store.current);
+      const newName = prompt('Nytt namn?', char ? char.name : '');
+      if (!newName) return;
+      storeHelper.renameCharacter(store, store.current, newName);
+      refreshCharSelect();
+      if (dom.cName) dom.cName.textContent = newName;
+    }
+
     /* Exportera rollperson --------------------------------- */
     if (id === 'exportChar') {
       if (!store.current) return alert('Ingen rollperson vald.');

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -92,6 +92,7 @@ class SharedToolbar extends HTMLElement {
 
         <div class="char-btn-row">
           <button id="newCharBtn" class="char-btn">Ny rollperson</button>
+          <button id="renameChar" class="char-btn">Byt namn</button>
           <button id="deleteChar" class="char-btn danger">Ta bort rollperson</button>
           <button id="exportChar" class="char-btn">Exportera</button>
           <button id="importChar" class="char-btn">Importera</button>

--- a/js/store.js
+++ b/js/store.js
@@ -392,6 +392,14 @@
     save(store);
   }
 
+  function renameCharacter(store, charId, newName) {
+    if (!charId || !newName) return;
+    const char = store.characters.find(c => c.id === charId);
+    if (!char) return;
+    char.name = newName;
+    save(store);
+  }
+
   function deleteCharacter(store, charId) {
     if (!charId) return;
     store.characters = store.characters.filter(c => c.id !== charId);
@@ -1007,6 +1015,7 @@ function defaultTraits() {
     resetPossessionRemoved,
     getHamnskifteRemoved,
     setHamnskifteRemoved,
+    renameCharacter,
     deleteCharacter,
     deleteAllCharacters,
     getDependents,


### PR DESCRIPTION
## Summary
- add rename button in filter panel
- handle rename action in toolbar click delegation
- implement character renaming in store and expose helper

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68905e4b86f8832383407dd4804fd16a