### PR TITLE
Lägg till specialisering för Monsterlärd

### DIFF
--- a/character.html
+++ b/character.html
@@ -21,6 +21,7 @@
   <script src="js/djurmask.js" defer></script>
   <script src="js/beastform.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
+  <script src="js/monsterlard.js" defer></script>
 </head>
 <body data-role="character">
 

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
   <script src="js/djurmask.js" defer></script>
   <script src="js/beastform.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
+  <script src="js/monsterlard.js" defer></script>
   <script src="js/elite-add.js"    defer></script>
 </head>
 <body data-role="index">

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -257,8 +257,14 @@ function initCharacter() {
         raceInfo = `<br><strong>Ras:</strong> ${p.race}`;
         infoHtml += raceInfo;
       }
-      const traitInfo = p.trait ? `<br><strong>Karaktärsdrag:</strong> ${p.trait}` : '';
-      const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml + traitInfo)}">Info</button>`;
+      let traitInfo = '';
+      if (p.trait) {
+        traitInfo = p.namn === 'Monsterlärd'
+          ? `<br><strong>Specialisering:</strong> ${p.trait}`
+          : `<br><strong>Karaktärsdrag:</strong> ${p.trait}`;
+        infoHtml += traitInfo;
+      }
+      const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
 
       const li=document.createElement('li');
       li.className='card' + (compact ? ' compact' : '');
@@ -503,6 +509,24 @@ function initCharacter() {
         ent.nivå = old;
         e.target.value = old;
         return;
+      }
+      if(name==='Monsterlärd'){
+        if(['Gesäll','Mästare'].includes(ent.nivå)){
+          if(!ent.trait && window.monsterLore){
+            monsterLore.pickSpec(spec=>{
+              if(!spec){ ent.nivå=old; e.target.value=old; return; }
+              ent.trait=spec;
+              storeHelper.setCurrentList(store,list); updateXP();
+              renderSkills(filtered()); renderTraits();
+            });
+            return;
+          }
+        }else if(ent.trait){
+          delete ent.trait;
+          storeHelper.setCurrentList(store,list); updateXP();
+          renderSkills(filtered()); renderTraits();
+          return;
+        }
       }
       storeHelper.setCurrentList(store,list); updateXP();
     }

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -111,6 +111,15 @@ function initIndex() {
           infoHtml += `<br><strong>Raser:</strong> ${str}`;
         }
       }
+      let spec = null;
+      if (p.namn === 'Monsterlärd') {
+        spec = charList.find(c => c.namn === 'Monsterlärd')?.trait || null;
+        if (spec) {
+          const t = `<br><strong>Specialisering:</strong> ${spec}`;
+          desc += t;
+          infoHtml += t;
+        }
+      }
       const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
         const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         const count = charList.filter(c => c.namn===p.namn && !c.trait).length;
@@ -130,6 +139,7 @@ function initIndex() {
         ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
         : '';
       const li=document.createElement('li'); li.className='card' + (compact ? ' compact' : '');
+      if (spec) li.dataset.trait = spec;
       const tagsHtml = (p.taggar?.typ || [])
         .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
         .map(t=>`<span class="tag">${t}</span>`).join(' ');
@@ -360,6 +370,16 @@ function initIndex() {
           });
           return;
         }
+        if (p.namn === 'Monsterlärd' && ['Gesäll','Mästare'].includes(lvl) && window.monsterLore) {
+          monsterLore.pickSpec(spec => {
+            if(!spec) return;
+            list.push({ ...p, nivå: lvl, trait: spec });
+            storeHelper.setCurrentList(store,list); updateXP();
+            renderList(filtered());
+            renderTraits();
+          });
+          return;
+        }
         if (p.namn === 'Exceptionellt karakt\u00e4rsdrag' && window.exceptionSkill) {
           const used=list.filter(x=>x.namn===p.namn).map(x=>x.trait).filter(Boolean);
           exceptionSkill.pickTrait(used, trait => {
@@ -541,6 +561,24 @@ function initIndex() {
         ent.nivå = old;
         e.target.value = old;
         return;
+      }
+      if(name==='Monsterlärd'){
+        if(['Gesäll','Mästare'].includes(ent.nivå)){
+          if(!ent.trait && window.monsterLore){
+            monsterLore.pickSpec(spec=>{
+              if(!spec){ ent.nivå=old; e.target.value=old; return; }
+              ent.trait=spec;
+              storeHelper.setCurrentList(store,list); updateXP();
+              renderList(filtered()); renderTraits();
+            });
+            return;
+          }
+        }else if(ent.trait){
+          delete ent.trait;
+          storeHelper.setCurrentList(store,list); updateXP();
+          renderList(filtered()); renderTraits();
+          return;
+        }
       }
       if(name==='Hamnskifte'){
         const lvlMap={"":0,Novis:1, Gesäll:2, Mästare:3};

--- a/js/monsterlard.js
+++ b/js/monsterlard.js
@@ -1,0 +1,50 @@
+(function(window){
+  const SPECS = ['Bestar','Kulturvarelser','Odöda','Styggelser'];
+
+  function createPopup(){
+    if(document.getElementById('monsterPopup')) return;
+    const div=document.createElement('div');
+    div.id='monsterPopup';
+    div.innerHTML=`<div class="popup-inner"><h3>Välj specialisering</h3><div id="monsterOpts"></div><button id="monsterCancel" class="char-btn danger">Avbryt</button></div>`;
+    document.body.appendChild(div);
+  }
+
+  function openPopup(cb){
+    createPopup();
+    const pop=document.getElementById('monsterPopup');
+    const box=pop.querySelector('#monsterOpts');
+    const cls=pop.querySelector('#monsterCancel');
+    box.innerHTML=SPECS.map((n,i)=>`<button data-i="${i}" class="char-btn">${n}</button>`).join('');
+    pop.classList.add('open');
+    function close(){
+      pop.classList.remove('open');
+      box.innerHTML='';
+      box.removeEventListener('click',onClick);
+      cls.removeEventListener('click',onCancel);
+      pop.removeEventListener('click',onOutside);
+    }
+    function onClick(e){
+      const b=e.target.closest('button[data-i]');
+      if(!b) return;
+      const idx=Number(b.dataset.i);
+      close();
+      cb(SPECS[idx]);
+    }
+    function onCancel(){ close(); cb(null); }
+    function onOutside(e){
+      if(!pop.querySelector('.popup-inner').contains(e.target)){
+        close();
+        cb(null);
+      }
+    }
+    box.addEventListener('click',onClick);
+    cls.addEventListener('click',onCancel);
+    pop.addEventListener('click',onOutside);
+  }
+
+  function pickSpec(cb){
+    openPopup(res=>cb(res));
+  }
+
+  window.monsterLore={pickSpec};
+})(window);


### PR DESCRIPTION
## Sammanfattning
- Skapar `monsterlard.js` med popup för val av specialisering.
- Integrerar specialiseringsval i index- och karaktärsvyn samt visar vald specialisering.
- Laddar nya modulen i både index- och karaktärssidan.

## Testning
- `npm test` *(misslyckas: Could not read package.json)*
- `node --check js/monsterlard.js js/index-view.js js/character-view.js`


------
https://chatgpt.com/codex/tasks/task_e_68905e9640948323a121e147f0679402