### PR TITLE
Add character duplication feature

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,7 @@ const $T   = id => bar.shadowRoot.getElementById(id);        // shadow-DOM
 const dom  = {
   /* toolbar / panel */
   charSel : $T('charSelect'),   delBtn : $T('deleteChar'),
-  newBtn  : $T('newCharBtn'),   xpOut  : $T('xpOut'),
+  newBtn  : $T('newCharBtn'),   dupBtn : $T('duplicateChar'),   xpOut  : $T('xpOut'),
   exportBtn: $T('exportChar'),  importBtn: $T('importChar'),
   xpIn    : $T('xpInput'),      xpSum  : $T('xpSummary'),
   clrBtn  : $T('clearFilters'),
@@ -222,6 +222,17 @@ function bindToolbar() {
 
       storeHelper.save(store);      // sparas nu korrekt
       location.reload();
+    }
+
+    /* Kopiera rollperson ----------------------------------- */
+    if (id === 'duplicateChar') {
+      if (!store.current) return alert('Ingen rollperson vald.');
+      const newId = storeHelper.duplicateCharacter(store, store.current);
+      if (newId) {
+        store.current = newId;
+        storeHelper.save(store);
+        location.reload();
+      }
     }
 
     /* Byt namn på rollperson -------------------------------- */

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -92,6 +92,7 @@ class SharedToolbar extends HTMLElement {
 
         <div class="char-btn-row">
           <button id="newCharBtn" class="char-btn">Ny rollperson</button>
+          <button id="duplicateChar" class="char-btn">Kopiera rollperson</button>
           <button id="renameChar" class="char-btn">Byt namn</button>
           <button id="deleteChar" class="char-btn danger">Ta bort rollperson</button>
           <button id="exportChar" class="char-btn">Exportera</button>

--- a/js/store.js
+++ b/js/store.js
@@ -392,6 +392,18 @@
     save(store);
   }
 
+  function duplicateCharacter(store, sourceId) {
+    if (!sourceId) return null;
+    const char = store.characters.find(c => c.id === sourceId);
+    if (!char) return null;
+    const newId = 'rp' + Date.now();
+    store.characters.push({ id: newId, name: `${char.name} (kopia)` });
+    const data = store.data[sourceId] ? JSON.parse(JSON.stringify(store.data[sourceId])) : {};
+    store.data[newId] = data;
+    save(store);
+    return newId;
+  }
+
   function renameCharacter(store, charId, newName) {
     if (!charId || !newName) return;
     const char = store.characters.find(c => c.id === charId);
@@ -1015,6 +1027,7 @@ function defaultTraits() {
     resetPossessionRemoved,
     getHamnskifteRemoved,
     setHamnskifteRemoved,
+    duplicateCharacter,
     renameCharacter,
     deleteCharacter,
     deleteAllCharacters,


### PR DESCRIPTION
## Summary
- Add "Kopiera rollperson" button to toolbar's filter panel
- Support duplicating selected character via new store helper and toolbar action
- Export new helper for character duplication

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890615c7d2c83238a4d78e4461d0797