### PR TITLE
Enable character PDF export

### DIFF
--- a/character.html
+++ b/character.html
@@ -7,6 +7,7 @@
 
   <link rel="stylesheet" href="css/style.css">
   <script src="https://unpkg.com/pdf-lib/dist/pdf-lib.min.js" defer></script>
+  <script src="js/export-pdf.js" defer></script>
   <script src="js/text-format.js" defer></script>
   <script src="js/lz-string.min.js" defer></script>
   <script src="js/store.js"          defer></script>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 
   <link rel="stylesheet" href="css/style.css">
   <script src="https://unpkg.com/pdf-lib/dist/pdf-lib.min.js" defer></script>
+  <script src="js/export-pdf.js" defer></script>
   <script src="js/text-format.js" defer></script>
   <script src="js/lz-string.min.js" defer></script>
   <script src="js/store.js"        defer></script>

--- a/js/export-pdf.js
+++ b/js/export-pdf.js
@@ -1,0 +1,28 @@
+// Simple PDF export functionality using pdf-lib
+// Provides exportPdf.exportCharacterPdf(store, charId)
+
+async function exportCharacterPdf(store, charId) {
+  const char = store.characters.find(c => c.id === charId);
+  if (!char) return;
+
+  const { PDFDocument } = PDFLib;
+  const pdfBytes = await fetch('export/symbaroum_rollformular.pdf').then(res => res.arrayBuffer());
+  const pdfDoc = await PDFDocument.load(pdfBytes);
+  const form = pdfDoc.getForm();
+  try {
+    const nameField = form.getTextField('Namn');
+    nameField.setText(char.name || '');
+  } catch (err) {
+    console.error('Kunde inte sätta namn i PDF', err);
+  }
+  const bytes = await pdfDoc.save();
+  const blob = new Blob([bytes], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = (char.name || 'character') + '.pdf';
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+window.exportPdf = { exportCharacterPdf };

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,9 @@
 const ROLE   = document.body.dataset.role;           // 'index' | 'character'
 let   store  = storeHelper.load();                   // Lokal lagring
 
+/* Extern PDF-exportfunktion */
+const exportPdf = window.exportPdf;
+
 /* ---------- Snabb DOM-access ---------- */
 const bar  = document.querySelector('shared-toolbar');
 const $T   = id => bar.shadowRoot.getElementById(id);        // shadow-DOM
@@ -253,6 +256,11 @@ function bindToolbar() {
       copyToClipboard(code)
         .then(() => alert('Karakt\u00e4rskoden har kopierats.'))
         .catch(() => prompt('Kopiera koden nedan:', code));
+    }
+
+    if (id === 'exportCharPdf') {
+      if (!store.current) return alert('Ingen rollperson vald.');
+      exportPdf.exportCharacterPdf(store, store.current);
     }
 
     /* Importera rollperson -------------------------------- */


### PR DESCRIPTION
## Summary
- add export-pdf helper using pdf-lib
- wire up Exportera PDF button in main.js
- load export-pdf script in both pages so the toolbar button works

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890792d97f08323a9523c7c6795cb84