### PR TITLE
feat: load PDF templates for export

### DIFF
--- a/js/export-pdf.js
+++ b/js/export-pdf.js
@@ -1,28 +1,42 @@
-// Simple PDF export functionality using pdf-lib
-// Provides exportPdf.exportCharacterPdf(store, charId)
+const exportPdf = {
+  pdfDoc: null,
+  form: null,
+  fieldTemplate: null,
+  fieldTypes: null,
 
-async function exportCharacterPdf(store, charId) {
-  const char = store.characters.find(c => c.id === charId);
-  if (!char) return;
+  async loadAssets() {
+    if (this.pdfDoc) return;
+    const [pdfBytes, templateJson, typesJson] = await Promise.all([
+      fetch('export/symbaroum_rollformular.pdf').then(r => r.arrayBuffer()),
+      fetch('export/symbaroum_pdf_fields_template.json').then(r => r.json()),
+      fetch('export/symbaroum_pdf_fields_types.json').then(r => r.json())
+    ]);
+    const { PDFDocument } = PDFLib;
+    this.pdfDoc = await PDFDocument.load(pdfBytes);
+    this.form = this.pdfDoc.getForm();
+    this.fieldTemplate = templateJson;
+    this.fieldTypes = typesJson;
+  },
 
-  const { PDFDocument } = PDFLib;
-  const pdfBytes = await fetch('export/symbaroum_rollformular.pdf').then(res => res.arrayBuffer());
-  const pdfDoc = await PDFDocument.load(pdfBytes);
-  const form = pdfDoc.getForm();
-  try {
-    const nameField = form.getTextField('Namn');
-    nameField.setText(char.name || '');
-  } catch (err) {
-    console.error('Kunde inte sätta namn i PDF', err);
+  async exportCharacterPdf(store, charId) {
+    await this.loadAssets();
+    const char = store.characters.find(c => c.id === charId);
+    if (!char) return;
+    try {
+      const nameField = this.form.getTextField('Namn');
+      nameField.setText(char.name || '');
+    } catch (err) {
+      console.error('Kunde inte sätta namn i PDF', err);
+    }
+    const bytes = await this.pdfDoc.save();
+    const blob = new Blob([bytes], { type: 'application/pdf' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = (char.name || 'character') + '.pdf';
+    a.click();
+    URL.revokeObjectURL(url);
   }
-  const bytes = await pdfDoc.save();
-  const blob = new Blob([bytes], { type: 'application/pdf' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = (char.name || 'character') + '.pdf';
-  a.click();
-  URL.revokeObjectURL(url);
-}
+};
 
-window.exportPdf = { exportCharacterPdf };
+window.exportPdf = exportPdf;


### PR DESCRIPTION
## Summary
- load PDF form and template JSONs for export
- expose `exportPdf.exportCharacterPdf` that uses pdf-lib

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68907b212d248323a97c1af1f89c2d36