### PR TITLE
Use Swedish default name for exported PDF

### DIFF
--- a/js/export-pdf.js
+++ b/js/export-pdf.js
@@ -93,14 +93,13 @@ const exportPdf = {
       this.setField(`Korruption, artefakt ${i}`, art.korruption || art.corruption || '');
     });
 
-    const bytes = await this.pdfDoc.save();
-    const blob = new Blob([bytes], { type: 'application/pdf' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = (char.name || 'character') + '.pdf';
-    a.click();
-    URL.revokeObjectURL(url);
+    const pdfBytes = await this.pdfDoc.save();
+    const blob = new Blob([pdfBytes], { type: 'application/pdf' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `${char.name || 'karaktar'}.pdf`;
+    link.click();
+    URL.revokeObjectURL(link.href);
   }
 };
 


### PR DESCRIPTION
## Summary
- Update PDF export logic to use `char.name` or fallback "karaktar" in download name
- Simplify PDF blob creation and link generation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68907e8ddb6083239576126be2ec5f5e