### PR TITLE
Use global exportPdf object

### DIFF
--- a/js/export-pdf.js
+++ b/js/export-pdf.js
@@ -1,4 +1,4 @@
-const exportPdf = {
+window.exportPdf = {
   pdfDoc: null,
   form: null,
   font: null,
@@ -129,5 +129,3 @@ const exportPdf = {
     URL.revokeObjectURL(link.href);
   }
 };
-
-window.exportPdf = exportPdf;


### PR DESCRIPTION
## Summary
- Define exportPdf directly on the global window object and remove duplicate assignment

## Testing
- `npm test` *(fails: could not find package.json)*
- `node -e "global.window={}; require('./js/export-pdf.js'); require('./js/export-pdf.js'); console.log('loaded');"`


------
https://chatgpt.com/codex/tasks/task_e_689084e9ac448323bc2a618cf7b61e40