### PR TITLE
Add notes page with form persistence

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -179,6 +179,7 @@ function boot() {
   if (dom.traits) { renderTraits(); bindTraits(); }
   if (ROLE === 'index')     initIndex();
   if (ROLE === 'character') initCharacter();
+  if (ROLE === 'notes')     initNotes();
 }
 
 /* ===========================================================

--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -1,0 +1,23 @@
+(function(window){
+  function initNotes() {
+    const form = document.getElementById('characterForm');
+    if(!form) return;
+    const fields = ['shadow','age','appearance','manner','quote','goal','drives','loyalties','likes','hates','background'];
+    const notes = storeHelper.getNotes(store);
+    fields.forEach(id=>{
+      const el=form.querySelector('#'+id);
+      if(el) el.value=notes[id]||'';
+    });
+    form.addEventListener('submit',e=>{
+      e.preventDefault();
+      const obj={};
+      fields.forEach(id=>{
+        const el=form.querySelector('#'+id);
+        obj[id]=el?el.value:'';
+      });
+      storeHelper.setNotes(store,obj);
+      alert('Anteckningar sparade!');
+    });
+  }
+  window.initNotes=initNotes;
+})(window);

--- a/js/store.js
+++ b/js/store.js
@@ -580,6 +580,36 @@ function defaultTraits() {
     save(store);
   }
 
+  /* ---------- 6b. Anteckningar ---------- */
+  function defaultNotes() {
+    return {
+      shadow: '',
+      age: '',
+      appearance: '',
+      manner: '',
+      quote: '',
+      goal: '',
+      drives: '',
+      loyalties: '',
+      likes: '',
+      hates: '',
+      background: ''
+    };
+  }
+
+  function getNotes(store) {
+    if (!store.current) return defaultNotes();
+    const data = store.data[store.current] || {};
+    return { ...defaultNotes(), ...(data.notes || {}) };
+  }
+
+  function setNotes(store, notes) {
+    if (!store.current) return;
+    store.data[store.current] = store.data[store.current] || {};
+    store.data[store.current].notes = { ...defaultNotes(), ...notes };
+    save(store);
+  }
+
   /* ---------- 6. XP-hantering ---------- */
   const XP_LADDER = { Novis: 10, Gesäll: 30, Mästare: 60 };
 
@@ -989,6 +1019,8 @@ function defaultTraits() {
     setInventory,
     getCustomEntries,
     setCustomEntries,
+    getNotes,
+    setNotes,
     getMoney,
     setMoney,
     getBonusMoney,

--- a/notes.html
+++ b/notes.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Anteckningar</title>
+
+  <link rel="stylesheet" href="css/style.css">
+  <script src="js/pdf-lib.min.js" defer></script>
+  <script src="js/export-pdf.js" defer></script>
+  <script src="js/text-format.js" defer></script>
+  <script src="js/lz-string.min.js" defer></script>
+  <script src="js/store.js"          defer></script>
+  <script src="js/utils.js"          defer></script>
+  <script src="js/inventory-utils.js" defer></script>
+  <script src="js/traits-utils.js" defer></script>
+  <script src="js/shared-toolbar.js" defer></script>
+  <script src="js/yrke-panel.js"  defer></script>
+  <script src="js/elite-req.js"   defer></script>
+  <script src="js/notes-view.js"  defer></script>
+  <script src="js/main.js"        defer></script>
+  <script src="js/exceptionellt.js" defer></script>
+  <script src="js/djurmask.js" defer></script>
+  <script src="js/beastform.js" defer></script>
+  <script src="js/bloodbond.js" defer></script>
+  <script src="js/monsterlard.js" defer></script>
+</head>
+<body data-role="notes">
+
+  <div class="panel">
+    <h1 class="app-title">Anteckningar</h1>
+    <form id="characterForm">
+
+      <!-- -------- Kortfattat -------- -->
+      <h3>Kortfattat</h3>
+      <div class="field-row">
+        <div class="form-group">
+          <label for="shadow">Skugga</label>
+          <input type="text" id="shadow" name="shadow" placeholder="Ex. ’Smygaren’">
+        </div>
+        <div class="form-group">
+          <label for="age">Ålder</label>
+          <input type="text" id="age" name="age" placeholder="T.ex. 34">
+        </div>
+      </div>
+      <div class="field-row">
+        <div class="form-group">
+          <label for="appearance">Utseende</label>
+          <input type="text" id="appearance" name="appearance" placeholder="Kort beskrivning">
+        </div>
+        <div class="form-group">
+          <label for="manner">Manér</label>
+          <input type="text" id="manner" name="manner" placeholder="Särskilda drag">
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="quote">Citat</label>
+        <input type="text" id="quote" name="quote" placeholder="Signaturcitat">
+      </div>
+
+      <!-- -------- Mellanlångt -------- -->
+      <h3>Mellanlångt</h3>
+      <div class="field-row">
+        <div class="form-group">
+          <label for="goal">Personligt mål</label>
+          <input type="text" id="goal" name="goal" placeholder="Livsmål, ambition">
+        </div>
+        <div class="form-group">
+          <label for="drives">Drivkrafter</label>
+          <input type="text" id="drives" name="drives" placeholder="Vad får dem att agera?">
+        </div>
+      </div>
+      <div class="field-row">
+        <div class="form-group">
+          <label for="loyalties">Lojaliteter</label>
+          <input type="text" id="loyalties" name="loyalties" placeholder="T.ex. familj, gille">
+        </div>
+        <div class="form-group">
+          <label for="likes">Älskar</label>
+          <input type="text" id="likes" name="likes" placeholder="T.ex. skogar, böcker">
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="hates">Hatar</label>
+        <input type="text" id="hates" name="hates" placeholder="T.ex. orättvisa, korruption">
+      </div>
+
+      <!-- -------- Lång text -------- -->
+      <h3>Bakgrund</h3>
+      <div class="form-group">
+        <label for="background">Berätta om bakgrund</label>
+        <textarea id="background" name="background" rows="6" placeholder="Här kan du skriva längre text…"></textarea>
+      </div>
+
+      <!-- -------- Knappar -------- -->
+      <div class="char-btn-row">
+        <button type="submit" class="char-btn">Spara</button>
+        <button type="reset"  class="char-btn danger">Rensa</button>
+      </div>
+
+    </form>
+  </div>
+
+  <shared-toolbar></shared-toolbar>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add notes.html with notes form, script tags, toolbar, and data-role
- implement notes-view.js to load/save notes fields via storeHelper
- extend storeHelper with getNotes/setNotes and wire boot to initNotes

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6891c0b62e188323944640ce69c61511