### PR TITLE
Export notes fields to PDF

### DIFF
--- a/js/export-pdf.js
+++ b/js/export-pdf.js
@@ -65,6 +65,19 @@ window.exportPdf = {
     this.setField('Total erfarenhet', totalXp);
     this.setField('Oanvänd erfarenhet', unusedXp);
 
+    const notes = storeHelper.getNotes(store);
+    this.setField('Skugga', notes.shadow);
+    this.setField('Ålder', notes.age);
+    this.setField('Utseende', notes.appearance);
+    this.setField('Manér', notes.manner);
+    this.setField('Citat', notes.quote);
+    this.setField('Personligt mål', notes.goal);
+    this.setField('Drivkrafter', notes.drives);
+    this.setField('Lojaliteter', notes.loyalties);
+    this.setField('Älskar', notes.likes);
+    this.setField('Hatar', notes.hates);
+    this.setField('Bakgrund', notes.background);
+
     Object.entries(traits).forEach(([k, v]) => this.setField(k, v));
 
     let truncated = false;


### PR DESCRIPTION
## Summary
- include character notes (shadow, age, appearance, manner, quote, goal, drives, loyalties, likes, hates, background) when exporting character sheets to PDF

## Testing
- `npm test` *(fails: Could not read package.json)*
- Node script using pdf-lib set 11 note fields in `symbaroum_rollformular.pdf`


------
https://chatgpt.com/codex/tasks/task_e_6891c5cb1324832398d4a56f1b0b75b9