### PR TITLE
docs: add notes page info and toolbar help

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A static web app for managing characters and inventory for the Symbaroum RPG. Op
 - [Funktioner](#funktioner)
 - [Projektstruktur](#projektstruktur)
 - [Export och import av rollpersoner](#export-och-import-av-rollpersoner)
+- [Anteckningssidan](#anteckningssidan)
 - [Användarmanual](#användarmanual)
 - [Utveckling och bidrag](#utveckling-och-bidrag)
 
@@ -35,6 +36,11 @@ Sidan fungerar helt offline och sparar all data i din webbläsares lagring.
 ## Export och import av rollpersoner
 
 Use the **Exportera** button in the filter panel to copy a short code representing the current character. Codes are compressed and only contain references to the built‑in database. The **Importera** button lets you paste such a code to recreate the character (requires that the database is loaded). Anteckningar följer med vid export så länge något fält är ifyllt.
+
+## Anteckningssidan
+
+`notes.html` är en fristående sida där du kan skriva bakgrund och övriga anteckningar för rollpersonen. All text sparas i webbläsarens lagring och inkluderas automatiskt vid export och import av rollpersonen.
+
 ## Användarmanual
 
 ### 1. Kom igång

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -307,7 +307,7 @@ class SharedToolbar extends HTMLElement {
         <div class="help-content">
           <h3>Verktygsrad</h3>
           <p>
-            <strong>🔄</strong> Byter mellan index- och rollpersons-vy.<br>
+            <strong>🔄/↩️</strong> Byter mellan index- och rollpersons-vy. Anteckningssidan använder ↩️ för att gå tillbaka.<br>
             <strong>🎒</strong> \u00d6ppnar inventariet.<br>
             <strong>📊</strong> \u00d6ppnar egenskaper.<br>
             <strong>Rensa filter</strong> nollst\u00e4ller filtren.<br>
@@ -319,6 +319,7 @@ class SharedToolbar extends HTMLElement {
             <strong>Ta bort rollperson</strong> raderar vald karakt\u00e4r.<br>
             <strong>Exportera</strong> kopierar karakt\u00e4ren som en delbar kod.<br>
             <strong>Importera</strong> \u00e5terst\u00e4ller en sparad karakt\u00e4r från kopierad kod.<br>
+            <strong>📜</strong> \u00f6ppnar anteckningssidan.<br>
             <strong>⚒️/⚗️/🏺</strong> v\u00e4ljer niv\u00e5 p\u00e5 smed, alkemist och artefaktmakare för prisreducieringar.<br>
             <strong>🔭</strong> l\u00e5ter tillagda filter utöka sökningen istället för att göra den snävare.<br>
             <strong>🤏</strong> v\u00e4xlar till kompakt vy.<br>


### PR DESCRIPTION
## Summary
- clarify that ↩️ on the notes page returns to the index
- mention the 📜 link in the filter menu help
- document `notes.html` and its export/import support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891c7002a6883239bb35459c115b4d8