### PR TITLE
Handle PDF asset load failures

### DIFF
--- a/js/export-pdf.js
+++ b/js/export-pdf.js
@@ -7,14 +7,21 @@ window.exportPdf = {
 
   async loadAssets() {
     if (this.pdfDoc) return;
-    const [pdfBytes, templateJson, typesJson, fontBytes] = await Promise.all([
-      fetch('export/symbaroum_rollformular.pdf').then(r => r.arrayBuffer()),
-      fetch('export/symbaroum_pdf_fields_template.json').then(r => r.json()),
-      fetch('export/symbaroum_pdf_fields_types.json').then(r => r.json()),
-      // "Libre Caslon Display" är licensierad under SIL Open Font License
-      // och kan distribueras tillsammans med projektet. Se Libre_Caslon_Display/OFL.txt.
-      fetch('Libre_Caslon_Display/LibreCaslonDisplay-Regular.ttf').then(r => r.arrayBuffer())
-    ]);
+    let pdfBytes, templateJson, typesJson, fontBytes;
+    try {
+      [pdfBytes, templateJson, typesJson, fontBytes] = await Promise.all([
+        fetch('export/symbaroum_rollformular.pdf').then(r => r.arrayBuffer()),
+        fetch('export/symbaroum_pdf_fields_template.json').then(r => r.json()),
+        fetch('export/symbaroum_pdf_fields_types.json').then(r => r.json()),
+        // "Libre Caslon Display" är licensierad under SIL Open Font License
+        // och kan distribueras tillsammans med projektet. Se Libre_Caslon_Display/OFL.txt.
+        fetch('Libre_Caslon_Display/LibreCaslonDisplay-Regular.ttf').then(r => r.arrayBuffer())
+      ]);
+    } catch (err) {
+      console.error('Kunde inte ladda PDF-resurser', err);
+      alert('Kunde inte ladda PDF-resurser.');
+      return;
+    }
     if (!window.PDFLib) {
       console.error('PDFLib är inte tillgängligt. Kan inte exportera PDF.');
       return;


### PR DESCRIPTION
## Summary
- Guard PDF asset loading with try/catch and alert on failure

## Testing
- `node - <<'NODE'` (assets load successfully)
- `node - <<'NODE'` (simulated missing asset triggers alert and no unhandled rejection)


------
https://chatgpt.com/codex/tasks/task_e_6891f77b6dd083238f3c2ef9667453ab