### PR TITLE
Restrict Dark Blood traits and adjust Bestialisk XP

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -402,6 +402,32 @@ function initCharacter() {
         const lvlSel = liEl.querySelector('select.level');
         let   lvl = lvlSel ? lvlSel.value : null;
         if (!lvl && p.nivåer) lvl = LVL.find(l => p.nivåer[l]) || p.nivå;
+        if(isMonstrousTrait(p)){
+          const baseName = storeHelper.HAMNSKIFTE_BASE[p.namn] || p.namn;
+          const baseRace = before.find(isRas)?.namn;
+          const trollTraits = ['Naturligt vapen', 'Pansar', 'Regeneration', 'Robust'];
+          const undeadTraits = ['Gravkyla', 'Skräckslå', 'Vandödhet'];
+          const bloodvaderTraits = ['Naturligt vapen','Pansar','Regeneration','Robust'];
+          const hamLvl = storeHelper.abilityLevel(before, 'Hamnskifte');
+          const bloodRaces = before.filter(x => x.namn === 'Blodsband' && x.race).map(x => x.race);
+          let monsterOk = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
+            (before.some(x => x.namn === 'Mörkt blod') && storeHelper.DARK_BLOOD_TRAITS.includes(baseName)) ||
+            (baseRace === 'Troll' && trollTraits.includes(baseName)) ||
+            (baseRace === 'Vandöd' && undeadTraits.includes(baseName)) ||
+            (baseRace === 'Rese' && baseName === 'Robust') ||
+            (before.some(x => x.namn === 'Blodvadare') && bloodvaderTraits.includes(baseName)) ||
+            ((baseRace === 'Andrik' || bloodRaces.includes('Andrik')) && baseName === 'Diminutiv') ||
+            (hamLvl >= 2 && lvl === 'Novis' && ['Naturligt vapen','Pansar'].includes(baseName)) ||
+            (hamLvl >= 3 && lvl === 'Novis' && ['Regeneration','Robust'].includes(baseName));
+          if(!monsterOk){
+            if(!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?'))
+              return;
+          }
+          if (storeHelper.hamnskifteNoviceLimit(before, p, lvl)) {
+            alert('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
+            return;
+          }
+        }
         if(name==='Råstyrka'){
           const robust=before.find(x=>x.namn==='Robust');
           const hasRobust=!!robust && (robust.nivå===undefined || robust.nivå!=='');
@@ -420,7 +446,8 @@ function initCharacter() {
         if(!confirm('Bestialisk hänger ihop med Mörkt blod. Ta bort ändå?'))
           return;
       }
-      if(isMonstrousTrait(p) && before.some(x=>x.namn==='Mörkt blod')){
+      const baseRem = storeHelper.HAMNSKIFTE_BASE[p.namn] || p.namn;
+      if(isMonstrousTrait(p) && storeHelper.DARK_BLOOD_TRAITS.includes(baseRem) && before.some(x=>x.namn==='Mörkt blod')){
         if(!confirm(name+' hänger ihop med Mörkt blod. Ta bort ändå?'))
           return;
       }

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -314,7 +314,7 @@ function initIndex() {
           const hamLvl = storeHelper.abilityLevel(list, 'Hamnskifte');
           const bloodRaces = list.filter(x => x.namn === 'Blodsband' && x.race).map(x => x.race);
           monsterOk = (p.taggar.typ || []).includes('Elityrkesförmåga') ||
-            list.some(x => x.namn === 'Mörkt blod') ||
+            (list.some(x => x.namn === 'Mörkt blod') && storeHelper.DARK_BLOOD_TRAITS.includes(baseName)) ||
             (baseRace === 'Troll' && trollTraits.includes(baseName)) ||
             (baseRace === 'Vandöd' && undeadTraits.includes(baseName)) ||
             (baseRace === 'Rese' && baseName === 'Robust') ||
@@ -456,7 +456,8 @@ function initIndex() {
           if(!confirm('Bestialisk hänger ihop med Mörkt blod. Ta bort ändå?'))
             return;
         }
-        if(isMonstrousTrait(p) && before.some(x=>x.namn==='Mörkt blod')){
+        const baseRem = storeHelper.HAMNSKIFTE_BASE[p.namn] || p.namn;
+        if(isMonstrousTrait(p) && storeHelper.DARK_BLOOD_TRAITS.includes(baseRem) && before.some(x=>x.namn==='Mörkt blod')){
           if(!confirm(p.namn+' hänger ihop med Mörkt blod. Ta bort ändå?'))
             return;
         }

--- a/js/store.js
+++ b/js/store.js
@@ -18,6 +18,8 @@
     Object.entries(HAMNSKIFTE_NAMES).map(([k,v]) => [v,k])
   );
 
+  const DARK_BLOOD_TRAITS = ['Naturligt vapen', 'Pansar', 'Robust', 'Regeneration', 'Vingar'];
+
   /* ---------- 1. Grund­struktur ---------- */
   function emptyStore() {
     return {
@@ -108,7 +110,6 @@
   function applyDarkBloodEffects(list) {
     const hasDark = list.some(x => x.namn === 'Mörkt blod');
     const idxBest = list.findIndex(x => x.namn === 'Bestialisk');
-    const extra = ['Naturligt vapen', 'Pansar', 'Robust', 'Regeneration', 'Vingar'];
 
     if (hasDark) {
       if (idxBest < 0) {
@@ -211,9 +212,9 @@
     }
 
     if (name === 'M\u00f6rkt blod') {
-      const extras = ['Naturligt vapen','Pansar','Robust','Regeneration','Vingar'];
       list.forEach(it => {
-        if (isMonstrousTrait(it) || it.namn === 'Bestialisk' || extras.includes(it.namn)) {
+        const base = HAMNSKIFTE_BASE[it.namn] || it.namn;
+        if (it.namn === 'Bestialisk' || DARK_BLOOD_TRAITS.includes(base)) {
           if (it.namn !== name) out.push(it.namn);
         }
       });
@@ -763,7 +764,11 @@ function defaultTraits() {
 
   function calcEntryXP(entry, list) {
     const types = (entry.taggar?.typ || []).map(t => t.toLowerCase());
-    if (types.includes('nackdel')) return -5;
+    if (types.includes('nackdel')) {
+      const hasDark = (list || []).some(x => x.namn === 'Mörkt blod');
+      if (entry.namn === 'Bestialisk' && hasDark) return 0;
+      return -5;
+    }
     let xp = 0;
     if (
       entry.nivåer &&
@@ -1086,6 +1091,7 @@ function defaultTraits() {
     deleteAllCharacters,
     getDependents,
     HAMNSKIFTE_NAMES,
-    HAMNSKIFTE_BASE
+    HAMNSKIFTE_BASE,
+    DARK_BLOOD_TRAITS
   };
 })(window);


### PR DESCRIPTION
## Summary
- Prevent Bestialisk from granting XP when paired with Mörkt blod
- Limit Mörkt blod to a specific set of monstrous traits in UI and dependency checks

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/store.js js/index-view.js js/character-view.js`

------
https://chatgpt.com/codex/tasks/task_e_6891f87885108323b15c9b85012c6d89