### PR TITLE
Add Ledare ability reminder for mystic powers

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -111,6 +111,9 @@ function initCharacter() {
     if(storeHelper.abilityLevel(list,'Dominera') >= 1){
       cond.push('Övertygande som träffsäker i närstrid');
     }
+    if(storeHelper.abilityLevel(list,'Ledare') >= 1){
+      cond.push('Övertygande istället för Viljestark vid mystiska förmågor och ritualer');
+    }
     if(!cond.length) cond.push('Inga särskilda ersättningar');
 
     summaryContent.innerHTML = `

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -226,6 +226,9 @@
       if (k === 'Övertygande' && storeHelper.abilityLevel(list, 'Dominera') >= 1) {
         extra += '<div class="trait-extra">Kan användas som träffsäker för attacker i närstrid</div>';
       }
+      if (k === 'Övertygande' && storeHelper.abilityLevel(list, 'Ledare') >= 1) {
+        extra += '<div class="trait-extra">Kan användas istället för Viljestark vid användandet av mystiska förmågor och ritualer</div>';
+      }
       if (k === defTrait) {
         const defHtml = defs.map(d => `<div class="trait-extra">Försvar${d.name ? ' (' + d.name + ')' : ''}: ${d.value}</div>`).join('');
         extra += defHtml;


### PR DESCRIPTION
## Summary
- note in traits panel: Övertygande can replace Viljestark for mystic powers/rituals when Ledare is Novis or better
- include the same reminder in the overview summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f8e90e188323a3b79541e9352906