### PR TITLE
Add notes preview and faction field

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -79,6 +79,8 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 .char-btn:hover  { opacity: .85; }
 .char-btn:active { transform: scale(.95); opacity: .7; }
 
+.hidden { display: none; }
+
 /* Knapp för översiktsmeny */
 .summary-btn {
   margin-left: auto;
@@ -1094,6 +1096,10 @@ textarea {
 /* Knapprad längst ner */
 .char-btn-row {
   margin-top: 1.2rem;
+}
+
+#notesDisplay {
+  white-space: pre-wrap;
 }
 
 /* Mobil: stapla kolumnerna */

--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -1,13 +1,69 @@
 (function(window){
-  function initNotes() {
-    const form = document.getElementById('characterForm');
-    if(!form) return;
-    const fields = ['shadow','age','appearance','manner','quote','goal','drives','loyalties','likes','hates','background'];
+  const fields = ['shadow','age','appearance','manner','quote','faction','goal','drives','loyalties','likes','hates','background'];
+  let form, previewBtn, editBtn, notesDisplay;
+
+  const esc = str => (str||'').replace(/[&<>"']/g, c=>({
+    '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'
+  }[c]));
+
+  const simple = (label,val)=> val ? `<p><strong>${label}:</strong> ${esc(val)}</p>` : '';
+
+  function renderView(n){
+    return `
+      <h3>Kortfattat</h3>
+      ${simple('Skugga', n.shadow)}
+      ${simple('Ålder', n.age)}
+      ${simple('Utseende', n.appearance)}
+      ${simple('Manér', n.manner)}
+      ${simple('Citat', n.quote)}
+      ${simple('Fraktion/ätt/klan/stam', n.faction)}
+      <h3>Mellanlångt</h3>
+      ${simple('Personligt mål', n.goal)}
+      ${simple('Drivkrafter', n.drives)}
+      ${simple('Lojaliteter', n.loyalties)}
+      ${simple('Älskar', n.likes)}
+      ${simple('Hatar', n.hates)}
+      <h3>Bakgrund</h3>
+      <p>${esc(n.background)}</p>
+    `;
+  }
+
+  function showPreview(){
+    const obj={};
+    fields.forEach(id=>{
+      const el=form.querySelector('#'+id);
+      obj[id]=el?el.value:'';
+    });
+    storeHelper.setNotes(store,obj);
+    notesDisplay.innerHTML = renderView(obj);
+    notesDisplay.appendChild(editBtn);
+    form.classList.add('hidden');
+    notesDisplay.classList.remove('hidden');
+  }
+
+  function showEdit(){
     const notes = storeHelper.getNotes(store);
     fields.forEach(id=>{
       const el=form.querySelector('#'+id);
       if(el) el.value=notes[id]||'';
     });
+    form.classList.remove('hidden');
+    notesDisplay.classList.add('hidden');
+  }
+
+  function initNotes() {
+    form = document.getElementById('characterForm');
+    if(!form) return;
+    previewBtn = document.getElementById('previewBtn');
+    editBtn = document.getElementById('editBtn');
+    notesDisplay = document.getElementById('notesDisplay');
+
+    const notes = storeHelper.getNotes(store);
+    fields.forEach(id=>{
+      const el=form.querySelector('#'+id);
+      if(el) el.value=notes[id]||'';
+    });
+
     form.addEventListener('submit',e=>{
       e.preventDefault();
       const obj={};
@@ -18,6 +74,11 @@
       storeHelper.setNotes(store,obj);
       alert('Anteckningar sparade!');
     });
+
+    if(previewBtn) previewBtn.onclick = showPreview;
+    if(editBtn) editBtn.onclick = showEdit;
   }
+
   window.initNotes=initNotes;
 })(window);
+

--- a/js/store.js
+++ b/js/store.js
@@ -592,6 +592,7 @@ function defaultTraits() {
       age: '',
       appearance: '',
       manner: '',
+      faction: '',
       quote: '',
       goal: '',
       drives: '',

--- a/notes.html
+++ b/notes.html
@@ -56,6 +56,11 @@
         <input type="text" id="quote" name="quote" placeholder="Signaturcitat">
       </div>
 
+      <div class="form-group">
+        <label for="faction">Fraktion/ätt/klan/stam</label>
+        <input type="text" id="faction" name="faction" placeholder="T.ex. ätt eller klan">
+      </div>
+
       <!-- -------- Mellanlångt -------- -->
       <h3>Mellanlångt</h3>
       <div class="field-row">
@@ -94,9 +99,14 @@
       <div class="char-btn-row">
         <button type="submit" class="char-btn">Spara</button>
         <button type="reset"  class="char-btn danger">Rensa</button>
+        <button type="button" id="previewBtn" class="char-btn">Visa anteckningar</button>
       </div>
 
     </form>
+  </div>
+
+  <div id="notesDisplay" class="panel hidden">
+    <button id="editBtn" class="char-btn">Redigera</button>
   </div>
 
   <shared-toolbar></shared-toolbar>


### PR DESCRIPTION
## Summary
- add preview and edit toggles for notes
- allow storing faction/ätt/klan/stam in notes
- style notes display and hidden class for toggle support

## Testing
- `node <test script>`

------
https://chatgpt.com/codex/tasks/task_e_6892eb54132083238ead88b5c0a07d63