### PR TITLE
Refactor notes page with edit toggle and clear/save controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -108,7 +108,7 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 /* Rad för knappar i filterpanelen */
 .char-btn-row {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
   gap: .4rem;
   margin-bottom: .6rem;
 }

--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -1,6 +1,6 @@
 (function(window){
   const fields = ['shadow','age','appearance','manner','quote','faction','goal','drives','loyalties','likes','hates','background'];
-  let form, previewBtn, editBtn, notesDisplay;
+  let form, editBtn, clearBtn, notesDisplay;
 
   const esc = str => (str||'').replace(/[&<>"']/g, c=>({
     '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'
@@ -28,17 +28,12 @@
     `;
   }
 
-  function showPreview(){
-    const obj={};
-    fields.forEach(id=>{
-      const el=form.querySelector('#'+id);
-      obj[id]=el?el.value:'';
-    });
-    storeHelper.setNotes(store,obj);
-    notesDisplay.innerHTML = renderView(obj);
-    notesDisplay.appendChild(editBtn);
+  function showView(){
+    const notes = storeHelper.getNotes(store);
+    notesDisplay.innerHTML = renderView(notes);
     form.classList.add('hidden');
     notesDisplay.classList.remove('hidden');
+    editBtn.classList.remove('hidden');
   }
 
   function showEdit(){
@@ -49,20 +44,17 @@
     });
     form.classList.remove('hidden');
     notesDisplay.classList.add('hidden');
+    editBtn.classList.add('hidden');
   }
 
   function initNotes() {
     form = document.getElementById('characterForm');
     if(!form) return;
-    previewBtn = document.getElementById('previewBtn');
     editBtn = document.getElementById('editBtn');
+    clearBtn = document.getElementById('clearBtn');
     notesDisplay = document.getElementById('notesDisplay');
 
-    const notes = storeHelper.getNotes(store);
-    fields.forEach(id=>{
-      const el=form.querySelector('#'+id);
-      if(el) el.value=notes[id]||'';
-    });
+    showView();
 
     form.addEventListener('submit',e=>{
       e.preventDefault();
@@ -72,10 +64,16 @@
         obj[id]=el?el.value:'';
       });
       storeHelper.setNotes(store,obj);
-      alert('Anteckningar sparade!');
+      showView();
     });
 
-    if(previewBtn) previewBtn.onclick = showPreview;
+    if(clearBtn) clearBtn.onclick = ()=>{
+      fields.forEach(id=>{
+        const el=form.querySelector('#'+id);
+        if(el) el.value='';
+      });
+    };
+
     if(editBtn) editBtn.onclick = showEdit;
   }
 

--- a/notes.html
+++ b/notes.html
@@ -26,8 +26,14 @@
 <body data-role="notes">
 
   <div class="panel">
-    <h1 class="app-title">Anteckningar</h1>
-    <form id="characterForm">
+    <div class="panel-header">
+      <h1 class="app-title">Anteckningar</h1>
+      <button id="editBtn" class="char-btn icon">✏️ Redigera</button>
+    </div>
+
+    <div id="notesDisplay"></div>
+
+    <form id="characterForm" class="hidden">
 
       <!-- -------- Kortfattat -------- -->
       <h3>Kortfattat</h3>
@@ -97,16 +103,11 @@
 
       <!-- -------- Knappar -------- -->
       <div class="char-btn-row">
+        <button type="button" id="clearBtn" class="char-btn danger">Sudda</button>
         <button type="submit" class="char-btn">Spara</button>
-        <button type="reset"  class="char-btn danger">Rensa</button>
-        <button type="button" id="previewBtn" class="char-btn">Visa anteckningar</button>
       </div>
 
     </form>
-  </div>
-
-  <div id="notesDisplay" class="panel hidden">
-    <button id="editBtn" class="char-btn">Redigera</button>
   </div>
 
   <shared-toolbar></shared-toolbar>


### PR DESCRIPTION
## Summary
- Show stored notes as static text by default and add a top "✏️ Redigera" button.
- Provide edit mode with Sudda and Spara buttons for clearing or saving entries.
- Make button rows responsive to any number of actions.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892f5fd83d48323b47deb069ef37371