### PR TITLE
Make note fields auto-expanding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -183,7 +183,7 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 }
 
 /* ---------- Input/Select ---------- */
-input, select {
+input, select, textarea {
   width: 100%;
   padding: .65rem 1rem;
   border-radius: .6rem;
@@ -192,7 +192,10 @@ input, select {
   color: var(--txt);
   font-size: 1rem;
 }
-input:focus, select:focus { outline: none; border-color: var(--accent); }
+input:focus, select:focus, textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
 
 /* ---------- Kortlista & kort ---------- */
 .card-list {
@@ -1087,10 +1090,21 @@ select.level {
   margin-bottom: .6rem;
 }
 
-/* Större textfält för ”Bakgrund” */
-textarea {
+/* Textfält som expanderar nedåt */
+textarea.auto-resize {
+  min-height: 2.6rem;
+  resize: none;
+  overflow: hidden;
+}
+
+#background.auto-resize {
   min-height: 8rem;
-  resize: vertical;
+}
+
+.view-mode .auto-resize {
+  border: none;
+  background: transparent;
+  padding: 0;
 }
 
 /* Knapprad längst ner */

--- a/js/auto-resize.js
+++ b/js/auto-resize.js
@@ -1,0 +1,16 @@
+(function(window){
+  function autoResize(el){
+    if(!el) return;
+    el.style.height = 'auto';
+    el.style.height = el.scrollHeight + 'px';
+  }
+  window.addEventListener('input', e=>{
+    if(e.target.classList && e.target.classList.contains('auto-resize')){
+      autoResize(e.target);
+    }
+  });
+  window.addEventListener('DOMContentLoaded', ()=>{
+    document.querySelectorAll('.auto-resize').forEach(autoResize);
+  });
+  window.autoResize = autoResize;
+})(window);

--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -9,9 +9,11 @@
       if(el){
         el.value=notes[id]||'';
         el.disabled=true;
+        if(typeof autoResize === 'function') autoResize(el);
       }
     });
     form.classList.remove('hidden');
+    form.classList.add('view-mode');
     editBtn.classList.remove('hidden');
     btnRow.classList.add('hidden');
   }
@@ -23,10 +25,12 @@
       if(el){
         el.value=notes[id]||'';
         el.disabled=false;
+        if(typeof autoResize === 'function') autoResize(el);
       }
     });
     editBtn.classList.add('hidden');
     btnRow.classList.remove('hidden');
+    form.classList.remove('view-mode');
   }
 
   function initNotes() {

--- a/karaktarsblad.html
+++ b/karaktarsblad.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Karaktärsblad</title>
   <link rel="stylesheet" href="css/style.css">
+  <script src="js/auto-resize.js" defer></script>
 </head>
 <body>
 
@@ -17,26 +18,26 @@
       <div class="field-row">
         <div class="form-group">
           <label for="shadow">Skugga</label>
-          <input type="text" id="shadow" name="shadow" placeholder="Ex. ’Smygaren’">
+          <textarea id="shadow" name="shadow" class="auto-resize" placeholder="Ex. ’Smygaren’"></textarea>
         </div>
         <div class="form-group">
           <label for="age">Ålder</label>
-          <input type="text" id="age" name="age" placeholder="T.ex. 34">
+          <textarea id="age" name="age" class="auto-resize" placeholder="T.ex. 34"></textarea>
         </div>
       </div>
       <div class="field-row">
         <div class="form-group">
           <label for="appearance">Utseende</label>
-          <input type="text" id="appearance" name="appearance" placeholder="Kort beskrivning">
+          <textarea id="appearance" name="appearance" class="auto-resize" placeholder="Kort beskrivning"></textarea>
         </div>
         <div class="form-group">
           <label for="manner">Manér</label>
-          <input type="text" id="manner" name="manner" placeholder="Särskilda drag">
+          <textarea id="manner" name="manner" class="auto-resize" placeholder="Särskilda drag"></textarea>
         </div>
       </div>
       <div class="form-group">
         <label for="quote">Citat</label>
-        <input type="text" id="quote" name="quote" placeholder="Signaturcitat">
+        <textarea id="quote" name="quote" class="auto-resize" placeholder="Signaturcitat"></textarea>
       </div>
 
       <!-- -------- Mellanlångt -------- -->
@@ -44,33 +45,33 @@
       <div class="field-row">
         <div class="form-group">
           <label for="goal">Personligt mål</label>
-          <input type="text" id="goal" name="goal" placeholder="Livsmål, ambition">
+          <textarea id="goal" name="goal" class="auto-resize" placeholder="Livsmål, ambition"></textarea>
         </div>
         <div class="form-group">
           <label for="drives">Drivkrafter</label>
-          <input type="text" id="drives" name="drives" placeholder="Vad får dem att agera?">
+          <textarea id="drives" name="drives" class="auto-resize" placeholder="Vad får dem att agera?"></textarea>
         </div>
       </div>
       <div class="field-row">
         <div class="form-group">
           <label for="loyalties">Lojaliteter</label>
-          <input type="text" id="loyalties" name="loyalties" placeholder="T.ex. familj, gille">
+          <textarea id="loyalties" name="loyalties" class="auto-resize" placeholder="T.ex. familj, gille"></textarea>
         </div>
         <div class="form-group">
           <label for="likes">Älskar</label>
-          <input type="text" id="likes" name="likes" placeholder="T.ex. skogar, böcker">
+          <textarea id="likes" name="likes" class="auto-resize" placeholder="T.ex. skogar, böcker"></textarea>
         </div>
       </div>
       <div class="form-group">
         <label for="hates">Hatar</label>
-        <input type="text" id="hates" name="hates" placeholder="T.ex. orättvisa, korruption">
+        <textarea id="hates" name="hates" class="auto-resize" placeholder="T.ex. orättvisa, korruption"></textarea>
       </div>
 
       <!-- -------- Lång text -------- -->
       <h3>Bakgrund</h3>
       <div class="form-group">
         <label for="background">Berätta om bakgrund</label>
-        <textarea id="background" name="background" rows="6" placeholder="Här kan du skriva längre text…"></textarea>
+        <textarea id="background" name="background" class="auto-resize" placeholder="Här kan du skriva längre text…"></textarea>
       </div>
 
       <!-- -------- Knappar -------- -->

--- a/notes.html
+++ b/notes.html
@@ -15,6 +15,7 @@
   <script src="js/shared-toolbar.js" defer></script>
   <script src="js/yrke-panel.js"  defer></script>
   <script src="js/elite-req.js"   defer></script>
+  <script src="js/auto-resize.js" defer></script>
   <script src="js/notes-view.js"  defer></script>
   <script src="js/main.js"        defer></script>
   <script src="js/exceptionellt.js" defer></script>
@@ -38,31 +39,31 @@
       <div class="field-row">
         <div class="form-group">
           <label for="shadow">Skugga</label>
-          <input type="text" id="shadow" name="shadow" placeholder="Ex. ’Smygaren’">
+          <textarea id="shadow" name="shadow" class="auto-resize" placeholder="Ex. ’Smygaren’"></textarea>
         </div>
         <div class="form-group">
           <label for="age">Ålder</label>
-          <input type="text" id="age" name="age" placeholder="T.ex. 34">
+          <textarea id="age" name="age" class="auto-resize" placeholder="T.ex. 34"></textarea>
         </div>
       </div>
       <div class="field-row">
         <div class="form-group">
           <label for="appearance">Utseende</label>
-          <input type="text" id="appearance" name="appearance" placeholder="Kort beskrivning">
+          <textarea id="appearance" name="appearance" class="auto-resize" placeholder="Kort beskrivning"></textarea>
         </div>
         <div class="form-group">
           <label for="manner">Manér</label>
-          <input type="text" id="manner" name="manner" placeholder="Särskilda drag">
+          <textarea id="manner" name="manner" class="auto-resize" placeholder="Särskilda drag"></textarea>
         </div>
       </div>
       <div class="form-group">
         <label for="quote">Citat</label>
-        <input type="text" id="quote" name="quote" placeholder="Signaturcitat">
+        <textarea id="quote" name="quote" class="auto-resize" placeholder="Signaturcitat"></textarea>
       </div>
 
       <div class="form-group">
         <label for="faction">Fraktion/ätt/klan/stam</label>
-        <input type="text" id="faction" name="faction" placeholder="T.ex. ätt eller klan">
+        <textarea id="faction" name="faction" class="auto-resize" placeholder="T.ex. ätt eller klan"></textarea>
       </div>
 
       <!-- -------- Mellanlångt -------- -->
@@ -70,33 +71,33 @@
       <div class="field-row">
         <div class="form-group">
           <label for="goal">Personligt mål</label>
-          <input type="text" id="goal" name="goal" placeholder="Livsmål, ambition">
+          <textarea id="goal" name="goal" class="auto-resize" placeholder="Livsmål, ambition"></textarea>
         </div>
         <div class="form-group">
           <label for="drives">Drivkrafter</label>
-          <input type="text" id="drives" name="drives" placeholder="Vad får dem att agera?">
+          <textarea id="drives" name="drives" class="auto-resize" placeholder="Vad får dem att agera?"></textarea>
         </div>
       </div>
       <div class="field-row">
         <div class="form-group">
           <label for="loyalties">Lojaliteter</label>
-          <input type="text" id="loyalties" name="loyalties" placeholder="T.ex. familj, gille">
+          <textarea id="loyalties" name="loyalties" class="auto-resize" placeholder="T.ex. familj, gille"></textarea>
         </div>
         <div class="form-group">
           <label for="likes">Älskar</label>
-          <input type="text" id="likes" name="likes" placeholder="T.ex. skogar, böcker">
+          <textarea id="likes" name="likes" class="auto-resize" placeholder="T.ex. skogar, böcker"></textarea>
         </div>
       </div>
       <div class="form-group">
         <label for="hates">Hatar</label>
-        <input type="text" id="hates" name="hates" placeholder="T.ex. orättvisa, korruption">
+        <textarea id="hates" name="hates" class="auto-resize" placeholder="T.ex. orättvisa, korruption"></textarea>
       </div>
 
       <!-- -------- Lång text -------- -->
       <h3>Bakgrund</h3>
       <div class="form-group">
         <label for="background">Berätta om bakgrund</label>
-        <textarea id="background" name="background" rows="6" placeholder="Här kan du skriva längre text…"></textarea>
+        <textarea id="background" name="background" class="auto-resize" placeholder="Här kan du skriva längre text…"></textarea>
       </div>
 
       <!-- -------- Knappar -------- -->


### PR DESCRIPTION
## Summary
- use auto-expanding textareas for static character and notes pages
- add generic auto-resize utility and style
- update notes view logic for presentation mode

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689304e698b88323920e091fdb7470f9