### PR TITLE
Render notes as card-style boxes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1102,9 +1102,17 @@ textarea.auto-resize {
 }
 
 .view-mode .auto-resize {
-  border: none;
-  background: transparent;
-  padding: 0;
+  display: none;
+}
+
+.note-box {
+  background: var(--card);
+  border: 2px solid var(--card-border);
+  border-radius: 1rem;
+  padding: 1rem 1.3rem;
+  margin-bottom: .6rem;
+  white-space: pre-wrap;
+  min-height: 2.6rem;
 }
 
 /* Knapprad längst ner */

--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -6,11 +6,16 @@
     const notes = storeHelper.getNotes(store);
     fields.forEach(id=>{
       const el=form.querySelector('#'+id);
-      if(el){
-        el.value=notes[id]||'';
-        el.disabled=true;
-        if(typeof autoResize === 'function') autoResize(el);
+      if(!el) return;
+      el.value=notes[id]||'';
+      el.disabled=true;
+      let box=el.parentElement.querySelector('.note-box');
+      if(!box){
+        box=document.createElement('div');
+        box.className='note-box';
+        el.parentElement.appendChild(box);
       }
+      box.textContent=el.value;
     });
     form.classList.remove('hidden');
     form.classList.add('view-mode');
@@ -22,11 +27,12 @@
     const notes = storeHelper.getNotes(store);
     fields.forEach(id=>{
       const el=form.querySelector('#'+id);
-      if(el){
-        el.value=notes[id]||'';
-        el.disabled=false;
-        if(typeof autoResize === 'function') autoResize(el);
-      }
+      if(!el) return;
+      el.value=notes[id]||'';
+      el.disabled=false;
+      const box=el.parentElement.querySelector('.note-box');
+      if(box) box.remove();
+      if(typeof autoResize === 'function') autoResize(el);
     });
     editBtn.classList.add('hidden');
     btnRow.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- Display saved notes inside card-styled boxes instead of disabled text areas.
- Hide textareas in view mode and restore them for editing.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689315a5c9408323a31f1b6ac422e2a5