### PR TITLE
Reorder toolbar buttons

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -41,13 +41,13 @@ class SharedToolbar extends HTMLElement {
           <span class="exp-counter">XP: <span id="xpOut">0</span></span>
         </div>
         <div class="button-row">
-          <a       id="switchRole" class="char-btn icon" title="Byt vy">🔄</a>
+          <button  id="clearFilters" class="char-btn">Rensa filter</button>
           <a       id="notesLink"  class="char-btn icon" title="Anteckningar">📜</a>
+          <button  id="traitsToggle" class="char-btn icon" title="Egenskaper">📊</button>
           <button  id="invToggle"    class="char-btn icon" title="Inventarie">
             🎒 <span id="invBadge">0</span>
           </button>
-          <button  id="traitsToggle" class="char-btn icon" title="Egenskaper">📊</button>
-          <button  id="clearFilters" class="char-btn">Rensa filter</button>
+          <a       id="switchRole" class="char-btn icon" title="Byt vy">🔄</a>
           <button  id="filterToggle" class="char-btn icon" title="Filter">⚙️</button>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- Reorder toolbar buttons so "Rensa filter" is leftmost, followed by notes, traits, inventory, character view, and gear on the right.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893196343088323855be901e6f6dc5c