### PR TITLE
Hide notes action buttons outside edit mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1105,6 +1105,10 @@ textarea.auto-resize {
   display: none;
 }
 
+.view-mode .char-btn-row {
+  display: none;
+}
+
 .note-box {
   background: var(--card);
   border: 2px solid var(--card-border);

--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -1,6 +1,6 @@
 (function(window){
   const fields = ['shadow','age','appearance','manner','quote','faction','goal','drives','loyalties','likes','hates','background'];
-  let form, editBtn, clearBtn, btnRow;
+  let form, editBtn, clearBtn;
 
   function showView(){
     const notes = storeHelper.getNotes(store);
@@ -20,7 +20,6 @@
     form.classList.remove('hidden');
     form.classList.add('view-mode');
     editBtn.classList.remove('hidden');
-    btnRow.classList.add('hidden');
   }
 
   function showEdit(){
@@ -35,7 +34,6 @@
       if(typeof autoResize === 'function') autoResize(el);
     });
     editBtn.classList.add('hidden');
-    btnRow.classList.remove('hidden');
     form.classList.remove('view-mode');
   }
 
@@ -44,7 +42,6 @@
     if(!form) return;
     editBtn = document.getElementById('editBtn');
     clearBtn = document.getElementById('clearBtn');
-    btnRow = form.querySelector('.char-btn-row');
 
     showView();
 


### PR DESCRIPTION
## Summary
- Hide Save and Clear buttons in Notes view until edit mode is active
- Simplify notes view script to rely on CSS for button visibility

## Testing
- `npm test` *(fails: enoent, missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689323f740e083239c12533d9781f0eb