### PR TITLE
Arrange character buttons into two rows of three

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -112,6 +112,12 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   gap: .4rem;
   margin-bottom: .6rem;
 }
+.char-btn-row.three-col {
+  grid-template-columns: repeat(3, 1fr);
+}
+.char-btn-row.three-col + .char-btn-row.three-col {
+  margin-top: 0;
+}
 .char-btn-row .char-btn {
   width: 100%;
 }

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -98,13 +98,15 @@ class SharedToolbar extends HTMLElement {
           <button class="char-btn icon" data-close="filterPanel">✕</button>
         </header>
 
-        <div class="char-btn-row">
-          <button id="newCharBtn" class="char-btn">Ny rollperson</button>
+        <div class="char-btn-row three-col">
           <button id="duplicateChar" class="char-btn">Kopiera rollperson</button>
           <button id="renameChar" class="char-btn">Byt namn</button>
+          <button id="newCharBtn" class="char-btn">Ny rollperson</button>
+        </div>
+        <div class="char-btn-row three-col">
           <button id="deleteChar" class="char-btn danger">Ta bort rollperson</button>
-          <button id="exportChar" class="char-btn">Exportera</button>
           <button id="importChar" class="char-btn">Importera</button>
+          <button id="exportChar" class="char-btn">Exportera</button>
         </div>
 
         <div class="filter-group">


### PR DESCRIPTION
## Summary
- Reordered character management buttons and split them into two rows of three for clearer layout.
- Added CSS helper class to enforce three-column button rows and remove extra spacing between rows.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933b12af9483239ef258c6c13ea1a7