### PR TITLE
Scroll to top after search

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -167,6 +167,7 @@ function initIndex() {
   dom.sIn.addEventListener('input',()=>{
     sTemp = dom.sIn.value.trim();
     activeTags(); renderList(filtered());
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   });
   dom.sIn.addEventListener('keydown',e=>{
     if(e.key==='Enter'){
@@ -182,6 +183,7 @@ function initIndex() {
       if(sTemp && !F.search.includes(sTemp)) F.search.push(sTemp);
       dom.sIn.value=''; sTemp='';
       activeTags(); renderList(filtered());
+      window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   });
   [ ['typSel','typ'], ['arkSel','ark'], ['tstSel','test'] ].forEach(([sel,key])=>{


### PR DESCRIPTION
## Summary
- Scroll to the top after rendering search results to keep latest content visible.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933cc34fa88323b6373056bb1b2915