### PR TITLE
Make notes fields vertical and prevent sideways expansion

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1075,6 +1075,7 @@ select.level {
 /* ---------- Form-grid för anteckningar på karaktärsbladet ---------- */
 .field-row {
   display: flex;
+  flex-direction: column;
   gap: 1rem;
   margin-bottom: 1rem;
 }
@@ -1083,6 +1084,7 @@ select.level {
   flex: 1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
 }
 
 .form-group label {
@@ -1139,12 +1141,4 @@ textarea.auto-resize {
 #notesDisplay {
   white-space: pre-wrap;
 }
-
-/* Mobil: stapla kolumnerna */
-@media (max-width: 600px) {
-  .field-row {
-    flex-direction: column;
-  }
-}
-
 


### PR DESCRIPTION
## Summary
- Stack `.field-row` elements vertically across all screen sizes
- Prevent textareas from widening by allowing form groups to shrink

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933f6b794483238d10a195a7a901c8