### PR TITLE
Reorder background field and remove notes section headers

### DIFF
--- a/notes.html
+++ b/notes.html
@@ -34,8 +34,14 @@
 
     <form id="characterForm" class="hidden">
 
+      <!-- -------- Bakgrund -------- -->
+      <h3>Berätta om rollpersonens bakgrund</h3>
+      <div class="form-group">
+        <label for="background">Berätta om rollpersonens bakgrund</label>
+        <textarea id="background" name="background" class="auto-resize" placeholder="Här kan du skriva längre text…"></textarea>
+      </div>
+
       <!-- -------- Kortfattat -------- -->
-      <h3>Kortfattat</h3>
       <div class="field-row">
         <div class="form-group">
           <label for="shadow">Skugga</label>
@@ -67,7 +73,6 @@
       </div>
 
       <!-- -------- Mellanlångt -------- -->
-      <h3>Mellanlångt</h3>
       <div class="field-row">
         <div class="form-group">
           <label for="goal">Personligt mål</label>
@@ -91,13 +96,6 @@
       <div class="form-group">
         <label for="hates">Hatar</label>
         <textarea id="hates" name="hates" class="auto-resize" placeholder="T.ex. orättvisa, korruption"></textarea>
-      </div>
-
-      <!-- -------- Lång text -------- -->
-      <h3>Bakgrund</h3>
-      <div class="form-group">
-        <label for="background">Berätta om bakgrund</label>
-        <textarea id="background" name="background" class="auto-resize" placeholder="Här kan du skriva längre text…"></textarea>
       </div>
 
       <!-- -------- Knappar -------- -->


### PR DESCRIPTION
## Summary
- Move background field to the top of notes form and retitle it
- Remove section headers "Kortfattat" and "Mellanlångt" for cleaner layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893421e2db08323b2a206d97e6b5aee