### PR TITLE
Add temporary compression export buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
   <link rel="stylesheet" href="css/style.css">
   <script src="js/text-format.js" defer></script>
   <script src="js/lz-string.min.js" defer></script>
+  <!-- TEMP: LZMA library for compression tests -->
+  <script src="https://cdn.jsdelivr.net/npm/lzma@2.3.2/src/lzma.js" defer></script>
   <script src="js/base91.js" defer></script>
   <script src="js/store.js"        defer></script>
   <script src="js/utils.js"        defer></script>
@@ -28,6 +30,13 @@
 <body data-role="index">
 
   <h1 class="app-title">SYMBAROUM V.10</h1>
+
+  <!-- TEMP: Compression test buttons -->
+  <div id="temp-compress-buttons">
+    <button id="exportLZMA">Export LZMA</button>
+    <button id="exportBrotli">Export Brotli</button>
+    <button id="exportZstd">Export Zstd</button>
+  </div>
 
   <div id="activeFilters" class="tags"></div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -169,6 +169,7 @@ function boot() {
   invUtil.sortAllInventories();
   refreshCharSelect();
   bindToolbar();
+  bindTempExportButtons(); // TEMP
   invUtil.renderInventory();
   invUtil.bindInv();
   invUtil.bindMoney();
@@ -348,6 +349,54 @@ function bindToolbar() {
       const val = dom.entryViewToggle.classList.toggle('active');
       storeHelper.setCompactEntries(store, val);
       if (window.indexViewUpdate) window.indexViewUpdate();
+    });
+  }
+}
+
+// TEMP: extra compression export buttons on index page
+function bindTempExportButtons() {
+  const lzmaBtn = document.getElementById('exportLZMA');
+  if (lzmaBtn) {
+    lzmaBtn.addEventListener('click', async () => {
+      if (!store.current) return alert('Ingen rollperson vald.');
+      try {
+        const code = await storeHelper.exportCharacterCodeLZMA(store, store.current);
+        copyToClipboard(code)
+          .then(() => alert('Karakt\u00e4rskoden har kopierats (LZMA).'))
+          .catch(() => prompt('Kopiera koden nedan:', code));
+      } catch {
+        alert('Export misslyckades.');
+      }
+    });
+  }
+
+  const brotliBtn = document.getElementById('exportBrotli');
+  if (brotliBtn) {
+    brotliBtn.addEventListener('click', async () => {
+      if (!store.current) return alert('Ingen rollperson vald.');
+      try {
+        const code = await storeHelper.exportCharacterCodeBrotli(store, store.current);
+        copyToClipboard(code)
+          .then(() => alert('Karakt\u00e4rskoden har kopierats (Brotli).'))
+          .catch(() => prompt('Kopiera koden nedan:', code));
+      } catch {
+        alert('Export misslyckades.');
+      }
+    });
+  }
+
+  const zstdBtn = document.getElementById('exportZstd');
+  if (zstdBtn) {
+    zstdBtn.addEventListener('click', async () => {
+      if (!store.current) return alert('Ingen rollperson vald.');
+      try {
+        const code = await storeHelper.exportCharacterCodeZstd(store, store.current);
+        copyToClipboard(code)
+          .then(() => alert('Karakt\u00e4rskoden har kopierats (Zstd).'))
+          .catch(() => prompt('Kopiera koden nedan:', code));
+      } catch {
+        alert('Export misslyckades.');
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- add temporary top-level buttons for LZMA, Brotli, and Zstd exports
- include LZMA library and dynamic imports for Brotli/Zstd with max compression
- wire up temporary handlers to copy compressed character codes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68934b2b0b8c8323b6649362ca58b0cd