### PR TITLE
Trigger filter reset via search

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Verktygsraden innehåller:
 - `🎒` öppnar inventariet.
 - `📊` öppnar egenskapspanelen.
 - `📜` öppnar anteckningspanelen.
-- `Rensa filter` tar bort alla aktiva sökord och valda filter.
+- Skriv `lol` i sökfältet och tryck Enter för att rensa alla filter.
 - `⚙️` öppnar filtermenyn där du bland annat skapar och hanterar rollpersoner.
 
 ### 4. Filtermenyn

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -317,6 +317,13 @@ function initCharacter() {
   dom.sIn.addEventListener('keydown',e=>{
     if(e.key==='Enter'){
       e.preventDefault();
+      const term = sTemp.toLowerCase();
+      if (term === 'lol') {
+        F.search=[];F.typ=[];F.ark=[];F.test=[]; sTemp='';
+        dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
+        activeTags(); renderSkills(filtered()); renderTraits();
+        return;
+      }
       if (tryBomb(sTemp)) {
         dom.sIn.value=''; sTemp='';
         return;
@@ -341,11 +348,6 @@ function initCharacter() {
     const sec=t.dataset.type,val=t.dataset.val;
     if(sec==='search'){F.search=F.search.filter(x=>x!==val);} 
     else F[sec]=F[sec].filter(x=>x!==val);
-    activeTags(); renderSkills(filtered()); renderTraits();
-  });
-  dom.clrBtn.addEventListener('click',()=>{
-    F.search=[];F.typ=[];F.ark=[];F.test=[]; sTemp='';
-    dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
     activeTags(); renderSkills(filtered()); renderTraits();
   });
 

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -172,6 +172,14 @@ function initIndex() {
   dom.sIn.addEventListener('keydown',e=>{
     if(e.key==='Enter'){
       e.preventDefault();
+      const term = sTemp.toLowerCase();
+      if (term === 'lol') {
+        F.search=[]; F.typ=[];F.ark=[];F.test=[]; sTemp='';
+        dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
+        activeTags(); renderList(filtered());
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+        return;
+      }
       if (tryBomb(sTemp)) {
         dom.sIn.value=''; sTemp='';
         return;
@@ -197,11 +205,6 @@ function initIndex() {
     const section=t.dataset.type, val=t.dataset.val;
     if(section==='search'){ F.search = F.search.filter(x=>x!==val); }
     else F[section] = F[section].filter(x=>x!==val);
-    activeTags(); renderList(filtered());
-  });
-  dom.clrBtn.addEventListener('click',()=>{
-    F.search=[]; F.typ=[];F.ark=[];F.test=[]; sTemp='';
-    dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
     activeTags(); renderList(filtered());
   });
 

--- a/js/main.js
+++ b/js/main.js
@@ -17,7 +17,6 @@ const dom  = {
   newBtn  : $T('newCharBtn'),   dupBtn : $T('duplicateChar'),   xpOut  : $T('xpOut'),
   exportBtn: $T('exportChar'),  importBtn: $T('importChar'),
   xpIn    : $T('xpInput'),      xpSum  : $T('xpSummary'),
-  clrBtn  : $T('clearFilters'),
 
   /* inventarie */
   invList : $T('invList'),      invBadge  : $T('invBadge'),

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -41,7 +41,6 @@ class SharedToolbar extends HTMLElement {
           <span class="exp-counter">XP: <span id="xpOut">0</span></span>
         </div>
         <div class="button-row">
-          <button  id="clearFilters" class="char-btn">Rensa filter</button>
           <a       id="notesLink"  class="char-btn icon" title="Anteckningar">📜</a>
           <button  id="traitsToggle" class="char-btn icon" title="Egenskaper">📊</button>
           <button  id="invToggle"    class="char-btn icon" title="Inventarie">
@@ -314,7 +313,7 @@ class SharedToolbar extends HTMLElement {
             <strong>📜 / 📇</strong> öppnar anteckningssidan (ikonen ändras beroende på sida).<br>
             <strong>🎒</strong> öppnar inventariepanelen.<br>
             <strong>📊</strong> öppnar egenskapspanelen.<br>
-            <strong>Rensa filter</strong> nollställer alla filter.<br>
+            <strong>Skriv "lol"</strong> i sökfältet nollställer alla filter.<br>
             <strong>⚙️</strong> öppnar filtermenyn.
           </p>
           <h3>Filtermenyn</h3>


### PR DESCRIPTION
## Summary
- Remove "Rensa filter" button from toolbar
- Typing `lol` in the search field and pressing Enter resets all filters
- Document new filter reset behavior in help and README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894313cbb7483239244b0dfa1ce9ca9