### PR TITLE
Byt ut K+ och K🆓 mot nya emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Både i index-vyn och i din karaktär visas poster som kort.
 - **Lägg till** eller `+` lägger till posten.
 - `−` tar bort en instans av posten eller hela raden om det bara finns en.
 - **Info** visar beskrivning och eventuella regler.
-- **K+** låter dig välja en extra kvalitet till ett vapen, rustning eller en artefakt.
-- **K🆓** markerar en av kvaliteterna som gratis.
+- **🔨** låter dig välja en extra kvalitet till ett vapen, rustning eller en artefakt.
+- **☭** markerar en av kvaliteterna som gratis.
 - **🆓** gör hela föremålet gratis vid beräkning av totalkostnad.
 - **↔** finns på artefakter och växlar dess effekt mellan att ge 1 XP eller permanent korruption.
 - **🗑** tar bort posten helt.

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -572,7 +572,7 @@
       <button data-act="add" class="char-btn">+</button>`;
           const freeCnt = Number(row.gratis || 0);
           const freeBtn = `<button data-act="free" class="char-btn${freeCnt? ' danger':''}">🆓</button>`;
-          const freeQBtn = allowQual ? `<button data-act="freeQual" class="char-btn">K🆓</button>` : '';
+          const freeQBtn = allowQual ? `<button data-act="freeQual" class="char-btn">☭</button>` : '';
           const toggleBtn = isArtifact ? `<button data-act="toggleEffect" class="char-btn">↔</button>` : '';
 
           const rowLevel = row.nivå ||
@@ -595,7 +595,7 @@
               </div>
               <div class="inv-controls">
                 ${btnRow}
- ${allowQual ? `<button data-act="addQual" class="char-btn">K+</button>` : ''}
+ ${allowQual ? `<button data-act="addQual" class="char-btn">🔨</button>` : ''}
                 ${freeQBtn}
                 ${toggleBtn}
                 ${freeBtn}
@@ -687,7 +687,7 @@
         return;
       }
 
-      // 2b) För + / - / K+ behöver vi id
+      // 2b) För + / - / 🔨 behöver vi id
       const itemName = li.dataset.name;
       const entry    = getEntry(itemName);
 
@@ -746,7 +746,7 @@
         return;
       }
 
-      // "K+" öppnar popup för att lägga kvalitet
+      // "🔨" öppnar popup för att lägga kvalitet
       if (act === 'addQual') {
         const tagTyp = (entry.taggar?.typ || []);
         if (!['Vapen','Sköld','Pil/Lod','Rustning','Artefakter'].some(t => tagTyp.includes(t))) return;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -429,8 +429,8 @@ class SharedToolbar extends HTMLElement {
             <strong>Lägg till / +</strong> lägger till posten.<br>
             <strong>−</strong> minskar antal eller tar bort posten.<br>
             <strong>Info</strong> visar detaljer.<br>
-            <strong>K+</strong> lägger till kvalitet.<br>
-            <strong>K🆓</strong> markerar en kostande kvalitet som gratis.<br>
+            <strong>🔨</strong> lägger till kvalitet.<br>
+            <strong>☭</strong> markerar en kostande kvalitet som gratis.<br>
             <strong>🆓</strong> gör ett föremål gratis.<br>
             <strong>💔</strong> visar konflikter.<br>
             <strong>↔</strong> växlar artefaktens kostnad mellan XP och permanent korruption.<br>


### PR DESCRIPTION
## Sammanfattning
- Byt ut inventarieknappen K+ mot hammaren 🔨.
- Byt ut K🆓 mot hammare-och-skäran ☭.
- Uppdatera hjälptext och README för de nya symbolerna.

## Testning
- `npm test` *(misslyckas: enoent - package.json saknas)*

------
https://chatgpt.com/codex/tasks/task_e_689433f807488323a681f4556a46d050