### PR TITLE
Add PWA support

### DIFF
--- a/character.html
+++ b/character.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="icons/icon_DA">
+  <meta name="theme-color" content="#121416">
   <title>Rollperson</title>
 
   <link rel="stylesheet" href="css/style.css">
@@ -22,6 +25,7 @@
   <script src="js/beastform.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
   <script src="js/monsterlard.js" defer></script>
+  <script src="js/pwa.js" defer></script>
 </head>
 <body data-role="character">
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="icons/icon_DA">
+  <meta name="theme-color" content="#121416">
   <title>Symbaroum: DA</title>
 
   <link rel="stylesheet" href="css/style.css">
@@ -23,6 +26,7 @@
   <script src="js/bloodbond.js" defer></script>
   <script src="js/monsterlard.js" defer></script>
   <script src="js/elite-add.js"    defer></script>
+  <script src="js/pwa.js" defer></script>
 </head>
 <body data-role="index">
 

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,0 +1,15 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('sw.js');
+  });
+}
+
+let deferredPrompt;
+window.addEventListener('beforeinstallprompt', e => {
+  e.preventDefault();
+  deferredPrompt = e;
+});
+
+window.addEventListener('appinstalled', () => {
+  deferredPrompt = null;
+});

--- a/karaktarsblad.html
+++ b/karaktarsblad.html
@@ -3,9 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="icons/icon_DA">
+  <meta name="theme-color" content="#121416">
   <title>Karaktärsblad</title>
   <link rel="stylesheet" href="css/style.css">
   <script src="js/auto-resize.js" defer></script>
+  <script src="js/pwa.js" defer></script>
 </head>
 <body>
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Symbaroum Companion",
+  "short_name": "Symbaroum",
+  "start_url": "index.html",
+  "display": "standalone",
+  "background_color": "#121416",
+  "theme_color": "#121416",
+  "icons": [
+    {
+      "src": "icons/icon_DA",
+      "sizes": "16x16 24x24 32x32 48x48 64x64 128x128 256x256 512x512",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/notes.html
+++ b/notes.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="icons/icon_DA">
+  <meta name="theme-color" content="#121416">
   <title>Anteckningar</title>
 
   <link rel="stylesheet" href="css/style.css">
@@ -23,6 +26,7 @@
   <script src="js/beastform.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
   <script src="js/monsterlard.js" defer></script>
+  <script src="js/pwa.js" defer></script>
 </head>
 <body data-role="notes">
 

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,47 @@
+const CACHE_NAME = 'symbaroum-pwa-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/character.html',
+  '/karaktarsblad.html',
+  '/notes.html',
+  '/css/style.css',
+  '/icons/icon_DA'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      if (response) {
+        return response;
+      }
+      return fetch(event.request).then(fetchResponse => {
+        return caches.open(CACHE_NAME).then(cache => {
+          cache.put(event.request, fetchResponse.clone());
+          return fetchResponse;
+        });
+      });
+    })
+  );
+});
+
+self.addEventListener('activate', event => {
+  const cacheWhitelist = [CACHE_NAME];
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.map(key => {
+          if (!cacheWhitelist.includes(key)) {
+            return caches.delete(key);
+          }
+        })
+      )
+    )
+  );
+});


### PR DESCRIPTION
## Summary
- add PWA manifest referencing existing icon
- implement service worker caching core assets
- register service worker and include manifest across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689463ff3974832386448aa8b244247e