### PR TITLE
Expose PWA install prompt and trigger on keyword

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -318,6 +318,13 @@ function initCharacter() {
     if(e.key==='Enter'){
       e.preventDefault();
       const term = sTemp.toLowerCase();
+      if (term === 'webapp' && window.deferredPrompt) {
+        window.deferredPrompt.prompt();
+        window.deferredPrompt.userChoice.finally(() => window.deferredPrompt = null);
+        alert('Installationsprompten har öppnats.');
+        dom.sIn.value = ''; sTemp = '';
+        return;
+      }
       if (term === 'lol') {
         F.search=[];F.typ=[];F.ark=[];F.test=[]; sTemp='';
         dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -173,6 +173,13 @@ function initIndex() {
     if(e.key==='Enter'){
       e.preventDefault();
       const term = sTemp.toLowerCase();
+      if (term === 'webapp' && window.deferredPrompt) {
+        window.deferredPrompt.prompt();
+        window.deferredPrompt.userChoice.finally(() => window.deferredPrompt = null);
+        alert('Installationsprompten har öppnats.');
+        dom.sIn.value = ''; sTemp = '';
+        return;
+      }
       if (term === 'lol') {
         F.search=[]; F.typ=[];F.ark=[];F.test=[]; sTemp='';
         dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -8,8 +8,10 @@ let deferredPrompt;
 window.addEventListener('beforeinstallprompt', e => {
   e.preventDefault();
   deferredPrompt = e;
+  window.deferredPrompt = deferredPrompt;
 });
 
 window.addEventListener('appinstalled', () => {
   deferredPrompt = null;
+  window.deferredPrompt = null;
 });


### PR DESCRIPTION
## Summary
- Expose PWA install prompt globally via `window.deferredPrompt`
- Trigger installation prompt when searching for the keyword `webapp`
- Provide alert feedback after prompting the user

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894726ab1548323ae50554dba02703a