### PR TITLE
feat: update PWA to check for new versions

### DIFF
--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,6 +1,13 @@
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('sw.js');
+    navigator.serviceWorker.register('sw.js').then(registration => {
+      registration.update();
+      document.addEventListener('visibilitychange', () => {
+        if (!document.hidden) {
+          registration.update();
+        }
+      });
+    });
   });
 }
 

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'symbaroum-pwa-v1';
+const CACHE_NAME = 'symbaroum-pwa-v2';
 const URLS_TO_CACHE = [
   '/',
   '/index.html',
@@ -11,37 +11,40 @@ const URLS_TO_CACHE = [
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+    caches
+      .open(CACHE_NAME)
+      .then(cache => cache.addAll(URLS_TO_CACHE))
+      .then(() => self.skipWaiting())
   );
 });
 
 self.addEventListener('fetch', event => {
   event.respondWith(
-    caches.match(event.request).then(response => {
-      if (response) {
-        return response;
-      }
-      return fetch(event.request).then(fetchResponse => {
-        return caches.open(CACHE_NAME).then(cache => {
+    fetch(event.request)
+      .then(fetchResponse =>
+        caches.open(CACHE_NAME).then(cache => {
           cache.put(event.request, fetchResponse.clone());
           return fetchResponse;
-        });
-      });
-    })
+        })
+      )
+      .catch(() => caches.match(event.request))
   );
 });
 
 self.addEventListener('activate', event => {
   const cacheWhitelist = [CACHE_NAME];
   event.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(
-        keys.map(key => {
-          if (!cacheWhitelist.includes(key)) {
-            return caches.delete(key);
-          }
-        })
+    caches
+      .keys()
+      .then(keys =>
+        Promise.all(
+          keys.map(key => {
+            if (!cacheWhitelist.includes(key)) {
+              return caches.delete(key);
+            }
+          })
+        )
       )
-    )
+      .then(() => self.clients.claim())
   );
 });


### PR DESCRIPTION
## Summary
- version service worker cache and switch to network-first strategy
- force new workers to activate immediately and claim clients
- update registration to check for updates on load and visibility changes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689474549c6c83239601fc09ce3bdc3c