### PR TITLE
Fix webapp search install prompt

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -318,10 +318,15 @@ function initCharacter() {
     if(e.key==='Enter'){
       e.preventDefault();
       const term = sTemp.toLowerCase();
-      if (term === 'webapp' && window.deferredPrompt) {
-        window.deferredPrompt.prompt();
-        window.deferredPrompt.userChoice.finally(() => window.deferredPrompt = null);
-        alert('Installationsprompten har öppnats.');
+      if (term === 'webapp') {
+        if (window.deferredPrompt) {
+          window.deferredPrompt.prompt();
+          window.deferredPrompt.userChoice
+            .then(() => window.deferredPrompt = null)
+            .catch(() => window.deferredPrompt = null);
+        } else {
+          alert('Installationsprompten är inte tillgänglig.');
+        }
         dom.sIn.value = ''; sTemp = '';
         return;
       }

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -173,10 +173,15 @@ function initIndex() {
     if(e.key==='Enter'){
       e.preventDefault();
       const term = sTemp.toLowerCase();
-      if (term === 'webapp' && window.deferredPrompt) {
-        window.deferredPrompt.prompt();
-        window.deferredPrompt.userChoice.finally(() => window.deferredPrompt = null);
-        alert('Installationsprompten har öppnats.');
+      if (term === 'webapp') {
+        if (window.deferredPrompt) {
+          window.deferredPrompt.prompt();
+          window.deferredPrompt.userChoice
+            .then(() => window.deferredPrompt = null)
+            .catch(() => window.deferredPrompt = null);
+        } else {
+          alert('Installationsprompten är inte tillgänglig.');
+        }
         dom.sIn.value = ''; sTemp = '';
         return;
       }


### PR DESCRIPTION
## Summary
- Ensure searching for `webapp` triggers the PWA installation prompt without blocking it with an alert
- Display a fallback message when the install prompt isn't available

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689476d51ba8832388528fd9d92d9c5e