### PR TITLE
Include PWA setup on install page

### DIFF
--- a/webapp.html
+++ b/webapp.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="icons/icon_DA">
+  <meta name="theme-color" content="#121416">
   <title>Installera som webapp</title>
   <link rel="stylesheet" href="css/style.css">
   <style>
@@ -67,5 +70,6 @@
       });
     });
   </script>
+  <script src="js/pwa.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make webapp install page register the PWA manifest and service worker

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68949098bee483238ec5990f259e5e05