### PR TITLE
Arrange tags and controls for compact entries

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -230,7 +230,7 @@ input:focus, select:focus, textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  font-size: 1.34rem;
+  font-size: calc(1.34rem - 2px);
   font-weight: 600;
 }
 .card-title .title-actions {

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -288,22 +288,22 @@ function initCharacter() {
       const conflictBtn = activeLvls.length
         ? `<button class="char-btn icon conflict-btn" data-name="${p.namn}" title="Aktiva nivåer: ${activeLvls.join(', ')}">💔</button>`
         : '';
-      let btn = '';
-      if(multi){
-        const addBtn = total < limit ? `<button data-act="add" class="char-btn" data-name="${p.namn}">Lägg till</button>` : '';
-        const remBtn = total>0 ? `<button data-act="rem" class="char-btn danger${addBtn ? '' : ' icon'}" data-name="${p.namn}">🗑</button>` : '';
-        btn = `<div class="inv-controls">${remBtn}${conflictBtn}${addBtn}</div>`;
-      }else{
-        btn = `<div class="inv-controls"><button class="char-btn danger icon" data-act="rem">🗑</button>${conflictBtn}</div>`;
-      }
-      li.dataset.xp = xpVal;
-      const showInfo = compact || hideDetails;
-      const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '';
-      li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span><span class="title-actions">${xpHtml}</span></div>
+        const showInfo = compact || hideDetails;
+        let btn = '';
+        if(multi){
+          const addBtn = total < limit ? `<button data-act="add" class="char-btn" data-name="${p.namn}">Lägg till</button>` : '';
+          const remBtn = total>0 ? `<button data-act="rem" class="char-btn danger${addBtn ? '' : ' icon'}" data-name="${p.namn}">🗑</button>` : '';
+          btn = `<div class="inv-controls">${showInfo ? infoBtn : ''}${remBtn}${conflictBtn}${addBtn}</div>`;
+        }else{
+          btn = `<div class="inv-controls">${showInfo ? infoBtn : ''}<button class="char-btn danger icon" data-act="rem">🗑</button>${conflictBtn}</div>`;
+        }
+        li.dataset.xp = xpVal;
+        const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '';
+        li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span><span class="title-actions">${xpHtml}</span></div>
         <div class="tags">${tagsHtml}</div>
         ${lvlSel}
         ${descHtml}
-        ${showInfo ? infoBtn : ''}${btn}`;
+        ${btn}`;
 
       dom.valda.appendChild(li);
     });

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -120,41 +120,43 @@ function initIndex() {
           infoHtml += t;
         }
       }
-      const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
+        const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
         const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         const count = charList.filter(c => c.namn===p.namn && !c.trait).length;
         const limit = storeHelper.monsterStackLimit(charList, p.namn);
         const badge = multi && count>0 ? ` <span class="count-badge">×${count}</span>` : '';
+        const showInfo = compact || hideDetails;
         let btn = '';
         if(multi){
           const addBtn = count < limit ? `<button data-act="add" class="char-btn" data-name="${p.namn}">Lägg till</button>` : '';
           const remBtn = count>0 ? `<button data-act="rem" class="char-btn danger${addBtn ? '' : ' icon'}" data-name="${p.namn}">🗑</button>` : '';
-          btn = `<div class="inv-controls">${remBtn}${addBtn}</div>`;
-      }else{
-        btn = inChar
-          ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
-          : `<button data-act="add" class="char-btn" data-name="${p.namn}">Lägg till</button>`;
-      }
-      const eliteBtn = isElityrke(p)
-        ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
-        : '';
-      const li=document.createElement('li'); li.className='card' + (compact ? ' compact' : '');
-      if (spec) li.dataset.trait = spec;
-      const tagsHtml = (p.taggar?.typ || [])
-        .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
-        .map(t=>`<span class="tag">${t}</span>`).join(' ');
-      const levelHtml = hideDetails ? '' : lvlSel;
-      const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
-      const showInfo = compact || hideDetails;
-      li.innerHTML = `
-        <div class="card-title">${p.namn}${badge}</div>
-        ${tagsHtml}
-        ${levelHtml}
-        ${descHtml}
-        ${showInfo ? infoBtn : ''}${btn}${eliteBtn}`;
-      dom.lista.appendChild(li);
-    });
-  };
+          btn = `<div class="inv-controls">${showInfo ? infoBtn : ''}${remBtn}${addBtn}</div>`;
+        }else{
+          const mainBtn = inChar
+            ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
+            : `<button data-act="add" class="char-btn" data-name="${p.namn}">Lägg till</button>`;
+          btn = `<div class="inv-controls">${showInfo ? infoBtn : ''}${mainBtn}</div>`;
+        }
+        const eliteBtn = isElityrke(p)
+          ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
+          : '';
+        const li=document.createElement('li'); li.className='card' + (compact ? ' compact' : '');
+        if (spec) li.dataset.trait = spec;
+        const tagsHtml = (p.taggar?.typ || [])
+          .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
+          .map(t=>`<span class="tag">${t}</span>`).join(' ');
+        const tagsDiv = tagsHtml ? `<div class="tags">${tagsHtml}</div>` : '';
+        const levelHtml = hideDetails ? '' : lvlSel;
+        const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
+        li.innerHTML = `
+          <div class="card-title">${p.namn}${badge}</div>
+          ${tagsDiv}
+          ${levelHtml}
+          ${descHtml}
+          ${btn}${eliteBtn}`;
+        dom.lista.appendChild(li);
+      });
+    };
 
   /* första render */
   renderList(filtered()); activeTags(); updateXP();


### PR DESCRIPTION
## Summary
- Ensure tags render side-by-side by wrapping them in a flex container
- Group Info button with add/remove controls for each entry
- Reduce entry title font size for a more compact layout

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check js/index-view.js`
- `node --check js/character-view.js`


------
https://chatgpt.com/codex/tasks/task_e_68949e64243483239660b7c2aee58eaf