### PR TITLE
Adjust mobile action button sizes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -468,8 +468,8 @@ select.level {
   .trait-value { font-size: 1.15rem; }
   .inv-controls { gap: .25rem; flex-wrap: nowrap; }
   .inv-controls .char-btn {
-    padding: .42rem .6rem;
-    font-size: 1.3rem;
+    padding: .3rem .5rem;
+    font-size: .9rem;
   }
 }
 /* ---------- Off-canvas-paneler från höger ---------- */


### PR DESCRIPTION
## Summary
- Reduce padding and font size of character action buttons on narrow screens for a better mobile fit.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894a1a5288c8323ae4914536ed94ec3