### PR TITLE
Inventory plus/minus controls and mobile elite button size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -471,6 +471,10 @@ select.level {
     padding: .3rem .5rem;
     font-size: .9rem;
   }
+  .inv-controls .char-btn[data-elite-req] {
+    padding: .15rem .25rem;
+    font-size: .45rem;
+  }
 }
 /* ---------- Off-canvas-paneler från höger ---------- */
 #invPanel,


### PR DESCRIPTION
## Summary
- Show minus/plus controls for inventory items that can stack once added
- Refresh list after inventory changes to display updated counts
- Place "Lägg till med förmågor" to the right of add button and shrink it on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894b4fe9f888323882caf87c5814329