### PR TITLE
Add XP increment and decrement controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1150,3 +1150,15 @@ textarea.auto-resize {
   white-space: pre-wrap;
 }
 
+/* Kontroll för erfarenhetspoäng */
+.xp-control {
+  display: flex;
+  align-items: center;
+  gap: .4rem;
+}
+
+.xp-control input {
+  width: 5rem;
+  text-align: center;
+}
+

--- a/js/main.js
+++ b/js/main.js
@@ -17,6 +17,7 @@ const dom  = {
   newBtn  : $T('newCharBtn'),   dupBtn : $T('duplicateChar'),   xpOut  : $T('xpOut'),
   exportBtn: $T('exportChar'),  importBtn: $T('importChar'),
   xpIn    : $T('xpInput'),      xpSum  : $T('xpSummary'),
+  xpMinus : $T('xpMinus'),      xpPlus : $T('xpPlus'),
 
   /* inventarie */
   invList : $T('invList'),      invBadge  : $T('invBadge'),
@@ -285,6 +286,21 @@ function bindToolbar() {
     storeHelper.setBaseXP(store, xp);
     updateXP();
   });
+
+  if (dom.xpPlus) {
+    dom.xpPlus.addEventListener('click', () => {
+      const xp = storeHelper.getBaseXP(store) + 1;
+      storeHelper.setBaseXP(store, xp);
+      updateXP();
+    });
+  }
+  if (dom.xpMinus) {
+    dom.xpMinus.addEventListener('click', () => {
+      const xp = Math.max(0, storeHelper.getBaseXP(store) - 1);
+      storeHelper.setBaseXP(store, xp);
+      updateXP();
+    });
+  }
 
   if (dom.forgeBtn) {
     if (storeHelper.getPartySmith(store)) dom.forgeBtn.classList.add('active');

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -157,7 +157,11 @@ class SharedToolbar extends HTMLElement {
         <!-- Erfarenhetspoäng -->
         <div class="filter-group">
           <label for="xpInput">Erfarenhetspoäng</label>
-          <input id="xpInput" type="number" min="0" value="0">
+          <div class="xp-control">
+            <button id="xpMinus" class="char-btn icon" type="button">&minus;</button>
+            <input id="xpInput" type="number" min="0" value="0">
+            <button id="xpPlus" class="char-btn icon" type="button">+</button>
+          </div>
         </div>
         <!-- Sammanfattning -->
         <div id="xpSummary" class="exp-counter"></div>


### PR DESCRIPTION
## Summary
- add plus and minus buttons next to experience points input
- hook up new buttons to update stored XP and style the controls

## Testing
- `node --check js/shared-toolbar.js js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_6894b99454e8832396239cd740a20acc