### PR TITLE
Show inventory item price in compact view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -249,6 +249,12 @@ input:focus, select:focus, textarea:focus {
 }
 .card-desc  { font-size: 1.15rem; }
 .card.compact .card-desc { display: none; }
+.card-price {
+  position: absolute;
+  left: 1.3rem;
+  bottom: 1rem;
+  font-size: .9rem;
+}
 
 /* Lista med niva-beskrivningar for formagor */
 .levels { margin-top: .6rem; }

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -83,6 +83,8 @@ function initIndex() {
         : '';
       const hideDetails = isRas(p) || isYrke(p) || isElityrke(p);
       let desc = abilityHtml(p);
+      let priceHtml = '';
+      let priceInfo = '';
       if (isInv(p)) {
         desc += itemStatHtml(p);
         const baseQuals = [
@@ -96,10 +98,12 @@ function initIndex() {
           desc += `<br>Kvalitet:<div class="tags">${qhtml}</div>`;
         }
         if (p.grundpris) {
-          desc += `<br>Pris: ${formatMoney(invUtil.calcEntryCost(p))}`;
+          const priceStr = formatMoney(invUtil.calcEntryCost(p));
+          priceHtml = `<div class="card-price">Pris: ${priceStr}</div>`;
+          priceInfo = `<br>Pris: ${priceStr}`;
         }
       }
-      let infoHtml = desc;
+      let infoHtml = desc + priceInfo;
       if (isRas(p) || isYrke(p) || isElityrke(p)) {
         const extra = yrkeInfoHtml(p);
         if (extra) infoHtml += `<br>${extra}`;
@@ -162,6 +166,7 @@ function initIndex() {
           ${tagsDiv}
           ${levelHtml}
           ${descHtml}
+          ${priceHtml}
           ${btn}`;
         dom.lista.appendChild(li);
       });


### PR DESCRIPTION
## Summary
- Always compute and display item price separately from description
- Add bottom-left price element for inventory entries
- Style price block with absolute positioning for compact and full views

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894b9faaea4832385ecd3673140d79d