### PR TITLE
Format money display

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -502,7 +502,7 @@
       <li class="card">
         <div class="card-title">Pengar</div>
         <div class="card-desc">
-          ${cash.daler} daler, ${cash.skilling} skilling, ${cash['örtegar']} örtegar
+          Kontant: ${cash.daler}D ${cash.skilling}S ${cash['örtegar']}Ö
           <br>Kostnad: ${tot.d}D ${tot.s}S ${tot.o}Ö
           <br>Oanvänt: <span id="unusedOut">0D 0S 0Ö</span>
         </div>


### PR DESCRIPTION
## Summary
- Show cash amounts in D/S/Ö format with a "Kontant" label in the inventory's money card

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894bb1f351c83239a8b44f2ebc6cc53