### PR TITLE
Display item price in compact entry view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -259,6 +259,13 @@ input:focus, select:focus, textarea:focus {
 }
 .card-desc  { font-size: 1.15rem; }
 .card.compact .card-desc { display: none; }
+.card-price {
+  position: absolute;
+  bottom: 0.6rem;
+  left: 1.3rem;
+  font-size: .9rem;
+  color: var(--subtxt);
+}
 
 /* Lista med niva-beskrivningar for formagor */
 .levels { margin-top: .6rem; }

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -94,6 +94,7 @@ function initIndex() {
           : '';
         const hideDetails = isRas(p) || isYrke(p) || isElityrke(p);
         let desc = abilityHtml(p);
+        let priceText = '';
         if (isInv(p)) {
           desc += itemStatHtml(p);
           const baseQuals = [
@@ -107,10 +108,10 @@ function initIndex() {
             desc += `<br>Kvalitet:<div class="tags">${qhtml}</div>`;
           }
           if (p.grundpris) {
-            desc += `<br>Pris: ${formatMoney(invUtil.calcEntryCost(p))}`;
+            priceText = formatMoney(invUtil.calcEntryCost(p));
           }
         }
-        let infoHtml = desc;
+        let infoHtml = priceText ? `${desc}<br>Pris: ${priceText}` : desc;
         if (isRas(p) || isYrke(p) || isElityrke(p)) {
           const extra = yrkeInfoHtml(p);
           if (extra) infoHtml += `<br>${extra}`;
@@ -168,11 +169,13 @@ function initIndex() {
         const tagsDiv = tagsHtml ? `<div class="tags">${tagsHtml}</div>` : '';
         const levelHtml = hideDetails ? '' : lvlSel;
         const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
+        const priceHtml = priceText ? `<div class="card-price">${priceText}</div>` : '';
         li.innerHTML = `
           <div class="card-title">${p.namn}${badge}</div>
           ${tagsDiv}
           ${levelHtml}
           ${descHtml}
+          ${priceHtml}
           ${btn}`;
         listEl.appendChild(li);
       });


### PR DESCRIPTION
## Summary
- Show inventory item prices even when entries are in compact mode
- Add dedicated CSS to anchor prices at the bottom-left of each card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894beab72948323b4f80b85a5fad2f1