### PR TITLE
Ensure consistent category order across pages

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -245,7 +245,7 @@ function initCharacter() {
       const cat = g.entry.taggar?.typ?.[0] || 'Övrigt';
       (cats[cat] ||= []).push(g);
     });
-    Object.keys(cats).sort().forEach(cat=>{
+    Object.keys(cats).sort(catComparator).forEach(cat=>{
       const catLi=document.createElement('li');
       catLi.className='cat-group';
       catLi.innerHTML=`<details open><summary>${cat}</summary><ul class="card-list"></ul></details>`;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -76,7 +76,7 @@ function initIndex() {
       const cat = p.taggar?.typ?.[0] || 'Övrigt';
       (cats[cat] ||= []).push(p);
     });
-    Object.keys(cats).sort().forEach(cat=>{
+    Object.keys(cats).sort(catComparator).forEach(cat=>{
       const catLi=document.createElement('li');
       catLi.className='cat-group';
       catLi.innerHTML=`<details open><summary>${cat}</summary><ul class="card-list"></ul></details>`;

--- a/js/utils.js
+++ b/js/utils.js
@@ -24,6 +24,37 @@
 
   const TYPE_PRIORITIES = { Ras: 0, Yrke: 1, Elityrke: 2 };
 
+  const CAT_ORDER = [
+    'Ras',
+    'Yrke',
+    'Elityrke',
+    'Förmåga',
+    'Ritual',
+    'Fördel',
+    'Nackdel',
+    'Särdrag',
+    'Rustning',
+    'Vapen',
+    'Pil/Lod',
+    'Kvalitet',
+    'Mystisk kvalitet',
+    'Elixir',
+    'Lägre Artefakt',
+    'Specialverktyg',
+    'Diverse',
+    'Mat',
+    'Dryck'
+  ];
+
+  function catComparator(a, b){
+    const ai = CAT_ORDER.indexOf(a);
+    const bi = CAT_ORDER.indexOf(b);
+    if (ai !== -1 && bi !== -1) return ai - bi;
+    if (ai !== -1) return -1;
+    if (bi !== -1) return 1;
+    return a.localeCompare(b);
+  }
+
   function isInv(p){ return (p.taggar?.typ||[]).some(t => EQUIP.includes(t)); }
   function isQual(p){
     return (p.taggar?.typ||[]).some(t => ['Kvalitet','Mystisk kvalitet'].includes(t));
@@ -196,4 +227,5 @@
   window.searchNormalize = searchNormalize;
   window.createSearchSorter = createSearchSorter;
   window.copyToClipboard = copyToClipboard;
+  window.catComparator = catComparator;
 })(window);


### PR DESCRIPTION
## Summary
- add global comparator enforcing a custom category order
- apply new ordering when rendering categories on index and character views

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c0360658832385e4a113c16f02cf