### PR TITLE
fix: only scroll search on submit

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -191,7 +191,6 @@ function initIndex() {
   dom.sIn.addEventListener('input',()=>{
     sTemp = dom.sIn.value.trim();
     activeTags(); renderList(filtered());
-    window.scrollTo({ top: 0, behavior: 'smooth' });
   });
   dom.sIn.addEventListener('keydown',e=>{
     if(e.key==='Enter'){


### PR DESCRIPTION
## Summary
- avoid scrolling to top while typing in the search field
- keep smooth scroll to top when submitting a search with Enter

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c11147cc8323a3d94acb87b61f47