### PR TITLE
Add button to collapse or expand all categories

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -6,6 +6,7 @@ function initIndex() {
   dom.filterUnion.classList.toggle('active', union);
   let compact = storeHelper.getCompactEntries(store);
   dom.entryViewToggle.classList.toggle('active', compact);
+  let catsMinimized = false;
 
   const getEntries = () =>
     DB.concat(storeHelper.getCustomEntries(store));
@@ -79,7 +80,7 @@ function initIndex() {
     Object.keys(cats).sort().forEach(cat=>{
       const catLi=document.createElement('li');
       catLi.className='cat-group';
-      catLi.innerHTML=`<details open><summary>${cat}</summary><ul class="card-list"></ul></details>`;
+      catLi.innerHTML=`<details${catsMinimized ? '' : ' open'}><summary>${cat}</summary><ul class="card-list"></ul></details>`;
       const listEl=catLi.querySelector('ul');
       cats[cat].forEach(p=>{
         const isEx = p.namn === 'Exceptionellt karakt\u00e4rsdrag';
@@ -178,6 +179,14 @@ function initIndex() {
       });
       dom.lista.appendChild(catLi);
     });
+    updateCatToggle();
+  };
+
+  const updateCatToggle = () => {
+    dom.catToggle.textContent = catsMinimized ? '📈' : '📉';
+    dom.catToggle.title = catsMinimized
+      ? 'Öppna alla kategorier'
+      : 'Minimera alla kategorier';
   };
 
   /* första render */
@@ -229,6 +238,14 @@ function initIndex() {
       activeTags(); renderList(filtered());
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
+  });
+
+  dom.catToggle.addEventListener('click', () => {
+    catsMinimized = !catsMinimized;
+    document.querySelectorAll('.cat-group > details').forEach(d => {
+      d.open = !catsMinimized;
+    });
+    updateCatToggle();
   });
   [ ['typSel','typ'], ['arkSel','ark'], ['tstSel','test'] ].forEach(([sel,key])=>{
     dom[sel].addEventListener('change',()=>{

--- a/js/main.js
+++ b/js/main.js
@@ -45,6 +45,7 @@ const dom  = {
   traitStats: $T('traitStats'),
 
   /* filterfält */
+  catToggle: $T('catToggle'),
   sIn   : $T('searchField'),  typSel : $T('typFilter'),
   arkSel: $T('arkFilter'),    tstSel : $T('testFilter'),
   filterUnion: $T('filterUnion'),

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -115,6 +115,7 @@ class SharedToolbar extends HTMLElement {
       <!-- ---------- Verktygsrad ---------- -->
       <footer class="toolbar">
         <div class="toolbar-top">
+          <button id="catToggle" class="char-btn icon" title="Minimera alla kategorier">📉</button>
           <input id="searchField" placeholder="Sök…">
           <span class="exp-counter">XP: <span id="xpOut">0</span></span>
         </div>


### PR DESCRIPTION
## Summary
- add toolbar button before the search field to minimize or open all categories with 📉/📈 icons
- track and toggle category state across renders

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/shared-toolbar.js`
- `node --check js/index-view.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6894c0d084248323901b8ab7c5080836