### PR TITLE
Hide tags in compact view

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -277,6 +277,12 @@ function initCharacter() {
             : `<br><strong>Karaktärsdrag:</strong> ${p.trait}`;
           infoHtml += traitInfo;
         }
+        const tagsHtml = (p.taggar?.typ || [])
+          .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
+          .map(t => `<span class="tag">${t}</span>`).join(' ');
+        if (compact && tagsHtml) {
+          infoHtml += `<br><div class="tags">${tagsHtml}</div>`;
+        }
         const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
 
         const li=document.createElement('li');
@@ -287,9 +293,6 @@ function initCharacter() {
         const total = storeHelper.getCurrentList(store).filter(x=>x.namn===p.namn && !x.trait).length;
         const limit = storeHelper.monsterStackLimit(storeHelper.getCurrentList(store), p.namn);
         const badge = g.count>1 ? ` <span class="count-badge">×${g.count}</span>` : '';
-        const tagsHtml = (p.taggar?.typ || [])
-          .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
-          .map(t => `<span class="tag">${t}</span>`).join(' ');
         const xpVal = storeHelper.calcEntryXP(p, storeHelper.getCurrentList(store));
         const xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
         const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
@@ -308,8 +311,11 @@ function initCharacter() {
         }
         li.dataset.xp = xpVal;
         const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '';
+        const tagsDiv = (!compact && tagsHtml)
+          ? `<div class="tags">${tagsHtml}</div>`
+          : '';
         li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span><span class="title-actions">${xpHtml}</span></div>
-        <div class="tags">${tagsHtml}</div>
+        ${tagsDiv}
         ${lvlSel}
         ${descHtml}
         ${btn}`;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -133,6 +133,12 @@ function initIndex() {
             infoHtml += t;
           }
         }
+        const tagsHtml = (p.taggar?.typ || [])
+          .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
+          .map(t=>`<span class="tag">${t}</span>`).join(' ');
+        if (compact && tagsHtml) {
+          infoHtml += `<br><div class="tags">${tagsHtml}</div>`;
+        }
         const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
         const multi = isInv(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         const count = isInv(p)
@@ -163,10 +169,9 @@ function initIndex() {
         }
         const li=document.createElement('li'); li.className='card' + (compact ? ' compact' : '');
         if (spec) li.dataset.trait = spec;
-        const tagsHtml = (p.taggar?.typ || [])
-          .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
-          .map(t=>`<span class="tag">${t}</span>`).join(' ');
-        const tagsDiv = tagsHtml ? `<div class="tags">${tagsHtml}</div>` : '';
+        const tagsDiv = (!compact && tagsHtml)
+          ? `<div class="tags">${tagsHtml}</div>`
+          : '';
         const levelHtml = hideDetails ? '' : lvlSel;
         const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
         const priceHtml = priceText ? `<div class="card-price">${priceText}</div>` : '';


### PR DESCRIPTION
## Summary
- Hide entry tags when compact list view is enabled
- Show tags within Info panel while compact view is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c188792c832384406fb7251d65ae