### PR TITLE
Display entry tags at top of info panel

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -279,9 +279,9 @@ function initCharacter() {
         }
         const tagsHtml = (p.taggar?.typ || [])
           .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
-          .map(t => `<span class="tag">${t}</span>`).join(' ');
-        if (compact && tagsHtml) {
-          infoHtml += `<br><div class="tags">${tagsHtml}</div>`;
+          .map(t=>`<span class="tag">${t}</span>`).join(' ');
+        if (tagsHtml) {
+          infoHtml = `<div class="tags">${tagsHtml}</div><br>${infoHtml}`;
         }
         const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
 

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -137,8 +137,8 @@ function initIndex() {
         const tagsHtml = (p.taggar?.typ || [])
           .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
           .map(t=>`<span class="tag">${t}</span>`).join(' ');
-        if (compact && tagsHtml) {
-          infoHtml += `<br><div class="tags">${tagsHtml}</div>`;
+        if (tagsHtml) {
+          infoHtml = `<div class="tags">${tagsHtml}</div><br>${infoHtml}`;
         }
         const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
         const multi = isInv(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));


### PR DESCRIPTION
## Summary
- Always prepend entry tags in the info panel for index view
- Show character entry tags at the top of their info panel

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6894c327a7cc8323add71e692905d9a9