### PR TITLE
Prioritize categories with direct search matches

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -241,11 +241,30 @@ function initCharacter() {
     dom.valda.innerHTML = '';
     if(!groups.length){ dom.valda.innerHTML = '<li class="card">Inga träffar.</li>'; return; }
     const cats = {};
+    const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
+      .map(t => searchNormalize(t.toLowerCase()));
+    const searchActive = terms.length > 0;
+    const catNameMatch = {};
     groups.forEach(g=>{
       const cat = g.entry.taggar?.typ?.[0] || 'Övrigt';
       (cats[cat] ||= []).push(g);
+      if (searchActive) {
+        const name = searchNormalize((g.entry.namn || '').toLowerCase());
+        if (terms.every(q => name.includes(q))) {
+          catNameMatch[cat] = true;
+        }
+      }
     });
-    Object.keys(cats).sort(catComparator).forEach(cat=>{
+    const catKeys = Object.keys(cats);
+    catKeys.sort((a,b)=>{
+      if (searchActive) {
+        const aMatch = catNameMatch[a] ? 1 : 0;
+        const bMatch = catNameMatch[b] ? 1 : 0;
+        if (aMatch !== bMatch) return bMatch - aMatch;
+      }
+      return catComparator(a,b);
+    });
+    catKeys.forEach(cat=>{
       const catLi=document.createElement('li');
       catLi.className='cat-group';
       catLi.innerHTML=`<details open><summary>${catName(cat)}</summary><ul class="card-list"></ul></details>`;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -73,11 +73,30 @@ function initIndex() {
     const invList  = storeHelper.getInventory(store);
     const compact = storeHelper.getCompactEntries(store);
     const cats = {};
+    const terms = [...F.search, ...(sTemp ? [sTemp] : [])]
+      .map(t => searchNormalize(t.toLowerCase()));
+    const searchActive = terms.length > 0;
+    const catNameMatch = {};
     arr.forEach(p=>{
       const cat = p.taggar?.typ?.[0] || 'Övrigt';
       (cats[cat] ||= []).push(p);
+      if (searchActive) {
+        const name = searchNormalize((p.namn || '').toLowerCase());
+        if (terms.every(q => name.includes(q))) {
+          catNameMatch[cat] = true;
+        }
+      }
     });
-    Object.keys(cats).sort(catComparator).forEach(cat=>{
+    const catKeys = Object.keys(cats);
+    catKeys.sort((a,b)=>{
+      if (searchActive) {
+        const aMatch = catNameMatch[a] ? 1 : 0;
+        const bMatch = catNameMatch[b] ? 1 : 0;
+        if (aMatch !== bMatch) return bMatch - aMatch;
+      }
+      return catComparator(a,b);
+    });
+    catKeys.forEach(cat=>{
       const catLi=document.createElement('li');
       catLi.className='cat-group';
       catLi.innerHTML=`<details${catsMinimized ? '' : ' open'}><summary>${catName(cat)}</summary><ul class="card-list"></ul></details>`;


### PR DESCRIPTION
## Summary
- Prioritize categories containing entries whose names match active search terms
- Apply search-aware category sorting for both main index and character views

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c4d198448323b6963f3f6a92da99