### PR TITLE
Use arrow icon for global category toggle

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -191,7 +191,7 @@ function initIndex() {
   };
 
   const updateCatToggle = () => {
-    dom.catToggle.textContent = catsMinimized ? '📈' : '📉';
+    dom.catToggle.textContent = catsMinimized ? '▶' : '▼';
     dom.catToggle.title = catsMinimized
       ? 'Öppna alla kategorier'
       : 'Minimera alla kategorier';

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -115,7 +115,7 @@ class SharedToolbar extends HTMLElement {
       <!-- ---------- Verktygsrad ---------- -->
       <footer class="toolbar">
         <div class="toolbar-top">
-          <button id="catToggle" class="char-btn icon" title="Minimera alla kategorier">📉</button>
+          <button id="catToggle" class="char-btn icon" title="Minimera alla kategorier">▼</button>
           <input id="searchField" placeholder="Sök…">
           <span class="exp-counter">XP: <span id="xpOut">0</span></span>
         </div>


### PR DESCRIPTION
## Summary
- Replace chart icons on the global category toggle with arrow icons matching individual category toggles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c504753083238148bc85bc651a2d