### PR TITLE
Pluralize and sort category labels

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -165,7 +165,12 @@
     const add   = bar.shadowRoot.getElementById('customAdd');
     const cancel= bar.shadowRoot.getElementById('customCancel');
 
-    type.innerHTML = EQUIP.map(t=>`<option>${t}</option>`).join('');
+    const equipOptions = EQUIP
+      .slice()
+      .sort((a, b) => catName(a).localeCompare(catName(b)))
+      .map(t => `<option value="${t}">${catName(t)}</option>`)
+      .join('');
+    type.innerHTML = equipOptions;
 
     pop.classList.add('open');
     if (effSel) effSel.value = 'corruption';
@@ -401,8 +406,11 @@
       });
       dom.invTypeSel.innerHTML =
         '<option value="">Kategori (alla)</option>' +
-        [...types].sort().map(t =>
-          `<option${t===F.typ?' selected':''}>${t}</option>`).join('');
+        [...types]
+          .sort((a, b) => catName(a).localeCompare(catName(b)))
+          .map(t =>
+            `<option value="${t}"${t===F.typ?' selected':''}>${catName(t)}</option>`)
+          .join('');
     }
 
     const inv = allInv

--- a/js/utils.js
+++ b/js/utils.js
@@ -60,6 +60,7 @@
     'Rustning': 'Rustningar',
     'Vapen': 'Vapen',
     'Pil/Lod': 'Pilar/Lod',
+    'Sköld': 'Sköldar',
     'Kvalitet': 'Kvaliteter',
     'Mystisk kvalitet': 'Mystiska kvaliteter',
     'Elixir': 'Elixir',
@@ -67,7 +68,10 @@
     'Specialverktyg': 'Specialverktyg',
     'Diverse': 'Diverse',
     'Mat': 'Mat',
-    'Dryck': 'Drycker'
+    'Dryck': 'Drycker',
+    'Byggnad': 'Byggnader',
+    'Förvaring': 'Förvaringsföremål',
+    'Fälla': 'Fällor'
   };
 
   function catName(cat){


### PR DESCRIPTION
## Summary
- Pluralize additional categories like Sköld, Byggnad, Förvaring and Fälla.
- Show pluralized category names in alphabetical order when adding custom items or filtering inventory.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894c56a5aa88323b80d0581275745d1