### PR TITLE
Flytta anteckningsknapp och uppdatera anteckningsvy

### DIFF
--- a/character.html
+++ b/character.html
@@ -37,7 +37,10 @@
   <div class="panel">
     <div class="panel-header">
       <h2 id="charName" style="margin:0;"></h2>
-      <button id="summaryToggle" class="char-btn icon summary-btn" title="Visa översikt">📋</button>
+      <div class="header-actions">
+        <a href="notes.html" id="notesLink" class="char-btn icon" title="Anteckningar">📜</a>
+        <button id="summaryToggle" class="char-btn icon summary-btn" title="Visa översikt">📋</button>
+      </div>
     </div>
     <ul id="valda" class="card-list"></ul>
   </div>

--- a/css/style.css
+++ b/css/style.css
@@ -192,6 +192,11 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   margin-bottom: .8rem;
 }
 
+.header-actions {
+  display: flex;
+  gap: .6rem;
+}
+
 /* ---------- Input/Select ---------- */
 input, select, textarea {
   width: 100%;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -120,7 +120,6 @@ class SharedToolbar extends HTMLElement {
           <span class="exp-counter">XP: <span id="xpOut">0</span></span>
         </div>
         <div class="button-row">
-          <a       id="notesLink"  class="char-btn icon" title="Anteckningar">📜</a>
           <button  id="traitsToggle" class="char-btn icon" title="Egenskaper">📊</button>
           <button  id="invToggle"    class="char-btn icon" title="Inventarie">
             🎒 <span id="invBadge">0</span>
@@ -501,33 +500,20 @@ class SharedToolbar extends HTMLElement {
   updateToolbarLinks() {
     const role = document.body.dataset.role;
     const switchLink = this.shadowRoot.getElementById('switchRole');
-    const notesLink  = this.shadowRoot.getElementById('notesLink');
 
     if (role === 'character') {
       switchLink.href = 'index.html';
       switchLink.textContent = '📇';
       switchLink.title = 'Till index';
-
-      notesLink.href = 'notes.html';
-      notesLink.textContent = '📜';
-      notesLink.title = 'Anteckningar';
     } else if (role === 'notes') {
       switchLink.href = 'character.html';
       switchLink.textContent = '🧝';
       switchLink.title = 'Till rollperson';
-
-      notesLink.href = 'index.html';
-      notesLink.textContent = '📇';
-      notesLink.title = 'Till index';
     } else {
       // Default to index
       switchLink.href = 'character.html';
       switchLink.textContent = '🧝';
       switchLink.title = 'Till rollperson';
-
-      notesLink.href = 'notes.html';
-      notesLink.textContent = '📜';
-      notesLink.title = 'Anteckningar';
     }
   }
 }

--- a/notes.html
+++ b/notes.html
@@ -33,7 +33,11 @@
   <div class="panel">
     <div class="panel-header">
       <h1 class="app-title">Anteckningar</h1>
-      <button id="editBtn" class="char-btn icon">✏️ Redigera</button>
+      <div class="header-actions">
+        <a href="index.html" class="char-btn icon" title="Till index">📇</a>
+        <a href="character.html" class="char-btn icon" title="Till rollperson">🧝</a>
+        <button id="editBtn" class="char-btn icon" title="Redigera">✏️</button>
+      </div>
     </div>
 
     <form id="characterForm" class="hidden">


### PR DESCRIPTION
## Sammanfattning
- Flytta anteckningsknappen till sidhuvudet på rollpersonssidan, vänster om översikt.
- Ta bort anteckningsknappen från verktygsraden och justera länklogik.
- Lägg till index- och rollpersonslänkar samt en penn-ikon för redigering i anteckningsvyn.

## Testning
- `npm test` *(misslyckas: package.json saknas)*

------
https://chatgpt.com/codex/tasks/task_e_6894c70e88548323a103a82966a8b05c