### PR TITLE
Sync category toggle state with open categories

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -100,7 +100,9 @@ function initIndex() {
       const catLi=document.createElement('li');
       catLi.className='cat-group';
       catLi.innerHTML=`<details${catsMinimized ? '' : ' open'}><summary>${catName(cat)}</summary><ul class="card-list"></ul></details>`;
+      const detailsEl = catLi.querySelector('details');
       const listEl=catLi.querySelector('ul');
+      detailsEl.addEventListener('toggle', updateCatToggle);
       cats[cat].forEach(p=>{
         const isEx = p.namn === 'Exceptionellt karakt\u00e4rsdrag';
         const inChar = isEx ? false : charList.some(c=>c.namn===p.namn);
@@ -210,6 +212,8 @@ function initIndex() {
   };
 
   const updateCatToggle = () => {
+    catsMinimized = [...document.querySelectorAll('.cat-group > details')]
+      .every(d => !d.open);
     dom.catToggle.textContent = catsMinimized ? '▶' : '▼';
     dom.catToggle.title = catsMinimized
       ? 'Öppna alla kategorier'
@@ -267,10 +271,12 @@ function initIndex() {
   });
 
   dom.catToggle.addEventListener('click', () => {
-    catsMinimized = !catsMinimized;
-    document.querySelectorAll('.cat-group > details').forEach(d => {
-      d.open = !catsMinimized;
-    });
+    const details = document.querySelectorAll('.cat-group > details');
+    if (catsMinimized) {
+      details.forEach(d => { d.open = true; });
+    } else {
+      details.forEach(d => { d.open = false; });
+    }
     updateCatToggle();
   });
   [ ['typSel','typ'], ['arkSel','ark'], ['tstSel','test'] ].forEach(([sel,key])=>{


### PR DESCRIPTION
## Summary
- Compute catsMinimized based on actual category open state
- Toggle button opens or closes all categories accordingly
- Keep toggle updated when categories render or are manually toggled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894dcf338b88323960f7c45422aa86a