### PR TITLE
Add Fältutrustning bundle to Diverse inventory

### DIFF
--- a/data/diverse.json
+++ b/data/diverse.json
@@ -1168,5 +1168,20 @@
       "skilling": 1,
       "örtegar": 0
     }
+  },
+  {
+    "id": "di79",
+    "namn": "Fältutrustning",
+    "beskrivning": "Samlat paket med nödvändig utrustning för fältlivet.",
+    "taggar": {
+      "typ": [
+        "Diverse"
+      ]
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 5,
+      "örtegar": 0
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- add "Fältutrustning" entry to Diverse data list
- expand "Fältutrustning" into its component items when added to inventory

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/inventory-utils.js`


------
https://chatgpt.com/codex/tasks/task_e_6894dca80bdc8323903dbdbf22d56608