### PR TITLE
Expand Fältutrustning bundle into component items

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -338,30 +338,48 @@ function initIndex() {
     if (act==='add') {
       if (isInv(p)) {
         const inv = storeHelper.getInventory(store);
-        const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt'].some(t=>p.taggar.typ.includes(t));
-        const rowBase = { name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
-        if (p.artifactEffect) rowBase.artifactEffect = p.artifactEffect;
-        const addRow = trait => {
-          if (trait) rowBase.trait = trait;
-          if (indiv) {
-            inv.push(rowBase);
-          } else {
-            const match = inv.find(x => x.name===p.namn && (!trait || x.trait===trait));
-            if (match) match.qty++;
-            else inv.push(rowBase);
-          }
+        if (p.namn === 'Fältutrustning') {
+          const bundle = ['Flinta och stål','Kokkärl','Rep, 10 meter','Sovfäll','Tändved','Vattenskinn'];
+          bundle.forEach(namn => {
+            const ent = invUtil.getEntry(namn);
+            if (!ent.namn) return;
+            const indivItem = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter']
+              .some(t=>ent.taggar.typ.includes(t));
+            const existing = inv.find(r => r.name === ent.namn);
+            if (indivItem || !existing) {
+              inv.push({ name: ent.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] });
+            } else {
+              existing.qty++;
+            }
+          });
           invUtil.saveInventory(inv); invUtil.renderInventory();
           renderList(filtered());
-        };
-        if (p.traits && window.maskSkill) {
-          const used = inv.filter(it => it.name===p.namn).map(it=>it.trait).filter(Boolean);
-          maskSkill.pickTrait(used, trait => {
-            if(!trait) return;
-            if (used.includes(trait) && !confirm('Samma karakt\u00e4rsdrag finns redan. L\u00e4gga till \u00e4nd\u00e5?')) return;
-            addRow(trait);
-          });
         } else {
-          addRow();
+          const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt'].some(t=>p.taggar.typ.includes(t));
+          const rowBase = { name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
+          if (p.artifactEffect) rowBase.artifactEffect = p.artifactEffect;
+          const addRow = trait => {
+            if (trait) rowBase.trait = trait;
+            if (indiv) {
+              inv.push(rowBase);
+            } else {
+              const match = inv.find(x => x.name===p.namn && (!trait || x.trait===trait));
+              if (match) match.qty++;
+              else inv.push(rowBase);
+            }
+            invUtil.saveInventory(inv); invUtil.renderInventory();
+            renderList(filtered());
+          };
+          if (p.traits && window.maskSkill) {
+            const used = inv.filter(it => it.name===p.namn).map(it=>it.trait).filter(Boolean);
+            maskSkill.pickTrait(used, trait => {
+              if(!trait) return;
+              if (used.includes(trait) && !confirm('Samma karakt\u00e4rsdrag finns redan. L\u00e4gga till \u00e4nd\u00e5?')) return;
+              addRow(trait);
+            });
+          } else {
+            addRow();
+          }
         }
       } else {
         const list = storeHelper.getCurrentList(store);


### PR DESCRIPTION
## Summary
- Prevent the Fältutrustning item from being added as a single entry
- Automatically insert its component items (flinta och stål, kokkärl, rep, sovfäll, tändved, vattenskinn) when adding Fältutrustning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894df9d81708323a30621da1b654fad