### PR TITLE
Fix mobile layout for notes header buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -190,11 +190,18 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   align-items: center;
   justify-content: space-between;
   margin-bottom: .8rem;
+  flex-wrap: wrap;
+  row-gap: .6rem;
 }
 
 .header-actions {
   display: flex;
   gap: .6rem;
+}
+
+.panel-header .app-title {
+  flex: 1;
+  margin: 0;
 }
 
 /* ---------- Input/Select ---------- */
@@ -496,6 +503,13 @@ select.level {
   .inv-controls .char-btn[data-elite-req] {
     padding: .15rem .25rem;
     font-size: .45rem;
+  }
+  .header-actions {
+    gap: .4rem;
+  }
+  .header-actions .char-btn.icon {
+    padding: .35rem .6rem;
+    font-size: .9rem;
   }
 }
 /* ---------- Off-canvas-paneler från höger ---------- */


### PR DESCRIPTION
## Summary
- Wrap notes header actions to prevent horizontal overflow on small screens
- Shrink header buttons and adjust spacing for better mobile fit

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fa5ec968832391cb8a8808fd1b90