### PR TITLE
Align notes page with other views

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 /* ===========================================================
    css/style.css
-   Gemensam styling för index.html & character.html
+   Gemensam styling för index.html, character.html & notes.html
    Optimerad 2025-06-19
    =========================================================== */
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,11 @@
 /* ===========================================================
-   js/main.js – gemensam logik för index- och character-vy
+   js/main.js – gemensam logik för index-, character- och notes-vy
    Fungerar ihop med Web Component <shared-toolbar>
    2025-06-20
    =========================================================== */
 
 /* ---------- Grunddata & konstanter ---------- */
-const ROLE   = document.body.dataset.role;           // 'index' | 'character'
+const ROLE   = document.body.dataset.role;           // 'index' | 'character' | 'notes'
 let   store  = storeHelper.load();                   // Lokal lagring
 
 /* ---------- Snabb DOM-access ---------- */
@@ -167,14 +167,19 @@ function yrkeInfoHtml(p) {
    GEMENSAM INIT
    =========================================================== */
 function boot() {
-  invUtil.sortAllInventories();
+  if (window.invUtil) {
+    invUtil.sortAllInventories();
+    invUtil.renderInventory();
+    invUtil.bindInv();
+    invUtil.bindMoney();
+  }
   refreshCharSelect();
   bindToolbar();
-  invUtil.renderInventory();
-  invUtil.bindInv();
-  invUtil.bindMoney();
 
-  if (dom.traits) { renderTraits(); bindTraits(); }
+  if (dom.traits && typeof renderTraits === 'function') {
+    renderTraits();
+    if (typeof bindTraits === 'function') bindTraits();
+  }
   if (ROLE === 'index')     initIndex();
   if (ROLE === 'character') initCharacter();
   if (ROLE === 'notes')     initNotes();

--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -17,7 +17,6 @@
       }
       box.textContent=el.value;
     });
-    form.classList.remove('hidden');
     form.classList.add('view-mode');
     editBtn.classList.remove('hidden');
   }

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -503,16 +503,11 @@ class SharedToolbar extends HTMLElement {
     const role = document.body.dataset.role;
     const switchLink = this.shadowRoot.getElementById('switchRole');
 
-    if (role === 'character') {
+    if (role === 'character' || role === 'notes') {
       switchLink.href = 'index.html';
       switchLink.textContent = '📇';
       switchLink.title = 'Till index';
-    } else if (role === 'notes') {
-      switchLink.href = 'character.html';
-      switchLink.textContent = '🧝';
-      switchLink.title = 'Till rollperson';
     } else {
-      // Default to index
       switchLink.href = 'character.html';
       switchLink.textContent = '🧝';
       switchLink.title = 'Till rollperson';

--- a/notes.html
+++ b/notes.html
@@ -13,19 +13,10 @@
   <script src="js/lz-string.min.js" defer></script>
   <script src="js/store.js"          defer></script>
   <script src="js/utils.js"          defer></script>
-  <script src="js/inventory-utils.js" defer></script>
-  <script src="js/traits-utils.js" defer></script>
   <script src="js/shared-toolbar.js" defer></script>
-  <script src="js/yrke-panel.js"  defer></script>
-  <script src="js/elite-req.js"   defer></script>
   <script src="js/auto-resize.js" defer></script>
   <script src="js/notes-view.js"  defer></script>
   <script src="js/main.js"        defer></script>
-  <script src="js/exceptionellt.js" defer></script>
-  <script src="js/djurmask.js" defer></script>
-  <script src="js/beastform.js" defer></script>
-  <script src="js/bloodbond.js" defer></script>
-  <script src="js/monsterlard.js" defer></script>
   <script src="js/pwa.js" defer></script>
 </head>
 <body data-role="notes">
@@ -34,13 +25,11 @@
     <div class="panel-header">
       <h1 class="app-title">Anteckningar</h1>
       <div class="header-actions">
-        <a href="index.html" class="char-btn icon" title="Till index">📇</a>
-        <a href="character.html" class="char-btn icon" title="Till rollperson">🧝</a>
         <button id="editBtn" class="char-btn icon" title="Redigera">✏️</button>
       </div>
     </div>
 
-    <form id="characterForm" class="hidden">
+    <form id="characterForm">
 
       <!-- -------- Bakgrund -------- -->
       <h3>Berätta om rollpersonens bakgrund</h3>


### PR DESCRIPTION
## Summary
- Remove redundant links and hidden form class on notes page so layout matches other views
- Trim unused scripts and adjust toolbar switch logic for notes
- Document notes view in shared styles and main logic

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6894fd0c390c8323b13a28484b66a5ca