### PR TITLE
Förbättra layouten för erfarenhetspoäng

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1176,11 +1176,17 @@ textarea.auto-resize {
 .xp-control {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: .4rem;
+  margin-bottom: .6rem;
 }
 
 .xp-control input {
   width: 5rem;
   text-align: center;
+}
+
+#xpSummary {
+  margin-top: .6rem;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -18,6 +18,7 @@ const dom  = {
   exportBtn: $T('exportChar'),  importBtn: $T('importChar'),
   xpIn    : $T('xpInput'),      xpSum  : $T('xpSummary'),
   xpMinus : $T('xpMinus'),      xpPlus : $T('xpPlus'),
+  xpTotal : $T('xpTotal'),      xpUsed : $T('xpUsed'),       xpFree : $T('xpFree'),
 
   /* inventarie */
   invList : $T('invList'),      invBadge  : $T('invBadge'),
@@ -546,10 +547,10 @@ function updateXP() {
   dom.xpIn.value = base;
   const xpContainer = dom.xpOut.closest('.exp-counter');
   if (xpContainer) xpContainer.classList.toggle('under', free < 0);
-  if (dom.xpSum) {
-    dom.xpSum.textContent = `Använt: ${used} • Oanvänt: ${free} • Totalt: ${total}`;
-    dom.xpSum.classList.toggle('under', free < 0);
-  }
+  if (dom.xpTotal) dom.xpTotal.textContent = total;
+  if (dom.xpUsed)  dom.xpUsed.textContent  = used;
+  if (dom.xpFree)  dom.xpFree.textContent  = free;
+  if (dom.xpSum)   dom.xpSum.classList.toggle('under', free < 0);
 }
 /* -----------------------------------------------------------
    Synk när annan flik ändrar localStorage

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -156,15 +156,20 @@ class SharedToolbar extends HTMLElement {
 
         <!-- Erfarenhetspoäng -->
         <div class="filter-group">
-          <label for="xpInput">Erfarenhetspoäng</label>
           <div class="xp-control">
             <button id="xpMinus" class="char-btn icon" type="button">&minus;</button>
-            <input id="xpInput" type="number" min="0" value="0">
+            <input id="xpInput" type="number" min="0" value="0" aria-label="Totala erfarenhetspoäng">
             <button id="xpPlus" class="char-btn icon" type="button">+</button>
           </div>
+          <div id="xpSummary" class="card exp-counter">
+            <div class="card-title">Erfarenhetspoäng</div>
+            <div class="card-desc">
+              Totalt: <span id="xpTotal">0</span><br>
+              Använt: <span id="xpUsed">0</span><br>
+              Oanvänt: <span id="xpFree">0</span>
+            </div>
+          </div>
         </div>
-        <!-- Sammanfattning -->
-        <div id="xpSummary" class="exp-counter"></div>
         <div class="exp-counter traits-total" style="text-align:center;">
           Karaktärsdrag: <span id="traitsTotal">0</span> / <span id="traitsMax">0</span>
         </div>


### PR DESCRIPTION
## Summary
- Formatera erfarenhetspoängens ruta som ett kort med totalsummering
- Centrera minus/plus-kontrollen och uppdatera färg vid negativa värden

## Testing
- `npm test` *(misslyckas: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fe486b10832383209b2577e3e71d