### PR TITLE
Fix expand/collapse categories button in character view

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -9,6 +9,16 @@ function initCharacter() {
   let compact = storeHelper.getCompactEntries(store);
   dom.entryViewToggle.classList.toggle('active', compact);
 
+  let catsMinimized = false;
+  const updateCatToggle = () => {
+    catsMinimized = [...document.querySelectorAll('.cat-group > details')]
+      .every(d => !d.open);
+    dom.catToggle.textContent = catsMinimized ? '▶' : '▼';
+    dom.catToggle.title = catsMinimized
+      ? 'Öppna alla kategorier'
+      : 'Minimera alla kategorier';
+  };
+
   const summaryBtn = document.getElementById('summaryToggle');
   const summaryPanel = document.getElementById('summaryPanel');
   const summaryClose = document.getElementById('summaryClose');
@@ -343,10 +353,21 @@ function initCharacter() {
       });
       dom.valda.appendChild(catLi);
     });
+    updateCatToggle();
   };
 
   renderSkills(filtered()); activeTags(); updateXP(); renderTraits();
   window.indexViewUpdate = () => { renderSkills(filtered()); renderTraits(); };
+
+  dom.catToggle.addEventListener('click', () => {
+    const details = document.querySelectorAll('.cat-group > details');
+    if (catsMinimized) {
+      details.forEach(d => { d.open = true; });
+    } else {
+      details.forEach(d => { d.open = false; });
+    }
+    updateCatToggle();
+  });
 
   /* --- filter-events */
   dom.sIn.addEventListener('input', ()=>{sTemp=dom.sIn.value.trim(); activeTags(); renderSkills(filtered()); renderTraits();});


### PR DESCRIPTION
## Summary
- Make the "expand/collapse all" button work on the character page
- Update button state after rendering categories

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check js/character-view.js`

------
https://chatgpt.com/codex/tasks/task_e_68950136224483238d0d4a4458bf1a47