### PR TITLE
Ensure character view collapse-all matches index behavior

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -277,8 +277,10 @@ function initCharacter() {
     catKeys.forEach(cat=>{
       const catLi=document.createElement('li');
       catLi.className='cat-group';
-      catLi.innerHTML=`<details open><summary>${catName(cat)}</summary><ul class="card-list"></ul></details>`;
-      const listEl=catLi.querySelector('ul');
+      catLi.innerHTML=`<details${catsMinimized ? '' : ' open'}><summary>${catName(cat)}</summary><ul class="card-list"></ul></details>`;
+      const detailsEl = catLi.querySelector('details');
+      detailsEl.addEventListener('toggle', updateCatToggle);
+      const listEl=detailsEl.querySelector('ul');
       cats[cat].forEach(g=>{
         const p = g.entry;
         const availLvls = LVL.filter(l=>p.nivåer?.[l]);


### PR DESCRIPTION
## Summary
- Preserve category open/closed state in character view by rendering `<details>` based on current collapse setting.
- Update collapse-all button dynamically when individual categories are toggled, mirroring index page behavior.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895041e0fc083238619d4ad92f0c0c6