### PR TITLE
Add link and cancel editing features to notes page

### DIFF
--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -1,6 +1,6 @@
 (function(window){
   const fields = ['shadow','age','appearance','manner','quote','faction','goal','drives','loyalties','likes','hates','background'];
-  let form, editBtn, clearBtn;
+  let form, editBtn, clearBtn, charLink, isEditing=false;
 
   function showView(){
     const notes = storeHelper.getNotes(store);
@@ -18,7 +18,12 @@
       box.textContent=el.value;
     });
     form.classList.add('view-mode');
-    editBtn.classList.remove('hidden');
+    isEditing=false;
+    if(editBtn){
+      editBtn.textContent='✏️';
+      editBtn.title='Redigera';
+      editBtn.onclick = showEdit;
+    }
   }
 
   function showEdit(){
@@ -32,8 +37,19 @@
       if(box) box.remove();
       if(typeof autoResize === 'function') autoResize(el);
     });
-    editBtn.classList.add('hidden');
     form.classList.remove('view-mode');
+    isEditing=true;
+    if(editBtn){
+      editBtn.textContent='❌';
+      editBtn.title='Stäng utan att spara';
+      editBtn.onclick = cancelEdit;
+    }
+  }
+
+  function cancelEdit(){
+    if(confirm('Nu stängs redigering utan att spara, är du säker?')){
+      showView();
+    }
   }
 
   function initNotes() {
@@ -41,6 +57,7 @@
     if(!form) return;
     editBtn = document.getElementById('editBtn');
     clearBtn = document.getElementById('clearBtn');
+    charLink = document.getElementById('charLink');
 
     showView();
 
@@ -56,11 +73,19 @@
     });
 
     if(clearBtn) clearBtn.onclick = ()=>{
-      fields.forEach(id=>{
-        const el=form.querySelector('#'+id);
-        if(el) el.value='';
-      });
+      if(!isEditing || confirm('Du håller på att sudda ut alla dina anteckningar, är du säker?')){
+        fields.forEach(id=>{
+          const el=form.querySelector('#'+id);
+          if(el) el.value='';
+        });
+      }
     };
+
+    if(charLink) charLink.addEventListener('click',e=>{
+      if(isEditing && !confirm('Nu stängs redigering utan att spara, är du säker?')){
+        e.preventDefault();
+      }
+    });
 
     if(editBtn) editBtn.onclick = showEdit;
   }

--- a/notes.html
+++ b/notes.html
@@ -35,6 +35,7 @@
     <div class="panel-header">
       <h1 class="app-title">Anteckningar</h1>
       <div class="header-actions">
+        <a href="character.html" id="charLink" class="char-btn icon" title="Till rollperson">👤</a>
         <button id="editBtn" class="char-btn icon" title="Redigera">✏️</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add character link next to edit button in notes header
- Replace edit pencil with cancel icon in edit mode and confirm before leaving
- Confirm before clearing notes while editing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689507cacc848323aa72319fdeddf6f8