### PR TITLE
Make notes fields collapsible with toolbar toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1124,6 +1124,24 @@ select.level {
   margin-bottom: 1rem;
 }
 
+.note-field {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.note-field > summary {
+  margin-bottom: .4rem;
+  color: var(--subtxt);
+  font-size: .95rem;
+  cursor: pointer;
+}
+
+.note-field textarea {
+  margin-bottom: .6rem;
+}
+
 .form-group {
   flex: 1;
   display: flex;

--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -1,6 +1,7 @@
 (function(window){
   const fields = ['shadow','age','appearance','manner','quote','faction','goal','drives','loyalties','likes','hates','background'];
   let form, editBtn, clearBtn, charLink, isEditing=false;
+  let catsMinimized = false;
 
   function showView(){
     const notes = storeHelper.getNotes(store);
@@ -60,6 +61,32 @@
     charLink = document.getElementById('charLink');
 
     showView();
+
+    const updateCatToggle = () => {
+      const details = document.querySelectorAll('.note-field');
+      catsMinimized = [...details].every(d => !d.open);
+      if (dom.catToggle) {
+        dom.catToggle.textContent = catsMinimized ? '▶' : '▼';
+        dom.catToggle.title = catsMinimized
+          ? 'Öppna alla fält'
+          : 'Minimera alla fält';
+      }
+    };
+
+    updateCatToggle();
+    document.querySelectorAll('.note-field').forEach(d => {
+      d.addEventListener('toggle', updateCatToggle);
+    });
+
+    if (dom.catToggle) dom.catToggle.addEventListener('click', () => {
+      const details = document.querySelectorAll('.note-field');
+      if (catsMinimized) {
+        details.forEach(d => { d.open = true; });
+      } else {
+        details.forEach(d => { d.open = false; });
+      }
+      updateCatToggle();
+    });
 
     form.addEventListener('submit',e=>{
       e.preventDefault();

--- a/notes.html
+++ b/notes.html
@@ -44,68 +44,67 @@
     <form id="characterForm">
 
       <!-- -------- Bakgrund -------- -->
-      <h3>Berätta om rollpersonens bakgrund</h3>
-      <div class="form-group">
-        <label for="background">Berätta om rollpersonens bakgrund</label>
+      <details class="note-field" open>
+        <summary>Berätta om rollpersonens bakgrund</summary>
         <textarea id="background" name="background" class="auto-resize" placeholder="Här kan du skriva längre text…"></textarea>
-      </div>
+      </details>
 
       <!-- -------- Kortfattat -------- -->
-      <div class="field-row">
-        <div class="form-group">
-          <label for="shadow">Skugga</label>
-          <textarea id="shadow" name="shadow" class="auto-resize" placeholder="Ex. ’Smygaren’"></textarea>
+        <div class="field-row">
+          <details class="note-field" open>
+            <summary>Skugga</summary>
+            <textarea id="shadow" name="shadow" class="auto-resize" placeholder="Ex. ’Smygaren’"></textarea>
+          </details>
+          <details class="note-field" open>
+            <summary>Ålder</summary>
+            <textarea id="age" name="age" class="auto-resize" placeholder="T.ex. 34"></textarea>
+          </details>
         </div>
-        <div class="form-group">
-          <label for="age">Ålder</label>
-          <textarea id="age" name="age" class="auto-resize" placeholder="T.ex. 34"></textarea>
+        <div class="field-row">
+          <details class="note-field" open>
+            <summary>Utseende</summary>
+            <textarea id="appearance" name="appearance" class="auto-resize" placeholder="Kort beskrivning"></textarea>
+          </details>
+          <details class="note-field" open>
+            <summary>Manér</summary>
+            <textarea id="manner" name="manner" class="auto-resize" placeholder="Särskilda drag"></textarea>
+          </details>
         </div>
-      </div>
-      <div class="field-row">
-        <div class="form-group">
-          <label for="appearance">Utseende</label>
-          <textarea id="appearance" name="appearance" class="auto-resize" placeholder="Kort beskrivning"></textarea>
-        </div>
-        <div class="form-group">
-          <label for="manner">Manér</label>
-          <textarea id="manner" name="manner" class="auto-resize" placeholder="Särskilda drag"></textarea>
-        </div>
-      </div>
-      <div class="form-group">
-        <label for="quote">Citat</label>
-        <textarea id="quote" name="quote" class="auto-resize" placeholder="Signaturcitat"></textarea>
-      </div>
+        <details class="note-field" open>
+          <summary>Citat</summary>
+          <textarea id="quote" name="quote" class="auto-resize" placeholder="Signaturcitat"></textarea>
+        </details>
 
-      <div class="form-group">
-        <label for="faction">Fraktion/ätt/klan/stam</label>
-        <textarea id="faction" name="faction" class="auto-resize" placeholder="T.ex. ätt eller klan"></textarea>
-      </div>
+        <details class="note-field" open>
+          <summary>Fraktion/ätt/klan/stam</summary>
+          <textarea id="faction" name="faction" class="auto-resize" placeholder="T.ex. ätt eller klan"></textarea>
+        </details>
 
       <!-- -------- Mellanlångt -------- -->
-      <div class="field-row">
-        <div class="form-group">
-          <label for="goal">Personligt mål</label>
-          <textarea id="goal" name="goal" class="auto-resize" placeholder="Livsmål, ambition"></textarea>
+        <div class="field-row">
+          <details class="note-field" open>
+            <summary>Personligt mål</summary>
+            <textarea id="goal" name="goal" class="auto-resize" placeholder="Livsmål, ambition"></textarea>
+          </details>
+          <details class="note-field" open>
+            <summary>Drivkrafter</summary>
+            <textarea id="drives" name="drives" class="auto-resize" placeholder="Vad får dem att agera?"></textarea>
+          </details>
         </div>
-        <div class="form-group">
-          <label for="drives">Drivkrafter</label>
-          <textarea id="drives" name="drives" class="auto-resize" placeholder="Vad får dem att agera?"></textarea>
+        <div class="field-row">
+          <details class="note-field" open>
+            <summary>Lojaliteter</summary>
+            <textarea id="loyalties" name="loyalties" class="auto-resize" placeholder="T.ex. familj, gille"></textarea>
+          </details>
+          <details class="note-field" open>
+            <summary>Älskar</summary>
+            <textarea id="likes" name="likes" class="auto-resize" placeholder="T.ex. skogar, böcker"></textarea>
+          </details>
         </div>
-      </div>
-      <div class="field-row">
-        <div class="form-group">
-          <label for="loyalties">Lojaliteter</label>
-          <textarea id="loyalties" name="loyalties" class="auto-resize" placeholder="T.ex. familj, gille"></textarea>
-        </div>
-        <div class="form-group">
-          <label for="likes">Älskar</label>
-          <textarea id="likes" name="likes" class="auto-resize" placeholder="T.ex. skogar, böcker"></textarea>
-        </div>
-      </div>
-      <div class="form-group">
-        <label for="hates">Hatar</label>
-        <textarea id="hates" name="hates" class="auto-resize" placeholder="T.ex. orättvisa, korruption"></textarea>
-      </div>
+        <details class="note-field" open>
+          <summary>Hatar</summary>
+          <textarea id="hates" name="hates" class="auto-resize" placeholder="T.ex. orättvisa, korruption"></textarea>
+        </details>
 
       <!-- -------- Knappar -------- -->
       <div class="char-btn-row">


### PR DESCRIPTION
## Summary
- Make each notes field a collapsible section.
- Wire up collapse-all toggle for notes view.
- Style note fields to match label appearance.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68950fbf9d2483238633679024040c0a