### PR TITLE
Show selected character name on notes page

### DIFF
--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -60,6 +60,10 @@
     clearBtn = document.getElementById('clearBtn');
     charLink = document.getElementById('charLink');
 
+    if (dom.cName) {
+      dom.cName.textContent = store.characters.find(c => c.id === store.current)?.name || '';
+    }
+
     showView();
 
     const updateCatToggle = () => {

--- a/notes.html
+++ b/notes.html
@@ -35,7 +35,8 @@
 
   <div class="panel">
     <div class="panel-header">
-      <div class="header-actions" style="margin-left:auto">
+      <h2 id="charName" style="margin:0;"></h2>
+      <div class="header-actions">
         <a href="character.html" id="charLink" class="char-btn icon" title="Till rollperson">🧝</a>
         <button id="editBtn" class="char-btn icon" title="Redigera">✏️</button>
       </div>


### PR DESCRIPTION
## Summary
- Display current character's name in the notes view header
- Sync notes view with selected character name on initialization

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895a5a8e71c8323be1e874ca5f39c41