### PR TITLE
Lägg till kollapsknappar i inventariet

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -261,6 +261,17 @@ input:focus, select:focus, textarea:focus {
   align-items: center;
   gap: .4rem;
 }
+.card-title .collapse-btn {
+  width: 1rem;
+  display: inline-block;
+  margin-right: .4rem;
+}
+.card-title .collapse-btn::before {
+  content: '▼';
+}
+.card.compact .card-title .collapse-btn::before {
+  content: '▶';
+}
 .xp-cost {
   font-size: .9rem;
   color: var(--subtxt);

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -508,7 +508,7 @@
     /* ---------- kort för pengar ---------- */
     const moneyCard = `
       <li class="card compact">
-        <div class="card-title">Pengar</div>
+        <div class="card-title"><span><span class="collapse-btn"></span>Pengar</span></div>
         <div class="card-desc">
           Kontant: ${cash.daler}D ${cash.skilling}S ${cash['örtegar']}Ö
           <br>Kostnad: ${tot.d}D ${tot.s}S ${tot.o}Ö
@@ -597,7 +597,7 @@
             <li class="card compact"
                 data-idx="${idx}"
                 data-name="${row.name}"${row.trait?` data-trait="${row.trait}"`:''}${dataLevel}>
-              <div class="card-title">${row.name}</div>
+              <div class="card-title"><span><span class="collapse-btn"></span>${row.name}</span></div>
               <div class="card-desc">
                 ${desc}${freeCnt ? ` <span class="tag free">Gratis${freeCnt>1? '×'+freeCnt:''}</span>` : ''}${lvlInfo}<br>Antal: ${row.qty}<br>Pris: ${priceText}
               </div>


### PR DESCRIPTION
## Sammanfattning
- Lägg till kollapsknappar i pengar- och föremålsrader i inventariet.
- Styla nya knappar med roterande pilar för att visa öppet/stängt läge.

## Testning
- `npm test` *(misslyckas: package.json saknas)*

------
https://chatgpt.com/codex/tasks/task_e_68960bc1d1f4832392f5df80bcf2fe69