### PR TITLE
Center character lock popup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1111,7 +1111,7 @@ select.level {
   width: 100%;
   height: 100%;
   display: none;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
   background: rgba(0,0,0,.6);
   z-index: 3000;
@@ -1120,19 +1120,19 @@ select.level {
 #charPopup .popup-inner {
   background: var(--panel);
   border: 1.5px solid var(--border);
-  border-radius: 1.2rem 1.2rem 0 0;
+  border-radius: 1.2rem;
   box-shadow: var(--shadow);
   padding: 1.5rem 1.4rem 2rem;
   width: 100%;
   max-width: 420px;
   text-align: center;
-  transform: translateY(100%);
+  transform: scale(.8);
   transition: transform .25s ease;
   display: flex;
   flex-direction: column;
   gap: .8rem;
 }
-#charPopup.open .popup-inner { transform: translateY(0); }
+#charPopup.open .popup-inner { transform: scale(1); }
 #charPopup .popup-inner button { width: 100%; }
 
 /* Gör samtliga popups scrollbara om innehållet blir för högt */


### PR DESCRIPTION
## Summary
- Center character selection lock popup so it appears prominently
- Use scale animation to match site styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960d6d143c83238eb64193f246ed4f