### PR TITLE
Isolate inventory entry collapse

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -271,8 +271,10 @@ input:focus, select:focus, textarea:focus {
   font-size: 1.1rem;
 }
 .card-desc  { font-size: 1.15rem; }
-.card.compact .card-desc { display: none; }
-.card.compact .inv-controls { display: none; }
+.card.compact .card-desc,
+.card.inv-compact .card-desc { display: none; }
+.card.compact .inv-controls,
+.card.inv-compact .inv-controls { display: none; }
 .card-price {
   position: absolute;
   bottom: 0.6rem;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -507,7 +507,7 @@
 
     /* ---------- kort för pengar ---------- */
     const moneyCard = `
-      <li class="card compact">
+      <li class="card inv-compact">
         <div class="card-title">Pengar</div>
         <div class="card-desc">
           Kontant: ${cash.daler}D ${cash.skilling}S ${cash['örtegar']}Ö
@@ -594,7 +594,7 @@
           );
 
           return `
-            <li class="card compact"
+            <li class="card inv-compact"
                 data-idx="${idx}"
                 data-name="${row.name}"${row.trait?` data-trait="${row.trait}"`:''}${dataLevel}>
               <div class="card-title">${row.name}</div>
@@ -673,7 +673,7 @@
       const title = e.target.closest('.card-title');
       if (title) {
         const li = title.closest('li.card');
-        li.classList.toggle('compact');
+        li.classList.toggle('inv-compact');
         return;
       }
 


### PR DESCRIPTION
## Summary
- Add distinct `inv-compact` class for inventory entries to separate collapse styling from index/character entries
- Apply new class in inventory renderer and title click handler
- Adjust CSS to hide inventory descriptions and controls when collapsed while keeping other entry behavior unchanged

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68960ce6c6808323bebd450186ae3314