### PR TITLE
Restrict collapse to inventory entries

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -254,7 +254,6 @@ input:focus, select:focus, textarea:focus {
   align-items: baseline;
   font-size: calc(1.34rem - 2px);
   font-weight: 600;
-  cursor: pointer;
 }
 .card-title .title-actions {
   display: flex;
@@ -265,6 +264,7 @@ input:focus, select:focus, textarea:focus {
   width: 1rem;
   display: inline-block;
   margin-right: .4rem;
+  cursor: pointer;
 }
 .card-title .collapse-btn::before {
   content: '▼';

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -669,10 +669,10 @@
         return;
       }
 
-      // 2) Klick på rubriken för att expandera/kollapsa posten
-      const title = e.target.closest('.card-title');
-      if (title) {
-        const li = title.closest('li.card');
+      // 2) Klick på collapse-knappen för att expandera/kollapsa posten
+      const collapseBtn = e.target.closest('.collapse-btn');
+      if (collapseBtn) {
+        const li = collapseBtn.closest('li.card');
         li.classList.toggle('compact');
         return;
       }


### PR DESCRIPTION
## Summary
- ensure card titles outside the inventory remain unaffected by collapse styling
- toggle inventory rows only when the dedicated collapse button is clicked

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68960f7a68988323a4869352883a24a7