### PR TITLE
Show controls and XP in compact entry view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -284,6 +284,10 @@ input:focus, select:focus, textarea:focus {
 .card-desc  { font-size: 1.15rem; }
 .card.compact .card-desc { display: none; }
 .card.compact .inv-controls { display: none; }
+#lista .card.compact .inv-controls,
+#valda .card.compact .inv-controls {
+  display: flex;
+}
 .card-price {
   position: absolute;
   bottom: 0.6rem;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -178,6 +178,10 @@ function initIndex() {
         }
         const limit = isInv(p) ? Infinity : storeHelper.monsterStackLimit(charList, p.namn);
         const badge = multi && count>0 ? ` <span class="count-badge">×${count}</span>` : '';
+        const xpVal = isInv(p) ? null : storeHelper.calcEntryXP(p, charList);
+        const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
+        const xpHtml = xpVal != null ? `<span class="xp-cost">Erf: ${xpText}</span>` : '';
+        const titleActions = xpHtml ? `<span class="title-actions">${xpHtml}</span>` : '';
         const showInfo = compact || hideDetails;
         const eliteBtn = isElityrke(p)
           ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
@@ -208,7 +212,7 @@ function initIndex() {
         const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
         const priceHtml = priceText ? `<div class="card-price">${priceText}</div>` : '';
         li.innerHTML = `
-          <div class="card-title">${p.namn}${badge}</div>
+          <div class="card-title"><span>${p.namn}${badge}</span>${titleActions}</div>
           ${tagsDiv}
           ${levelHtml}
           ${descHtml}


### PR DESCRIPTION
## Summary
- Display entry controls in compact view for character and index lists while keeping inventory items collapsed
- Render XP cost in index listings and keep price visible in compact mode

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689613ac1c108323bbfb7c324c6135e7