### PR TITLE
Add collapse-all toggle for inventory

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -619,6 +619,15 @@
     dom.invBadge.textContent    = allInv.reduce((s, r) => s + r.qty, 0);
     dom.unusedOut = $T('unusedOut');
     if (dom.unusedOut) dom.unusedOut.textContent = diffText;
+    if (dom.collapseAllBtn) updateCollapseBtnState();
+  }
+
+  function updateCollapseBtnState() {
+    if (!dom.collapseAllBtn || !dom.invList) return;
+    const cards = [...dom.invList.querySelectorAll('li.card')];
+    const anyOpen = cards.some(li => !li.classList.contains('compact'));
+    dom.collapseAllBtn.textContent = anyOpen ? '▶' : '▼';
+    dom.collapseAllBtn.title = anyOpen ? 'Kollapsa alla' : 'Öppna alla';
   }
 
   function bindInv() {
@@ -643,6 +652,14 @@
         if (window.indexViewUpdate) window.indexViewUpdate();
       });
     });
+    if (dom.collapseAllBtn) {
+      dom.collapseAllBtn.addEventListener('click', () => {
+        const cards = [...dom.invList.querySelectorAll('li.card')];
+        const anyOpen = cards.some(li => !li.classList.contains('compact'));
+        cards.forEach(li => li.classList.toggle('compact', anyOpen));
+        updateCollapseBtnState();
+      });
+    }
     dom.invList.addEventListener('click', e => {
       // 1) Klick på kryss för att ta bort en enskild kvalitet
       const removeTagBtn = e.target.closest('.tag.removable[data-qual]');
@@ -674,6 +691,7 @@
       if (collapseBtn) {
         const li = collapseBtn.closest('li.card');
         li.classList.toggle('compact');
+        updateCollapseBtnState();
         return;
       }
 

--- a/js/main.js
+++ b/js/main.js
@@ -32,6 +32,7 @@ const dom  = {
   moneyResetBtn: $T('moneyResetBtn'),
   clearInvBtn : $T('clearInvBtn'),
   invTypeSel : $T('invTypeFilter'),
+  collapseAllBtn: $T('collapseAllInv'),
   unusedOut: $T('unusedOut'),
 
   /* smith filter */

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -133,7 +133,10 @@ class SharedToolbar extends HTMLElement {
       <aside id="invPanel" class="offcanvas">
         <header class="inv-header">
           <h2>Inventarie</h2>
-          <button class="char-btn icon" data-close="invPanel">✕</button>
+          <div>
+            <button id="collapseAllInv" class="char-btn icon" title="Kollapsa alla">▶</button>
+            <button class="char-btn icon" data-close="invPanel">✕</button>
+          </div>
         </header>
         <div class="filter-group">
           <label for="invTypeFilter">Kategori</label>


### PR DESCRIPTION
## Summary
- Add button to inventory panel for expanding or collapsing all items
- Update JavaScript to toggle all entries and keep button state in sync

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68961507b5288323aa2719e260897673