### PR TITLE
Allow collapsing inventory cards by clicking title

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -255,6 +255,9 @@ input:focus, select:focus, textarea:focus {
   font-size: calc(1.34rem - 2px);
   font-weight: 600;
 }
+#invList .card-title {
+  cursor: pointer;
+}
 .card-title .title-actions {
   display: flex;
   align-items: center;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -686,10 +686,10 @@
         return;
       }
 
-      // 2) Klick på collapse-knappen för att expandera/kollapsa posten
-      const collapseBtn = e.target.closest('.collapse-btn');
-      if (collapseBtn) {
-        const li = collapseBtn.closest('li.card');
+      // 2) Klick på titeln för att expandera/kollapsa posten
+      const cardTitle = e.target.closest('.card-title');
+      if (cardTitle) {
+        const li = cardTitle.closest('li.card');
         li.classList.toggle('compact');
         updateCollapseBtnState();
         return;


### PR DESCRIPTION
## Summary
- Make entire inventory card header clickable to toggle collapse
- Show pointer cursor over inventory card titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68961dcfcc44832387abcde6191b34c9