### PR TITLE
Add weight to all traps

### DIFF
--- a/data/fallor.json
+++ b/data/fallor.json
@@ -8,6 +8,7 @@
     "nivåer": {
       "Novis": "Apteras med Försåtsgillrare eller Pyroteknik. Vid utlöst kastar den brinnande substans på målet. Substansen fortsätter brinna. Att skrapa bort substansen är en stridshandling som kräver lyckat [Kvick←Listig] där Listig motsvarar minmakarens (vanligen 13, −3). Vatten kväver lågorna tills offret lämnar vattnet. Allierade får egna försök att skrapa bort. Explosionen gör 1t8 skada; därefter brinner substansen i 1t4 rundor och ger 1t4 skada per runda."
     },
+    "stat": { "vikt": 1.0 },
     "grundpris": { "daler": 2, "skilling": 0, "örtegar": 0 }
   },
   {
@@ -19,6 +20,7 @@
     "nivåer": {
       "Gesäll": "Apteras med Försåtsgillrare eller Pyroteknik. Vid utlöst kastar den brinnande substans på målet. Substansen fortsätter brinna. Att skrapa bort substansen är en stridshandling som kräver lyckat [Kvick←Listig] där Listig motsvarar minmakarens (vanligen 13, −3). Vatten kväver lågorna tills offret lämnar vattnet. Allierade får egna försök att skrapa bort. Explosionen gör 1t10 skada; därefter brinner substansen i 1t6 rundor och ger 1t6 skada per runda."
     },
+    "stat": { "vikt": 1.0 },
     "grundpris": { "daler": 4, "skilling": 0, "örtegar": 0 }
   },
   {
@@ -30,6 +32,7 @@
     "nivåer": {
       "Mästare": "Apteras med Försåtsgillrare eller Pyroteknik. Vid utlöst kastar den brinnande substans på målet. Substansen fortsätter brinna. Att skrapa bort substansen är en stridshandling som kräver lyckat [Kvick←Listig] där Listig motsvarar minmakarens (vanligen 13, −3). Vatten kväver lågorna tills offret lämnar vattnet. Allierade får egna försök att skrapa bort. Explosionen gör 1t12 skada; därefter brinner substansen i 1t8 rundor och ger 1t8 skada per runda."
     },
+    "stat": { "vikt": 1.0 },
     "grundpris": { "daler": 8, "skilling": 0, "örtegar": 0 }
   },
   {
@@ -41,6 +44,7 @@
     "nivåer": {
       "Novis": "Fångstarmar med taggar hugger i offret. För att slita sig loss krävs lyckat [Stark←Listig] där Listig motsvarar fällsmedens (vanligen 13, −3). Varje försök är en stridshandling. Fällan ger 1t8 skada."
     },
+    "stat": { "vikt": 1.0 },
     "grundpris": { "daler": 1, "skilling": 0, "örtegar": 0 }
   },
   {
@@ -52,6 +56,7 @@
     "nivåer": {
       "Gesäll": "Fångstarmar med taggar hugger i offret. För att slita sig loss krävs lyckat [Stark←Listig] där Listig motsvarar fällsmedens (vanligen 13, −3). Varje försök är en stridshandling. Fällan ger 1t10 skada."
     },
+    "stat": { "vikt": 1.0 },
     "grundpris": { "daler": 2, "skilling": 0, "örtegar": 0 }
   },
   {
@@ -63,6 +68,7 @@
     "nivåer": {
       "Mästare": "Fångstarmar med taggar hugger i offret. För att slita sig loss krävs lyckat [Stark←Listig] där Listig motsvarar fällsmedens (vanligen 13, −3). Varje försök är en stridshandling. Fällan ger 1t12 skada."
     },
+    "stat": { "vikt": 1.0 },
     "grundpris": { "daler": 3, "skilling": 0, "örtegar": 0 }
   }
 ]


### PR DESCRIPTION
## Summary
- add `stat` block with `vikt` 1.0 to every trap in `fallor.json`

## Testing
- `npm test` *(fails: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689661df50f4832380be19f5dcad01cf