### PR TITLE
Add weight for bottled drinks

### DIFF
--- a/data/dryck.json
+++ b/data/dryck.json
@@ -82,6 +82,9 @@
         "Dryck"
       ]
     },
+    "stat": {
+      "vikt": 1.0
+    },
     "grundpris": {
       "daler": 3,
       "skilling": 0,
@@ -96,6 +99,9 @@
       "typ": [
         "Dryck"
       ]
+    },
+    "stat": {
+      "vikt": 1.0
     },
     "grundpris": {
       "daler": 2,
@@ -112,6 +118,9 @@
         "Dryck"
       ]
     },
+    "stat": {
+      "vikt": 1.0
+    },
     "grundpris": {
       "daler": 1,
       "skilling": 0,
@@ -126,6 +135,9 @@
       "typ": [
         "Dryck"
       ]
+    },
+    "stat": {
+      "vikt": 1.0
     },
     "grundpris": {
       "daler": 1,
@@ -142,6 +154,9 @@
         "Dryck"
       ]
     },
+    "stat": {
+      "vikt": 1.0
+    },
     "grundpris": {
       "daler": 15,
       "skilling": 0,
@@ -156,6 +171,9 @@
       "typ": [
         "Dryck"
       ]
+    },
+    "stat": {
+      "vikt": 1.0
     },
     "grundpris": {
       "daler": 2,


### PR DESCRIPTION
## Summary
- add weight stats for bottled beverages in the drink dataset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966109bba083239fa6ca0eefa7b03b