### PR TITLE
Add carry capacity tracking in inventory menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1274,3 +1274,10 @@ textarea.auto-resize {
   margin-top: .6rem;
 }
 
+.cap-info { font-size: .85rem; }
+.cap-row { display: flex; }
+.cap-row .label { flex: 1; }
+.cap-row .value { flex: 1; text-align: right; font-variant-numeric: tabular-nums; }
+.cap-info.cap-neg { color: var(--danger); }
+.cap-info.cap-pos { color: #4caf50; }
+

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -119,6 +119,7 @@ function initIndex() {
         const hideDetails = isRas(p) || isYrke(p) || isElityrke(p);
         let desc = abilityHtml(p);
         let priceText = '';
+        let weightText = '';
         if (isInv(p)) {
           desc += itemStatHtml(p);
           const baseQuals = [
@@ -134,8 +135,14 @@ function initIndex() {
           if (p.grundpris) {
             priceText = formatMoney(invUtil.calcEntryCost(p));
           }
+          const baseW = p.vikt ?? p.stat?.vikt ?? 0;
+          const massCnt = baseQuals.filter(q => q === 'Massivt').length;
+          if (baseW || massCnt) {
+            const w = baseW + massCnt;
+            weightText = `<br>Vikt: ${formatWeight(w)}`;
+          }
         }
-        let infoHtml = priceText ? `${desc}<br>Pris: ${priceText}` : desc;
+        let infoHtml = priceText ? `${desc}<br>Pris: ${priceText}${weightText}` : `${desc}${weightText}`;
         if (isRas(p) || isYrke(p) || isElityrke(p)) {
           const extra = yrkeInfoHtml(p);
           if (extra) infoHtml += `<br>${extra}`;

--- a/js/utils.js
+++ b/js/utils.js
@@ -187,6 +187,10 @@
     return '';
   }
 
+  function formatWeight(w) {
+    return `${Math.round(w * 10) / 10} kg`;
+  }
+
   // Normalize text for searches by removing diacritics except for
   // the Swedish characters å, ä and ö. Everything should be in
   // lowercase before calling this function.
@@ -258,6 +262,7 @@
   window.splitQuals = splitQuals;
   window.formatMoney = formatMoney;
   window.itemStatHtml = itemStatHtml;
+  window.formatWeight = formatWeight;
   window.searchNormalize = searchNormalize;
   window.createSearchSorter = createSearchSorter;
   window.copyToClipboard = copyToClipboard;


### PR DESCRIPTION
## Summary
- Display new "Bärkapacitet" section in inventory with max, used and remaining weight
- Show item weight per stack in inventory and index views, including Massivt quality
- Add helpers and styles for weight formatting and capacity coloring

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689669e3bd5c83239758ba984c6a1dcf