### PR TITLE
Use strength-based carry capacity

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -65,13 +65,11 @@ function initCharacter() {
     const vals = {};
     KEYS.forEach(k=>{ vals[k] = (traits[k]||0) + (bonus[k]||0) + (maskBonus[k]||0); });
 
-    const hasPack = list.some(e=>e.namn==='Packåsna');
     const hasHardnackad = list.some(p=>p.namn==='Hårdnackad');
     const hasKraftprov = list.some(p=>p.namn==='Kraftprov');
     const valStark = vals['Stark'];
+    const capacity = storeHelper.calcCarryCapacity(valStark, list);
     const hardy = hasHardnackad ? 1 : 0;
-    let capacity = valStark;
-    if(hasPack) capacity = Math.ceil(capacity * 1.5);
     const talBase = hasKraftprov ? valStark + 5 : Math.max(10, valStark);
     const tal = talBase + hardy;
     const pain = storeHelper.calcPainThreshold(valStark, list, effects);

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -418,8 +418,8 @@
     const bonus = window.exceptionSkill ? exceptionSkill.getBonuses(list) : {};
     const maskBonus = window.maskSkill ? maskSkill.getBonuses(allInv) : {};
     const valStark = (traits['Stark']||0) + (bonus['Stark']||0) + (maskBonus['Stark']||0);
-    let maxCapacity = valStark * 5;
-    if (list.some(e=>e.namn==='Packåsna')) maxCapacity = Math.ceil(maxCapacity * 1.5);
+    const baseCap = storeHelper.calcCarryCapacity(valStark, list);
+    const maxCapacity = baseCap * 5;
     const remainingCap = maxCapacity - usedWeight;
 
     if (dom.invTypeSel) {

--- a/js/store.js
+++ b/js/store.js
@@ -806,6 +806,14 @@ function defaultTraits() {
     return Number(baseXp || 0) + countDisadvantages(list) * 5;
   }
 
+  function calcCarryCapacity(strength, list) {
+    let base = Number(strength || 0);
+    if (Array.isArray(list) && list.some(e => e.namn === 'Packåsna')) {
+      base = Math.ceil(base * 1.5);
+    }
+    return base;
+  }
+
   function calcPainThreshold(strength, list, extra) {
     const painBonus = list.filter(e => e.namn === 'Smärttålig').length;
     const painPenalty = list.filter(e => e.namn === 'Bräcklig').length;
@@ -1073,6 +1081,7 @@ function defaultTraits() {
     calcEntryXP,
     calcTotalXP,
     calcPermanentCorruption,
+    calcCarryCapacity,
     calcPainThreshold,
     abilityLevel,
     hamnskifteNoviceLimit,

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -182,9 +182,7 @@
       let beforeExtra = '';
       let afterExtra = `<div class="trait-count">Förmågor: ${counts[k]}</div>`;
       if (k === 'Stark') {
-        let base = val;
-        const hasPack = list.some(e => e.namn === 'Packåsna');
-        if (hasPack) base = Math.ceil(base * 1.5);
+        const base = storeHelper.calcCarryCapacity(val, list);
         tal  += hardy;
         pain = storeHelper.calcPainThreshold(val, list, effects);
         beforeExtra = `<div class="trait-count">Förmågor: ${counts[k]}</div>` + `<div class="trait-extra">Bärkapacitet: ${base}</div>`;


### PR DESCRIPTION
## Summary
- centralize carry capacity calculation via `calcCarryCapacity`
- derive inventory limits from strength-based capacity
- show carry capacity consistently in trait and character views

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966d46d1988323a9e6501ebe447d8e