### PR TITLE
Koppla inventariens bärkapacitet till styrka

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -419,7 +419,7 @@
     const maskBonus = window.maskSkill ? maskSkill.getBonuses(allInv) : {};
     const valStark = (traits['Stark']||0) + (bonus['Stark']||0) + (maskBonus['Stark']||0);
     const baseCap = storeHelper.calcCarryCapacity(valStark, list);
-    const maxCapacity = baseCap * 5;
+    const maxCapacity = baseCap;
     const remainingCap = maxCapacity - usedWeight;
 
     if (dom.invTypeSel) {


### PR DESCRIPTION
## Sammanfattning
- Länkar inventariets maxkapacitet direkt till bärkapaciteten som beräknas från Stark-värdet.
- Kapaciteten tar nu automatiskt hänsyn till fördelen Packåsna via `calcCarryCapacity`.

## Testning
- `npm test` *(misslyckades: saknar package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689704b802348323ad53d8a5ae5a2fe7