### PR TITLE
Display weights with two decimals

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -139,7 +139,7 @@ function initCharacter() {
       </section>
       <section class="summary-section">
         <h3>Bärkapacitet</h3>
-        <ul><li>${capacity}</li></ul>
+        <ul><li>${formatWeight(capacity)}</li></ul>
       </section>
       <section class="summary-section">
         <h3>Hälsa</h3>

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -185,7 +185,7 @@
         const base = storeHelper.calcCarryCapacity(val, list);
         tal  += hardy;
         pain = storeHelper.calcPainThreshold(val, list, effects);
-        beforeExtra = `<div class="trait-count">Förmågor: ${counts[k]}</div>` + `<div class="trait-extra">Bärkapacitet: ${base}</div>`;
+        beforeExtra = `<div class="trait-count">Förmågor: ${counts[k]}</div>` + `<div class="trait-extra">Bärkapacitet: ${formatWeight(base)}</div>`;
         afterExtra = '';
         extra = `<div class="trait-extra">Tålighet: ${tal} • Smärtgräns: ${pain}</div>`;
       } else if (k === 'Viljestark') {

--- a/js/utils.js
+++ b/js/utils.js
@@ -188,7 +188,7 @@
   }
 
   function formatWeight(w) {
-    return `${Math.round(w * 10) / 10} kg`;
+    return `${Number(w).toFixed(2)} kg`;
   }
 
   // Normalize text for searches by removing diacritics except for


### PR DESCRIPTION
## Summary
- Show weights with two decimals for items and capacity
- Include formatted weights in trait and character summaries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897063aafdc83238b3f20e04e241143