### PR TITLE
Add weight input for custom inventory items

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 ### 5. Inventariepanelen
 Via `🎒` kommer du åt allt du har samlat på dig.
 - **Kategori** låter dig filtrera inventarielistan på typ av utrustning.
-- **Nytt föremål** lägger till ett eget objekt. Här kan du även bestämma grundpris och beskrivning.
+- **Nytt föremål** lägger till ett eget objekt. Här kan du även bestämma vikt, grundpris och beskrivning.
 - **Hantera pengar** öppnar en popup där du kan nollställa, addera eller ersätta dina pengar.
 - **Rensa inventarie** tar bort all utrustning.
 I listan för varje föremål finns knappar för att öka/minska antal, markera som gratis, redigera kvaliteter och mer.

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -156,6 +156,7 @@
     const pop   = bar.shadowRoot.getElementById('customPopup');
     const name  = bar.shadowRoot.getElementById('customName');
     const type  = bar.shadowRoot.getElementById('customType');
+    const wIn   = bar.shadowRoot.getElementById('customWeight');
     const effBox= bar.shadowRoot.getElementById('customArtifactEffect');
     const effSel= effBox ? effBox.querySelector('select') : null;
     const dIn   = bar.shadowRoot.getElementById('customDaler');
@@ -188,6 +189,7 @@
       pop.removeEventListener('click', onOutside);
       name.value = '';
       dIn.value = sIn.value = oIn.value = '';
+      wIn.value = '';
       desc.value = '';
       if (effSel) effSel.value = 'corruption';
       if (effBox) effBox.style.display = 'none';
@@ -197,6 +199,7 @@
       const entry = {
         namn: name.value.trim(),
         taggar: { typ: [type.value] },
+        vikt: Number(wIn.value)||0,
         grundpris: {
           daler: Number(dIn.value)||0,
           skilling: Number(sIn.value)||0,

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -285,6 +285,7 @@ class SharedToolbar extends HTMLElement {
           <h3>Nytt föremål</h3>
           <input id="customName" placeholder="Namn">
           <select id="customType"></select>
+          <input id="customWeight" type="number" min="0" step="0.01" placeholder="Vikt (kg)">
           <div id="customArtifactEffect" class="filter-group" style="display:none">
             <label for="artifactEffect">Effekt</label>
             <select id="artifactEffect">


### PR DESCRIPTION
## Summary
- enable entering item weight in the "Nytt föremål" popup
- store and reset the new weight field when saving custom items
- document that custom items now accept weight

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973b5f4164832390f419db1946c110