### PR TITLE
Align inventory weight display with money style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1274,10 +1274,8 @@ textarea.auto-resize {
   margin-top: .6rem;
 }
 
-.cap-info { font-size: .85rem; }
 .cap-row { display: flex; }
 .cap-row .label { flex: 1; }
 .cap-row .value { flex: 1; text-align: right; font-variant-numeric: tabular-nums; }
-.cap-info.cap-neg { color: var(--danger); }
-.cap-info.cap-pos { color: #4caf50; }
+.cap-neg { color: var(--danger); }
 

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -545,10 +545,10 @@
     const capCard = `
       <li class="card compact">
         <div class="card-title"><span><span class="collapse-btn"></span>Bärkapacitet</span></div>
-        <div class="card-desc cap-info ${remainingCap < 0 ? 'cap-neg' : 'cap-pos'}">
-          <div class="cap-row"><span class="label">Maxkapacitet:</span><span class="value">${formatWeight(maxCapacity)}</span></div>
-          <div class="cap-row"><span class="label">Använd vikt:</span><span class="value">${formatWeight(usedWeight)}</span></div>
-          <div class="cap-row"><span class="label">Återstående kapacitet:</span><span class="value">${formatWeight(remainingCap)}</span></div>
+        <div class="card-desc ${remainingCap < 0 ? 'cap-neg' : ''}">
+          <div class="cap-row"><span class="label">Max:</span><span class="value">${formatWeight(maxCapacity)}</span></div>
+          <div class="cap-row"><span class="label">Använd:</span><span class="value">${formatWeight(usedWeight)}</span></div>
+          <div class="cap-row"><span class="label">Återstående:</span><span class="value">${formatWeight(remainingCap)}</span></div>
         </div>
       </li>`;
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -188,7 +188,7 @@
   }
 
   function formatWeight(w) {
-    return `${Number(w).toFixed(2)} kg`;
+    return Number(w).toFixed(2);
   }
 
   // Normalize text for searches by removing diacritics except for


### PR DESCRIPTION
## Summary
- Match Bärkapacitet card with Pengar styling and neutral positive colors
- Remove "kg" suffix from all weight outputs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973b24d7688323bf51bb1bb29242e6