### PR TITLE
Combine money and capacity cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1279,3 +1279,16 @@ textarea.auto-resize {
 .cap-row .value { flex: 1; text-align: right; font-variant-numeric: tabular-nums; }
 .cap-neg { color: var(--danger); }
 
+.formal-section { margin-bottom: .8rem; }
+.formal-section:last-child { margin-bottom: 0; }
+.formal-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  margin-bottom: .3rem;
+}
+.money-control { display: flex; gap: .3rem; }
+.money-control .char-btn { padding: .3rem .6rem; }
+.cap-food { color: var(--txt); }
+


### PR DESCRIPTION
## Summary
- Merge money and carry capacity into a single "Formaliteter" card.
- Drop cost and used rows, add +/− buttons for adjusting daler and a food count.
- Style new layout and keep food count color neutral.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897927dd6088323b926893f0a9b317f