### PR TITLE
Move food field to bottom and show money weight under Pengar

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -552,7 +552,7 @@
     }).length;
 
     const moneyRow = moneyWeight
-      ? `          <div class="cap-row"><span class="label">Pengar:</span><span class="value">${formatWeight(moneyWeight)}</span></div>`
+      ? `            <div class="cap-row"><span class="label">Pengavikt:</span><span class="value">${formatWeight(moneyWeight)}</span></div>`
       : '';
 
     /* ---------- kort för formaliteter (pengar & bärkapacitet) ---------- */
@@ -570,13 +570,13 @@
             </div>
             Kontant: ${cash.daler}D ${cash.skilling}S ${cash['örtegar']}Ö<br>
             Oanvänt: <span id="unusedOut">0D 0S 0Ö</span>
+${moneyRow}
           </div>
           <div class="formal-section ${remainingCap < 0 ? 'cap-neg' : ''}">
             <div class="formal-title">Bärkapacitet</div>
-            <div class="cap-row cap-food"><span class="label">Mat:</span><span class="value">${foodCount}</span></div>
             <div class="cap-row"><span class="label">Max:</span><span class="value">${formatWeight(maxCapacity)}</span></div>
-${moneyRow}
             <div class="cap-row"><span class="label">Återstående:</span><span class="value">${formatWeight(remainingCap)}</span></div>
+            <div class="cap-row cap-food"><span class="label">Proviant:</span><span class="value">${foodCount}</span></div>
           </div>
         </div>
       </li>`;


### PR DESCRIPTION
## Summary
- Label money weight as **Pengavikt** and display it under the Pengar section
- Rename Mat field to Proviant and place it last within Bärkapacitet

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897975e5c3c8323b5701595f4cea21b