### PR TITLE
Flytta formaliteterknappar och lägg till ikoner

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 ### 5. Inventariepanelen
 Via `🎒` kommer du åt allt du har samlat på dig.
 - **Kategori** låter dig filtrera inventarielistan på typ av utrustning.
-- Under **Formaliteter** hittar du knappar för **Nytt föremål**, **Hantera pengar** och **Rensa inventarie**.
+- Under **Formaliteter** hittar du knappar för **🆕**, **🏦**, **🧹** och **x²** (kommer snart).
 I listan för varje föremål finns knappar för att öka/minska antal, markera som gratis, redigera kvaliteter och mer.
 
 ### 6. Egenskapspanelen

--- a/css/style.css
+++ b/css/style.css
@@ -421,9 +421,8 @@ input:focus, select:focus, textarea:focus {
 /* Knappar i inventariepanelen */
 .inv-buttons {
   display: flex;
-  flex-direction: column;
   gap: .4rem;
-  margin-top: .6rem;
+  margin-bottom: .6rem;
 }
 
 /* ---------- Pengahantering ---------- */

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -561,6 +561,12 @@
       <li class="card${openKeys.has(formalKey) ? '' : ' compact'}" data-special="${formalKey}">
         <div class="card-title"><span><span class="collapse-btn"></span>Formaliteter</span></div>
         <div class="card-desc">
+          <div class="inv-buttons">
+            <button id="addCustomBtn" class="char-btn icon" title="Nytt föremål">🆕</button>
+            <button id="manageMoneyBtn" class="char-btn icon" title="Hantera pengar">🏦</button>
+            <button id="clearInvBtn" class="char-btn icon danger" title="Rensa inventarie">🧹</button>
+            <button id="squareBtn" class="char-btn icon" title="x²">x²</button>
+          </div>
           <div class="formal-section">
             <div class="formal-title">Pengar
               <div class="money-control">
@@ -577,11 +583,6 @@ ${moneyRow}
             <div class="cap-row"><span class="label">Max:</span><span class="value">${formatWeight(maxCapacity)}</span></div>
             <div class="cap-row"><span class="label">Återstående:</span><span class="value">${formatWeight(remainingCap)}</span></div>
             <div class="cap-row cap-food"><span class="label">Proviant:</span><span class="value">${foodCount}</span></div>
-          </div>
-          <div class="inv-buttons">
-            <button id="addCustomBtn" class="char-btn" style="flex:1">Nytt föremål</button>
-            <button id="manageMoneyBtn" class="char-btn" style="flex:1">Hantera pengar</button>
-            <button id="clearInvBtn" class="char-btn danger" style="flex:1">Rensa inventarie</button>
           </div>
         </div>
       </li>`;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -421,9 +421,10 @@ class SharedToolbar extends HTMLElement {
           </p>
           <h3>Inventariepanelen</h3>
           <p>
-            <strong>Nytt föremål</strong> lägger till eget föremål.<br>
-            <strong>Hantera pengar</strong> justerar pengar.<br>
-            <strong>Rensa inventarie</strong> tömmer inventariet.
+            <strong>🆕</strong> lägger till eget föremål.<br>
+            <strong>🏦</strong> justerar pengar.<br>
+            <strong>🧹</strong> tömmer inventariet.<br>
+            <strong>x²</strong> saknar funktion ännu.
           </p>
           <h3>Egenskapspanelen</h3>
           <p>Ange total XP och få en summering av valda förmågor.</p>


### PR DESCRIPTION
## Summary
- Flyttat "Nytt föremål", "Hantera pengar" och "Rensa inventarie" till en gemensam rad högst upp i formalitetsrutan
- Lagt till ikoner för respektive knapp och en ny platshållarknapp "x²"
- Uppdaterat hjälpmeny och dokumentation för de nya knapparna

## Testing
- `npm test` *(misslyckades: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979a4b24d88323ab3dabbd5635acca