### PR TITLE
Improve formalities money layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -422,7 +422,7 @@ input:focus, select:focus, textarea:focus {
 .inv-buttons {
   display: flex;
   gap: .4rem;
-  margin-bottom: .6rem;
+  margin-bottom: 1rem;
 }
 
 /* ---------- Pengahantering ---------- */
@@ -1273,9 +1273,20 @@ textarea.auto-resize {
   margin-top: .6rem;
 }
 
-.cap-row { display: flex; }
-.cap-row .label { flex: 1; }
-.cap-row .value { flex: 1; text-align: right; font-variant-numeric: tabular-nums; }
+.cap-row,
+.money-line {
+  display: flex;
+}
+.cap-row .label,
+.money-line .label {
+  flex: 1;
+}
+.cap-row .value,
+.money-line .value {
+  flex: 1;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
 .cap-neg { color: var(--danger); }
 
 .formal-section { margin-bottom: .8rem; }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -564,8 +564,8 @@
           <div class="inv-buttons">
             <button id="addCustomBtn" class="char-btn icon" title="Nytt föremål">🆕</button>
             <button id="manageMoneyBtn" class="char-btn icon" title="Hantera pengar">🏦</button>
-            <button id="clearInvBtn" class="char-btn icon danger" title="Rensa inventarie">🧹</button>
             <button id="squareBtn" class="char-btn icon" title="x²">x²</button>
+            <button id="clearInvBtn" class="char-btn icon danger" title="Rensa inventarie">🧹</button>
           </div>
           <div class="formal-section">
             <div class="formal-title">Pengar
@@ -574,8 +574,8 @@
                 <button data-act="moneyPlus" class="char-btn icon">+</button>
               </div>
             </div>
-            Kontant: ${cash.daler}D ${cash.skilling}S ${cash['örtegar']}Ö<br>
-            Oanvänt: <span id="unusedOut">0D 0S 0Ö</span>
+            <div class="money-line"><span class="label">Kontant:</span><span class="value">${cash.daler}D ${cash.skilling}S ${cash['örtegar']}Ö</span></div>
+            <div class="money-line"><span class="label">Oanvänt:</span><span class="value" id="unusedOut">0D 0S 0Ö</span></div>
 ${moneyRow}
           </div>
           <div class="formal-section ${remainingCap < 0 ? 'cap-neg' : ''}">


### PR DESCRIPTION
## Summary
- Move red "Rensa inventarie" button to the far right and add spacing before the money section
- Right-align Kontant and Oanvänt values for consistent layout
- Support new money rows in styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979cfc656c83238a9fdd6471b675db