### PR TITLE
Ensure formalities buttons wrap on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -421,6 +421,7 @@ input:focus, select:focus, textarea:focus {
 /* Knappar i inventariepanelen */
 .inv-buttons {
   display: flex;
+  flex-wrap: wrap;
   gap: .4rem;
   margin-bottom: .6rem;
 }


### PR DESCRIPTION
## Summary
- Allow inventory panel buttons to wrap so they stay within the Formaliteter box on small screens

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68979dc7ab988323963a61cd2afd36bc