### PR TITLE
Add quantity popup for inventory items

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -949,7 +949,38 @@ select.level {
 #moneyPopup.open .popup-inner { transform: translateY(0); }
 #moneyPopup .popup-inner button { width: 100%; }
 
-/* ---------- Popup f\u00f6r alkemistniv\u00e5 ---------- */
+/* ---------- Popup för antal ---------- */
+#qtyPopup {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 3000;
+}
+#qtyPopup.open { display: flex; }
+#qtyPopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem 1.2rem 0 0;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.4rem 2rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+  transform: translateY(100%);
+  transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: .8rem;
+}
+#qtyPopup.open .popup-inner { transform: translateY(0); }
+#qtyPopup .popup-inner button { width: 100%; }
+
+/* ---------- Popup för alkemistnivå ---------- */
 #alcPopup {
   position: fixed;
   inset: 0;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -280,6 +280,47 @@
     pop.addEventListener('click', onOutside);
   }
 
+  function openQtyPopup() {
+    const pop   = bar.shadowRoot.getElementById('qtyPopup');
+    const inEl  = bar.shadowRoot.getElementById('qtyInput');
+    const list  = bar.shadowRoot.getElementById('qtyItemList');
+    const cancel= bar.shadowRoot.getElementById('qtyCancel');
+
+    inEl.value = '';
+    const inv = storeHelper.getInventory(store);
+    list.innerHTML = inv.map((row,i)=> `<button data-idx="${i}" class="char-btn">${row.name}</button>`).join('');
+
+    pop.classList.add('open');
+
+    const close = () => {
+      pop.classList.remove('open');
+      list.removeEventListener('click', onBtn);
+      cancel.removeEventListener('click', onCancel);
+      pop.removeEventListener('click', onOutside);
+      list.innerHTML = '';
+      inEl.value = '';
+    };
+    const onBtn = e => {
+      const b = e.target.closest('button[data-idx]');
+      if (!b) return;
+      const idx = Number(b.dataset.idx);
+      const qty = parseInt(inEl.value, 10);
+      if (!qty || qty <= 0) return;
+      inv[idx].qty += qty;
+      saveInventory(inv);
+      renderInventory();
+      close();
+    };
+    const onCancel = () => { close(); };
+    const onOutside = e => {
+      if(!pop.querySelector('.popup-inner').contains(e.target)) close();
+    };
+
+    list.addEventListener('click', onBtn);
+    cancel.addEventListener('click', onCancel);
+    pop.addEventListener('click', onOutside);
+  }
+
   function calcRowCost(row, forgeLvl, alcLevel, artLevel) {
     const entry  = getEntry(row.name);
     const tagger = entry.taggar ?? {};
@@ -712,6 +753,8 @@ ${allowQual ? `<button data-act="addQual" class="char-btn">🔨</button>` : ''}
         renderInventory();
       };
     }
+    const squareBtn = $T('squareBtn');
+    if (squareBtn) squareBtn.onclick = openQtyPopup;
     const customBtn = $T('addCustomBtn');
     if (customBtn) customBtn.onclick = () => {
       openCustomPopup(entry => {
@@ -996,6 +1039,7 @@ ${allowQual ? `<button data-act="addQual" class="char-btn">🔨</button>` : ''}
     openQualPopup,
     openCustomPopup,
     openMoneyPopup,
+    openQtyPopup,
     recalcArtifactEffects,
     addWellEquippedItems,
     removeWellEquippedItems,

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -315,6 +315,16 @@ class SharedToolbar extends HTMLElement {
         </div>
       </div>
 
+      <!-- ---------- Popup Antal ---------- -->
+      <div id="qtyPopup">
+        <div class="popup-inner">
+          <h3>Lägg till antal</h3>
+          <input id="qtyInput" type="number" min="1" step="1" placeholder="Antal">
+          <div id="qtyItemList"></div>
+          <button id="qtyCancel" class="char-btn danger">Avbryt</button>
+        </div>
+      </div>
+
       <!-- ---------- Popup Alkemistniv\u00e5 ---------- -->
       <div id="alcPopup">
         <div class="popup-inner">


### PR DESCRIPTION
## Summary
- Add qtyPopup markup for quick quantity adjustments
- Style qtyPopup with slide-up animation matching money popup
- Implement openQtyPopup logic and bind x² button in inventory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979e23ddc8832387288d83cd787552