### PR TITLE
Ensure x² popup doesn't close inventory and correct food stack count

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 ### 5. Inventariepanelen
 Via `🎒` kommer du åt allt du har samlat på dig.
 - **Kategori** låter dig filtrera inventarielistan på typ av utrustning.
-- Under **Formaliteter** hittar du knappar för **🆕**, **🏦**, **🧹** och **x²** (kommer snart).
+- Under **Formaliteter** hittar du knappar för **🆕**, **💰**, **🧹** och **x²** (kommer snart).
 I listan för varje föremål finns knappar för att öka/minska antal, markera som gratis, redigera kvaliteter och mer.
 
 ### 6. Egenskapspanelen

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -587,10 +587,12 @@
     const diff  = oToMoney(Math.abs(diffO));
     const diffText = `${diffO < 0 ? '-' : ''}${diff.d}D ${diff.s}S ${diff.o}Ö`;
 
-    const foodCount = allInv.filter(row => {
-      const entry = getEntry(row.name);
-      return (entry.taggar?.typ || []).some(t => t.toLowerCase() === 'mat');
-    }).length;
+    const foodCount = allInv
+      .filter(row => {
+        const entry = getEntry(row.name);
+        return (entry.taggar?.typ || []).some(t => t.toLowerCase() === 'mat');
+      })
+      .reduce((sum, row) => sum + (row.qty || 0), 0);
 
     const moneyRow = moneyWeight
       ? `            <div class="cap-row"><span class="label">Pengavikt:</span><span class="value">${formatWeight(moneyWeight)}</span></div>`
@@ -604,7 +606,7 @@
         <div class="card-desc">
           <div class="inv-buttons">
             <button id="addCustomBtn" class="char-btn icon" title="Nytt föremål">🆕</button>
-            <button id="manageMoneyBtn" class="char-btn icon" title="Hantera pengar">🏦</button>
+            <button id="manageMoneyBtn" class="char-btn icon" title="Hantera pengar">💰</button>
             <button id="squareBtn" class="char-btn icon" title="x²">x²</button>
             <button id="clearInvBtn" class="char-btn icon danger" title="Rensa inventarie">🧹</button>
           </div>

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -432,7 +432,7 @@ class SharedToolbar extends HTMLElement {
           <h3>Inventariepanelen</h3>
           <p>
             <strong>🆕</strong> lägger till eget föremål.<br>
-            <strong>🏦</strong> justerar pengar.<br>
+              <strong>💰</strong> justerar pengar.<br>
             <strong>🧹</strong> tömmer inventariet.<br>
             <strong>x²</strong> saknar funktion ännu.
           </p>
@@ -496,7 +496,7 @@ class SharedToolbar extends HTMLElement {
     if (path.some(el => toggles.includes(el.id))) return;
 
     // ignore clicks inside popups so panels stay open
-    const popups = ['qualPopup','customPopup','moneyPopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','nilasPopup'];
+      const popups = ['qualPopup','customPopup','moneyPopup','qtyPopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','nilasPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));


### PR DESCRIPTION
## Summary
- Keep the inventory panel open when interacting with the x² quantity popup
- Sum all quantities for food when displaying "Proviant" in the inventory
- Replace bank emoji with money bag emoji for managing money

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689854d28cc4832380f05e203c231de4