### PR TITLE
Add icon and accent border to Formaliteter card

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 ### 5. Inventariepanelen
 Via `🎒` kommer du åt allt du har samlat på dig.
 - **Kategori** låter dig filtrera inventarielistan på typ av utrustning.
-- Under **Formaliteter** hittar du knappar för **🆕**, **🏦**, **🧹** och **x²** (kommer snart).
+- Under **Formaliteter 🔎** hittar du knappar för **🆕**, **🏦**, **🧹** och **x²** (kommer snart).
 I listan för varje föremål finns knappar för att öka/minska antal, markera som gratis, redigera kvaliteter och mer.
 
 ### 6. Egenskapspanelen

--- a/css/style.css
+++ b/css/style.css
@@ -248,6 +248,10 @@ input:focus, select:focus, textarea:focus {
   gap: .45rem;
   position: relative;
 }
+.card[data-special="__formal__"] {
+  border-color: var(--accent);
+}
+
 .card-title {
   display: flex;
   justify-content: space-between;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -600,7 +600,7 @@
     const formalKey = '__formal__';
     const formalCard = `
       <li class="card${openKeys.has(formalKey) ? '' : ' compact'}" data-special="${formalKey}">
-        <div class="card-title"><span><span class="collapse-btn"></span>Formaliteter</span></div>
+        <div class="card-title"><span><span class="collapse-btn"></span>Formaliteter 🔎</span></div>
         <div class="card-desc">
           <div class="inv-buttons">
             <button id="addCustomBtn" class="char-btn icon" title="Nytt föremål">🆕</button>


### PR DESCRIPTION
## Summary
- Append a 🔎 icon to the Formaliteter card title for clearer identification.
- Style the Formaliteter card with an accent-blue border to match button colors.
- Update documentation to mention the new "Formaliteter 🔎" label.

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689857037e048323b9d2cae9709bc044