### PR TITLE
Styla Formaliteter-kortet

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -248,6 +248,11 @@ input:focus, select:focus, textarea:focus {
   gap: .45rem;
   position: relative;
 }
+
+/* särställ "Formaliteter"-kortet med blå kant */
+.card[data-special="__formal__"] {
+  border: 2px solid var(--accent);
+}
 .card-title {
   display: flex;
   justify-content: space-between;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -602,7 +602,7 @@
     const formalKey = '__formal__';
     const formalCard = `
       <li class="card${openKeys.has(formalKey) ? '' : ' compact'}" data-special="${formalKey}">
-        <div class="card-title"><span><span class="collapse-btn"></span>Formaliteter</span></div>
+        <div class="card-title"><span><span class="collapse-btn"></span>Formaliteter 🔎</span></div>
         <div class="card-desc">
           <div class="inv-buttons">
             <button id="addCustomBtn" class="char-btn icon" title="Nytt föremål">🆕</button>


### PR DESCRIPTION
## Summary
- Lägg till 🔎 efter "Formaliteter" i inventarie-kortets rubrik
- Ge "Formaliteter"-kortet blå kantlinje som matchar knappfärgen

## Testing
- `npm test` *(saknar package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68986d39f46483238fd3d629bea29f23