### PR TITLE
Disallow Korruptionskänslig for Dvärg

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -466,6 +466,10 @@ function initCharacter() {
     const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !tr;
     let list;
         if(actBtn.dataset.act==='add'){
+          if(name==='Korruptionskänslig' && before.some(x=>x.namn==='Dvärg')){
+            alert('Dvärgar kan inte ta Korruptionskänslig.');
+            return;
+          }
           if(!multi) return;
           const cnt = before.filter(x=>x.namn===name && !x.trait).length;
           const limit = storeHelper.monsterStackLimit(before, name);

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -403,9 +403,22 @@ function initIndex() {
         }
       } else {
         const list = storeHelper.getCurrentList(store);
+        if (p.namn === 'Korruptionskänslig' && list.some(x => x.namn === 'Dvärg')) {
+          alert('Dvärgar kan inte ta Korruptionskänslig.');
+          return;
+        }
         if (isRas(p) && list.some(isRas)) {
           alert('Du kan bara välja en ras.');
           return;
+        }
+        if (p.namn === 'Dvärg') {
+          const hasKorrupt = list.some(x => x.namn === 'Korruptionskänslig');
+          if (hasKorrupt) {
+            if (!confirm('Du har korruptionskänslig, om du väljer till rasen Dvärg så kommer den nackdelen tas bort. Fortsätt?')) return;
+            for (let i = list.length - 1; i >= 0; i--) {
+              if (list[i].namn === 'Korruptionskänslig') list.splice(i, 1);
+            }
+          }
         }
         if (isYrke(p) && list.some(isYrke)) {
           if (!confirm('Du kan bara välja ett yrke. Lägga till ändå?')) return;

--- a/js/store.js
+++ b/js/store.js
@@ -148,6 +148,14 @@
     }
   }
 
+  function enforceDwarf(list) {
+    if (list.some(x => x.namn === 'Dvärg')) {
+      for (let i = list.length - 1; i >= 0; i--) {
+        if (list[i].namn === 'Korruptionskänslig') list.splice(i, 1);
+      }
+    }
+  }
+
   function applyHamnskifteTraits(store, list) {
     if (!store.current) return;
     const data = store.data[store.current] || {};
@@ -257,6 +265,7 @@
     applyDarkBloodEffects(list);
     applyRaceTraits(list);
     enforceEarthbound(list);
+    enforceDwarf(list);
     applyHamnskifteTraits(store, list);
     store.data[store.current] = store.data[store.current] || {};
     store.data[store.current].list = list;


### PR DESCRIPTION
## Summary
- prevent Dvärg characters from selecting Korruptionskänslig
- prompt to remove Korruptionskänslig when choosing Dvärg
- automatically strip Korruptionskänslig from lists containing Dvärg

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6898a162bfc88323a00e54fb6ac4ae0b