### PR TITLE
Remove XP input spinner buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1322,6 +1322,18 @@ textarea.auto-resize {
   text-align: center;
 }
 
+/* Remove default number input spinners so XP is adjusted only via buttons */
+.xp-control input::-webkit-outer-spin-button,
+.xp-control input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.xp-control input[type="number"] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
 #xpSummary {
   margin-top: .6rem;
 }


### PR DESCRIPTION
## Summary
- remove default spinner buttons from the XP input so experience points are adjusted only via external +/- controls

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6898a5c15fd88323a69cff2923b092f3