### PR TITLE
Ensure free inventory tag appears last

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -716,7 +716,7 @@ ${moneyRow}
                 data-name="${row.name}"${row.trait?` data-trait="${row.trait}"`:''}${dataLevel}>
               <div class="card-title"><span><span class="collapse-btn"></span>${row.name}</span></div>
               <div class="card-desc">
-                ${desc}${freeCnt ? ` <span class="tag free removable" data-free="1">Gratis${freeCnt>1? '×'+freeCnt:''} ✕</span>` : ''}${lvlInfo}<br>Antal: ${row.qty}<br>Pris: ${priceText}<br>Vikt: ${weightText}
+                ${desc}${lvlInfo}${freeCnt ? ` <span class="tag free removable" data-free="1">Gratis${freeCnt>1? '×'+freeCnt:''} ✕</span>` : ''}<br>Antal: ${row.qty}<br>Pris: ${priceText}<br>Vikt: ${weightText}
               </div>
               <div class="inv-controls">
                 ${btnRow}


### PR DESCRIPTION
## Summary
- Keep "Gratis" marker at the end of inventory tags by moving it after level tag

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b23fcc68832399ba7ecff548c685