### PR TITLE
Fix category collapse reset when selecting entries

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -250,6 +250,10 @@ function initCharacter() {
         }
     });
     const compact = storeHelper.getCompactEntries(store);
+    const openCats = new Set(
+      [...dom.valda.querySelectorAll('.cat-group > details[open]')]
+        .map(d => d.dataset.cat)
+    );
     dom.valda.innerHTML = '';
     if(!groups.length){ dom.valda.innerHTML = '<li class="card">Inga träffar.</li>'; return; }
     const cats = {};
@@ -279,7 +283,7 @@ function initCharacter() {
     catKeys.forEach(cat=>{
       const catLi=document.createElement('li');
       catLi.className='cat-group';
-      catLi.innerHTML=`<details${catsMinimized ? '' : ' open'}><summary>${catName(cat)}</summary><ul class="card-list"></ul></details>`;
+      catLi.innerHTML=`<details data-cat="${cat}"${openCats.has(cat) ? ' open' : ''}><summary>${catName(cat)}</summary><ul class="card-list"></ul></details>`;
       const detailsEl = catLi.querySelector('details');
       detailsEl.addEventListener('toggle', updateCatToggle);
       const listEl=detailsEl.querySelector('ul');

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -74,6 +74,10 @@ function initIndex() {
   };
 
   const renderList = arr=>{
+    const openCats = new Set(
+      [...dom.lista.querySelectorAll('.cat-group > details[open]')]
+        .map(d => d.dataset.cat)
+    );
     dom.lista.innerHTML = '';
     if(!arr.length){ dom.lista.innerHTML = '<li class="card">Inga träffar.</li>'; return; }
     const charList = storeHelper.getCurrentList(store);
@@ -106,7 +110,7 @@ function initIndex() {
     catKeys.forEach(cat=>{
       const catLi=document.createElement('li');
       catLi.className='cat-group';
-      catLi.innerHTML=`<details${catsMinimized ? '' : ' open'}><summary>${catName(cat)}</summary><ul class="card-list"></ul></details>`;
+      catLi.innerHTML=`<details data-cat="${cat}"${openCats.has(cat) ? ' open' : ''}><summary>${catName(cat)}</summary><ul class="card-list"></ul></details>`;
       const detailsEl = catLi.querySelector('details');
       const listEl=catLi.querySelector('ul');
       detailsEl.addEventListener('toggle', updateCatToggle);


### PR DESCRIPTION
## Summary
- Preserve opened/closed state of category panels in lists by tracking them before re-render
- Attach category identifiers to `<details>` elements so only previously open categories expand after updates

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898b8c8b56883238d8e4d93ba5d086a