### PR TITLE
Support duplicating non-stackable items via x² button

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 ### 5. Inventariepanelen
 Via `🎒` kommer du åt allt du har samlat på dig.
 - **Kategori** låter dig filtrera inventarielistan på typ av utrustning.
-- Under **Formaliteter** hittar du knappar för **🆕**, **💰**, **🧹** och **x²** (kommer snart).
+- Under **Formaliteter** hittar du knappar för **🆕**, **💰**, **🧹** och **x²** för att lägga till flera av samma föremål. Om föremålet inte kan staplas skapas nya fält.
 I listan för varje föremål finns knappar för att öka/minska antal, markera som gratis, redigera kvaliteter och mer.
 
 ### 6. Egenskapspanelen

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -306,7 +306,22 @@
       const realIdx = Number(b.dataset.idx);
       const qty = parseInt(inEl.value, 10);
       if (!qty || qty <= 0) return;
-      inv[realIdx].qty += qty;
+
+      const row   = inv[realIdx];
+      const entry = getEntry(row.name);
+      const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter']
+        .some(t => entry.taggar?.typ?.includes(t));
+
+      if (indiv) {
+        for (let i = 0; i < qty; i++) {
+          const clone = JSON.parse(JSON.stringify(row));
+          clone.qty = 1;
+          inv.push(clone);
+        }
+      } else {
+        row.qty += qty;
+      }
+
       saveInventory(inv);
       renderInventory();
       close();

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -434,7 +434,7 @@ class SharedToolbar extends HTMLElement {
             <strong>🆕</strong> lägger till eget föremål.<br>
               <strong>💰</strong> justerar pengar.<br>
             <strong>🧹</strong> tömmer inventariet.<br>
-            <strong>x²</strong> saknar funktion ännu.
+            <strong>x²</strong> lägger till flera av samma föremål. Föremål som inte kan staplas får nya fält.
           </p>
           <h3>Egenskapspanelen</h3>
           <p>Ange total XP och få en summering av valda förmågor.</p>


### PR DESCRIPTION
## Summary
- Allow the x² quantity popup to create new inventory entries for items that cannot be stacked
- Document and explain x² button behaviour in README and help overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b9b444a083238f24a764b3d157bc