### PR TITLE
feat: add drag and drop for inventory

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -250,6 +250,10 @@ input:focus, select:focus, textarea:focus {
   position: relative;
 }
 
+#invList li.card[draggable="true"] {
+  cursor: move;
+}
+
 /* särställ "Formaliteter"-kortet med blå kant */
 .card[data-special="__formal__"] {
   border: 2px solid var(--accent);

--- a/js/main.js
+++ b/js/main.js
@@ -167,7 +167,6 @@ function yrkeInfoHtml(p) {
    =========================================================== */
 function boot() {
   if (window.invUtil) {
-    invUtil.sortAllInventories();
     invUtil.renderInventory();
     invUtil.bindInv();
     invUtil.bindMoney();


### PR DESCRIPTION
## Summary
- allow drag-and-drop reordering of inventory items
- stop auto-sorting inventories on save and at boot
- add cursor style for draggable inventory cards

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/inventory-utils.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_689916d1957c8323a60239d7be4019e6