### PR TITLE
Add Apps Script CORS handler

### DIFF
--- a/apps_script/Code.gs
+++ b/apps_script/Code.gs
@@ -1,0 +1,11 @@
+function addCors_(origin, output) {
+  output.setHeader('Access-Control-Allow-Origin', origin);
+  output.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  output.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  return output;
+}
+
+function doOptions(e) {
+  var origin = e && e.parameter && e.parameter.origin ? e.parameter.origin : '*';
+  return addCors_(origin, ContentService.createTextOutput(''));
+}


### PR DESCRIPTION
## Summary
- add addCors_ to set required CORS headers
- implement doOptions to respond to preflight requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899acbe17e48323ae79133d2a4c94ab