### PR TITLE
Update web export endpoint

### DIFF
--- a/js/online-export.js
+++ b/js/online-export.js
@@ -19,7 +19,7 @@
  */
 
 // Din Apps Script Web App URL (inkl. /exec)
-const APPS_URL = 'https://script.google.com/macros/s/AKfycbzJeAxY90mHOAgkXEsS_tPN5XgTOzm4iSsuOS6FWwSD_rZxkokJ6aP6fIu3sL7Vnr4m/exec';
+const APPS_URL = 'https://script.google.com/macros/s/AKfycbzO0FNuuBUTU8D_tXZ1Hxhjf1Q6n2n37RVLYvhOHzY25kigbLVQDdNNFJ-mvC0cc1sd/exec';
 
 // Mappar som visas för besökare (keys matchar Apps Script CONFIG.FOLDERS)
 const FOLDERS = [

--- a/websave/README.md
+++ b/websave/README.md
@@ -14,8 +14,8 @@ Denna paket innehåller:
    - **Execute as**: *Me*.
    - **Who has access**: *Anyone*.
 6. **Deploy** och godkänn Drive-behörigheter.
-7. Kopiera **Web app URL** – du har redan denna:  
-   `https://script.google.com/macros/s/AKfycbzJeAxY90mHOAgkXEsS_tPN5XgTOzm4iSsuOS6FWwSD_rZxkokJ6aP6fIu3sL7Vnr4m/exec`
+7. Kopiera **Web app URL** – du har redan denna:
+   `https://script.google.com/macros/s/AKfycbzO0FNuuBUTU8D_tXZ1Hxhjf1Q6n2n37RVLYvhOHzY25kigbLVQDdNNFJ-mvC0cc1sd/exec`
 
 > Koden skriver över filer med samma filnamn i vald mapp. Rate limit är aktiv: max 60 POST/minut per klientnyckel och 600 globalt.
 

--- a/websave/online-export.js
+++ b/websave/online-export.js
@@ -19,7 +19,7 @@
  */
 
 // Din Apps Script Web App URL (inkl. /exec)
-const APPS_URL = 'https://script.google.com/macros/s/AKfycbzJeAxY90mHOAgkXEsS_tPN5XgTOzm4iSsuOS6FWwSD_rZxkokJ6aP6fIu3sL7Vnr4m/exec';
+const APPS_URL = 'https://script.google.com/macros/s/AKfycbzO0FNuuBUTU8D_tXZ1Hxhjf1Q6n2n37RVLYvhOHzY25kigbLVQDdNNFJ-mvC0cc1sd/exec';
 
 // Mappar som visas för besökare (keys matchar Apps Script CONFIG.FOLDERS)
 const FOLDERS = [


### PR DESCRIPTION
## Summary
- point web export scripts to new Google Apps Script URL
- update documentation with the new endpoint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899aed30110832390ea7fbff59c9109