### PR TITLE
Handle origin in web app

### DIFF
--- a/apps_script/Code.gs
+++ b/apps_script/Code.gs
@@ -28,7 +28,7 @@ const CONFIG = {
 };
 
 function doGet(e) {
-  const origin = pickAllowedOrigin_();
+  const origin = pickAllowedOrigin_(e);
   const action = (e && e.parameter && e.parameter.action) || 'ping';
 
   if (action === 'ping') {
@@ -70,7 +70,7 @@ function doGet(e) {
 }
 
 function doPost(e) {
-  const origin = pickAllowedOrigin_();
+  const origin = pickAllowedOrigin_(e);
 
   if (!e || !e.parameter) return error_(origin, 400, 'No data');
 
@@ -130,8 +130,13 @@ function fileLivesInAllowedFolder_(file) {
   return false;
 }
 
-function pickAllowedOrigin_() {
-  // En enkel plats för ev. framtida logik. Apps Script behöver inte CORS-header här för "simple requests".
+function pickAllowedOrigin_(e) {
+  // Läs origin från event-objektet och verifiera mot tillåtna domäner
+  const origin = e && e.parameter && e.parameter.origin;
+  if (origin && CONFIG.ALLOWED_ORIGINS.indexOf(origin) !== -1) {
+    return origin;
+  }
+  // Fallback om inget giltigt origin angavs
   return CONFIG.ALLOWED_ORIGINS[0];
 }
 

--- a/js/online-export.js
+++ b/js/online-export.js
@@ -21,6 +21,10 @@
 // Din Apps Script Web App URL (inkl. /exec)
 const APPS_URL = 'https://script.google.com/macros/s/AKfycbzO0FNuuBUTU8D_tXZ1Hxhjf1Q6n2n37RVLYvhOHzY25kigbLVQDdNNFJ-mvC0cc1sd/exec';
 
+// Ursprung att skicka till Apps Script (inkluderas i alla anrop)
+const ORIGIN = window.location.origin;
+const ORIGIN_ENC = encodeURIComponent(ORIGIN);
+
 // Mappar som visas för besökare (keys matchar Apps Script CONFIG.FOLDERS)
 const FOLDERS = [
   { key: 'daniel', label: 'Daniel' },
@@ -123,6 +127,7 @@ function setupExport() {
       form.set('filename', fileName);
       form.set('json', jsonText);
       form.set('clientKey', getClientKey());
+      form.set('origin', ORIGIN);
 
       try {
         const res = await fetch(APPS_URL, {
@@ -150,7 +155,7 @@ function setupImport() {
     openModal('Välj mapp', body, async () => {
       const folderKey = document.getElementById('folderPick').value;
 
-      const listUrl = `${APPS_URL}?action=list&folderKey=${encodeURIComponent(folderKey)}`;
+      const listUrl = `${APPS_URL}?action=list&folderKey=${encodeURIComponent(folderKey)}&origin=${ORIGIN_ENC}`;
       let data;
       try {
         const res = await fetch(listUrl);
@@ -166,7 +171,7 @@ function setupImport() {
       const body2 = `<label>Fil:<br/><select id="filePick" size="8" style="width:100%">${options}</select></label>`;
       openModal('Välj fil', body2, async () => {
         const fileId = document.getElementById('filePick').value;
-        const getUrl = `${APPS_URL}?action=get&fileId=${encodeURIComponent(fileId)}`;
+        const getUrl = `${APPS_URL}?action=get&fileId=${encodeURIComponent(fileId)}&origin=${ORIGIN_ENC}`;
         try {
           const res2 = await fetch(getUrl);
           const text = await res2.text();


### PR DESCRIPTION
## Summary
- Validate request origins in Apps Script web app
- Pass page origin to Apps Script from online export tool

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b9b7ab488323810f5f2a5240b554