### PR TITLE
Update online import/export link

### DIFF
--- a/js/online-export.js
+++ b/js/online-export.js
@@ -19,7 +19,7 @@
  */
 
 // Din Apps Script Web App URL (inkl. /exec)
-const APPS_URL = 'https://script.google.com/macros/s/AKfycbzO0FNuuBUTU8D_tXZ1Hxhjf1Q6n2n37RVLYvhOHzY25kigbLVQDdNNFJ-mvC0cc1sd/exec';
+const APPS_URL = 'https://script.google.com/macros/s/AKfycbz7H5mEeUNBqjh1im5fFiRlCcj7PMKyql3oJmGs92KATGaaX6ey7H9j8veSZ5q4mVdI/exec';
 
 // Ursprung att skicka till Apps Script (inkluderas i alla anrop)
 const ORIGIN = window.location.origin;

--- a/websave/README.md
+++ b/websave/README.md
@@ -15,7 +15,7 @@ Denna paket innehåller:
    - **Who has access**: *Anyone*.
 6. **Deploy** och godkänn Drive-behörigheter.
 7. Kopiera **Web app URL** – du har redan denna:
-   `https://script.google.com/macros/s/AKfycbzO0FNuuBUTU8D_tXZ1Hxhjf1Q6n2n37RVLYvhOHzY25kigbLVQDdNNFJ-mvC0cc1sd/exec`
+    `https://script.google.com/macros/s/AKfycbz7H5mEeUNBqjh1im5fFiRlCcj7PMKyql3oJmGs92KATGaaX6ey7H9j8veSZ5q4mVdI/exec`
 
 > Koden skriver över filer med samma filnamn i vald mapp. Rate limit är aktiv: max 60 POST/minut per klientnyckel och 600 globalt.
 

--- a/websave/online-export.js
+++ b/websave/online-export.js
@@ -19,7 +19,7 @@
  */
 
 // Din Apps Script Web App URL (inkl. /exec)
-const APPS_URL = 'https://script.google.com/macros/s/AKfycbzO0FNuuBUTU8D_tXZ1Hxhjf1Q6n2n37RVLYvhOHzY25kigbLVQDdNNFJ-mvC0cc1sd/exec';
+const APPS_URL = 'https://script.google.com/macros/s/AKfycbz7H5mEeUNBqjh1im5fFiRlCcj7PMKyql3oJmGs92KATGaaX6ey7H9j8veSZ5q4mVdI/exec';
 
 // Mappar som visas för besökare (keys matchar Apps Script CONFIG.FOLDERS)
 const FOLDERS = [


### PR DESCRIPTION
## Summary
- point online import/export to new Apps Script URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899bb02e6d08323827a6f84a1f777b9