### PR TITLE
Bypass cache for external and non-GET requests

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -19,6 +19,14 @@ self.addEventListener('install', event => {
 });
 
 self.addEventListener('fetch', event => {
+  if (
+    event.request.method !== 'GET' ||
+    !event.request.url.startsWith(self.location.origin)
+  ) {
+    event.respondWith(fetch(event.request));
+    return;
+  }
+
   event.respondWith(
     fetch(event.request)
       .then(fetchResponse =>


### PR DESCRIPTION
## Summary
- Skip service worker caching for non-GET or cross-origin requests
- Preserve existing caching for internal GET requests

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899be108b0483239b17a42760888483