### PR TITLE
Adjust carry capacity calculation and update Packåsna

### DIFF
--- a/data/fordel.json
+++ b/data/fordel.json
@@ -353,7 +353,7 @@
   {
     "id": "ford24",
     "namn": "Packåsna",
-    "beskrivning": "Rollpersonen är van att bära mycket, tungt och långt. Beräkningen av rollpersonens bärförmåga görs med dennes Stark ×1,5. Se regeln för Bärförmåga på sidan 100 i Spelarens handbok.",
+      "beskrivning": "Rollpersonen är van att bära mycket, tungt och långt. Beräkningen av rollpersonens bärförmåga görs med dennes Stark ×1,5 + 3. Se regeln för Bärförmåga på sidan 100 i Spelarens handbok.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
       "typ": [

--- a/js/store.js
+++ b/js/store.js
@@ -826,9 +826,10 @@ function defaultTraits() {
   }
 
   function calcCarryCapacity(strength, list) {
-    let base = Number(strength || 0);
+    const str = Number(strength || 0);
+    let base = str + 3;
     if (Array.isArray(list) && list.some(e => e.namn === 'Packåsna')) {
-      base = Math.ceil(base * 1.5);
+      base = Math.ceil(str * 1.5) + 3;
     }
     return base;
   }


### PR DESCRIPTION
## Summary
- Add baseline bonus to carrying capacity calculation
- Let Packåsna multiply strength by 1.5 before adding baseline bonus
- Note Packåsna's updated formula in its description

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a37e09ae08323ba8cae774bb2fca2