### PR TITLE
Begränsa erfarenhetspoäng från nackdelar

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -478,6 +478,7 @@ function initCharacter() {
     const name = liEl.dataset.name;
     const tr = liEl.dataset.trait || null;
     const before = storeHelper.getCurrentList(store);
+    const disBefore = storeHelper.countDisadvantages(before);
     const p = DB.find(x=>x.namn===name) || before.find(x=>x.namn===name);
     if(!p) return;
     const multi = (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t))) && !tr;
@@ -536,6 +537,10 @@ function initCharacter() {
           return;
         }
         list = [...before, { ...p, nivå: lvl }];
+        const disAfter = storeHelper.countDisadvantages(list);
+        if (disAfter === 5 && disBefore < 5) {
+          alert('Nu har du försökt gamea systemet för mycket, framtida nackdelar ger +0 erfarenhetspoäng');
+        }
     }else if(actBtn.dataset.act==='rem'){
       if(name==='Bestialisk' && before.some(x=>x.namn==='Mörkt blod')){
         if(!confirm('Bestialisk hänger ihop med Mörkt blod. Ta bort ändå?'))

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -421,6 +421,12 @@ function initIndex() {
         }
       } else {
         const list = storeHelper.getCurrentList(store);
+        const disBefore = storeHelper.countDisadvantages(list);
+        const checkDisadvWarning = () => {
+          if (storeHelper.countDisadvantages(list) === 5 && disBefore < 5) {
+            alert('Nu har du försökt gamea systemet för mycket, framtida nackdelar ger +0 erfarenhetspoäng');
+          }
+        };
         if (p.namn === 'Korruptionskänslig' && list.some(x => x.namn === 'Dvärg')) {
           alert('Dvärgar kan inte ta Korruptionskänslig.');
           return;
@@ -526,6 +532,7 @@ function initIndex() {
           bloodBond.pickRace(used, race => {
             if(!race) return;
             list.push({ ...p, race });
+            checkDisadvWarning();
             storeHelper.setCurrentList(store,list); updateXP();
             renderList(filtered());
             renderTraits();
@@ -536,6 +543,7 @@ function initIndex() {
           monsterLore.pickSpec(spec => {
             if(!spec) return;
             list.push({ ...p, nivå: lvl, trait: spec });
+            checkDisadvWarning();
             storeHelper.setCurrentList(store,list); updateXP();
             renderList(filtered());
             renderTraits();
@@ -552,6 +560,7 @@ function initIndex() {
             }else{
               list.push({ ...p, nivå:lvl, trait });
             }
+            checkDisadvWarning();
             storeHelper.setCurrentList(store,list); updateXP();
             renderList(filtered());
             renderTraits();
@@ -571,6 +580,7 @@ function initIndex() {
         }
         let form = 'normal';
         const finishAdd = () => {
+          checkDisadvWarning();
           storeHelper.setCurrentList(store, list); updateXP();
           if (p.namn === 'Privilegierad') {
             invUtil.renderInventory();

--- a/js/store.js
+++ b/js/store.js
@@ -782,12 +782,36 @@ function defaultTraits() {
     return xp;
   }
 
+  function getDisadvantages(list) {
+    const hasDark = list.some(x => x.namn === 'Mörkt blod');
+    return list.filter(item => {
+      const isDis = (item.taggar?.typ || [])
+        .map(t => t.toLowerCase())
+        .includes('nackdel');
+      if (!isDis) return false;
+      if (hasDark && item.namn === 'Bestialisk') return false;
+      return true;
+    });
+  }
+
+  function countDisadvantages(list) {
+    return getDisadvantages(list).length;
+  }
+
+  function disadvantagesWithXP(list) {
+    return getDisadvantages(list).slice(0,5);
+  }
+
   function calcEntryXP(entry, list) {
     const types = (entry.taggar?.typ || []).map(t => t.toLowerCase());
     if (types.includes('nackdel')) {
       const hasDark = (list || []).some(x => x.namn === 'Mörkt blod');
       if (entry.namn === 'Bestialisk' && hasDark) return 0;
-      return -5;
+      const disXp = disadvantagesWithXP(list || []);
+      if ((list || []).includes(entry)) {
+        return disXp.includes(entry) ? -5 : 0;
+      }
+      return disXp.length < 5 ? -5 : 0;
     }
     let xp = 0;
     if (
@@ -809,20 +833,8 @@ function defaultTraits() {
     return xp;
   }
 
-  function countDisadvantages(list) {
-    const hasDark = list.some(x => x.namn === 'Mörkt blod');
-    return list.filter(item => {
-      const isDis = (item.taggar?.typ || [])
-        .map(t => t.toLowerCase())
-        .includes('nackdel');
-      if (!isDis) return false;
-      if (hasDark && item.namn === 'Bestialisk') return false;
-      return true;
-    }).length;
-  }
-
   function calcTotalXP(baseXp, list) {
-    return Number(baseXp || 0) + countDisadvantages(list) * 5;
+    return Number(baseXp || 0) + disadvantagesWithXP(list).length * 5;
   }
 
   function calcCarryCapacity(strength, list) {
@@ -1067,6 +1079,7 @@ function defaultTraits() {
     calcUsedXP,
     calcEntryXP,
     calcTotalXP,
+    countDisadvantages,
     calcPermanentCorruption,
     calcCarryCapacity,
     calcPainThreshold,


### PR DESCRIPTION
## Sammanfattning
- Begränsa erfarenhetspoäng till de fem första nackdelarna
- Visa varning när en rollperson når fem nackdelar

## Testning
- `npm test` *(misslyckades: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a39ebbeb0832390ad08e74737edce