### PR TITLE
Remove online import/export error alerts

### DIFF
--- a/js/online-export.js
+++ b/js/online-export.js
@@ -139,7 +139,7 @@ function setupExport() {
         if (!data || data.ok !== true) throw new Error(data && data.error ? data.error : '');
         alert(data.overwritten ? `Skrev över: ${data.name}` : `Uppladdad: ${data.name}`);
       } catch (err) {
-        alert('Uppladdning misslyckades' + (err && err.message ? `: ${err.message}` : ''));
+        console.error('Uppladdning misslyckades', err);
       }
     });
   });
@@ -161,11 +161,11 @@ function setupImport() {
         const res = await fetch(listUrl);
         data = await safeJson(res);
       } catch (err) {
-        alert('Kunde inte hämta filer' + (err && err.message ? `: ${err.message}` : ''));
+        console.error('Kunde inte hämta filer', err);
         return;
       }
       const files = (data && data.files) || [];
-      if (!files.length) { alert('Inga filer hittades'); return; }
+      if (!files.length) { console.warn('Inga filer hittades'); return; }
 
       const options = files.map(f => `<option value="${f.id}">${escapeHtml(f.name)} — ${f.modified}</option>`).join('');
       const body2 = `<label>Fil:<br/><select id="filePick" size="8" style="width:100%">${options}</select></label>`;
@@ -178,7 +178,7 @@ function setupImport() {
           const obj = JSON.parse(text);
           window.loadImportedJson(obj);
         } catch (err) {
-          alert('Kunde inte importera filen' + (err && err.message ? `: ${err.message}` : ''));
+          console.error('Kunde inte importera filen', err);
         }
       });
     });

--- a/websave/online-export.js
+++ b/websave/online-export.js
@@ -131,7 +131,7 @@ function setupExport() {
         if (!data || data.ok !== true) throw new Error(data && data.error ? data.error : '');
         alert(data.overwritten ? `Skrev över: ${data.name}` : `Uppladdad: ${data.name}`);
       } catch (err) {
-        alert('Uppladdning misslyckades' + (err && err.message ? `: ${err.message}` : ''));
+        console.error('Uppladdning misslyckades', err);
       }
     });
   });
@@ -153,11 +153,11 @@ function setupImport() {
         const res = await fetch(listUrl);
         data = await safeJson(res);
       } catch (err) {
-        alert('Kunde inte hämta filer' + (err && err.message ? `: ${err.message}` : ''));
+        console.error('Kunde inte hämta filer', err);
         return;
       }
       const files = (data && data.files) || [];
-      if (!files.length) { alert('Inga filer hittades'); return; }
+      if (!files.length) { console.warn('Inga filer hittades'); return; }
 
       const options = files.map(f => `<option value="${f.id}">${escapeHtml(f.name)} — ${f.modified}</option>`).join('');
       const body2 = `<label>Fil:<br/><select id="filePick" size="8" style="width:100%">${options}</select></label>`;
@@ -170,7 +170,7 @@ function setupImport() {
           const obj = JSON.parse(text);
           window.loadImportedJson(obj);
         } catch (err) {
-          alert('Kunde inte importera filen' + (err && err.message ? `: ${err.message}` : ''));
+          console.error('Kunde inte importera filen', err);
         }
       });
     });


### PR DESCRIPTION
## Summary
- suppress online import/export alerts by logging errors to console instead

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a45bbe9e083238118d78f5e38b3c8