### PR TITLE
Allow choosing file name/location for export and import

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sidan fungerar helt offline och sparar all data i din webbläsares lagring.
 
 ## Export och import av rollpersoner
 
-Use the **Exportera** button in the filter panel to download a JSON file representing the current character. The **Importera** button lets you select such a file to recreate the character (requires that the database is loaded). Anteckningar följer med vid export så länge något fält är ifyllt.
+Use the **Exportera** button in the filter panel to download a JSON file representing the current character. When supported by your browser a “Save As” dialog allows you to pick both filename and location; otherwise the file is downloaded normally. The **Importera** button lets you select such a file to recreate the character (requires that the database is loaded). Anteckningar följer med vid export så länge något fält är ifyllt.
 
 ## Anteckningssidan
 


### PR DESCRIPTION
## Summary
- let users pick file name and save location when exporting characters, falling back to previous download method if unsupported
- use open/save file pickers for import/export when available and update documentation

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_689a45d232708323ba0dfeffe709e043