### PR TITLE
Remove online import functionality

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -265,7 +265,6 @@ class SharedToolbar extends HTMLElement {
         </div>
         <div class="char-btn-row">
           <button id="exportOnlineBtn" class="char-btn">Exportera online</button>
-          <button id="importOnlineBtn" class="char-btn">Importera online</button>
         </div>
       </aside>
 

--- a/websave/README.md
+++ b/websave/README.md
@@ -2,7 +2,7 @@
 
 Denna paket innehåller:
 - `apps_script/Code.gs` – koden för Google Apps Script Web App (backend).
-- `web/online-export.js` – färdig klientkod (export/import + enkel modal + rate limit-nyckel).
+- `web/online-export.js` – färdig klientkod (export + enkel modal + rate limit-nyckel).
 - `web/snippet.html` – minimalt exempel på hur du kopplar in knapparna.
 
 ## 1) Skapa och publicera Web App
@@ -19,11 +19,10 @@ Denna paket innehåller:
 
 > Koden skriver över filer med samma filnamn i vald mapp. Rate limit är aktiv: max 60 POST/minut per klientnyckel och 600 globalt.
 
-## 2) Lägg till knappar på din webb
-Placera två knappar där du vill i din HTML:
+## 2) Lägg till knapp på din webb
+Placera en knapp där du vill i din HTML:
 ```html
 <button id="exportOnlineBtn">Exportera online</button>
-<button id="importOnlineBtn">Importera</button>
 ```
 
 ## 3) Lägg in klientkoden
@@ -36,8 +35,8 @@ Lägg in den precis före `</body>`:
 Klientkoden är redan inställd på din Web App URL.
 Den skapar en anonym `clientKey` i `localStorage` och skickar den till backend för rate limit.
 
-## 4) Hookar för export/import
-Minimikrav: tillhandahåll två funktioner i din sida **före** du laddar `online-export.js`.
+## 4) Hook för export
+Minimikrav: tillhandahåll funktionen i din sida **före** du laddar `online-export.js`.
 Om du inte gör det används standardbeteende.
 
 ```html
@@ -47,19 +46,12 @@ Om du inte gör det används standardbeteende.
     savedAt: new Date().toISOString(),
     data: window.myAppState || {}
   });
-
-  // Ta emot importerad JSON
-  window.loadImportedJson = (obj) => {
-    window.myAppState = obj;
-    alert('Import klar.');
-  };
 </script>
 ```
 
 ## 5) Test lokalt
 - Starta din sida på `http://localhost:5500`.
 - Klicka **Exportera online** → välj mapp → ange filnamn → OK.
-- Klicka **Importera** → välj mapp → välj fil → OK.
 
 ## 6) Mappar i Drive
 Följande mappar används:

--- a/websave/online-export.js
+++ b/websave/online-export.js
@@ -2,20 +2,18 @@
  * online-export.js
  * 
  * Användning i korthet:
- * 1) Lägg två knappar i HTML:
+ * 1) Lägg en knapp i HTML:
  *    <button id="exportOnlineBtn">Exportera online</button>
- *    <button id="importOnlineBtn">Importera</button>
  * 
  * 2) Inkludera denna fil längst ned innan </body>:
  *    <script src="online-export.js"></script>
  * 
  * 3) Konfigurera APPS_URL om det behövs (nedan är redan din URL).
  * 
- * 4) Lägg till två hookar i din app:
+ * 4) Lägg till en hook i din app:
  *    - window.getCurrentJsonForExport = () => ({ ...din data... });
- *    - window.loadImportedJson = (obj) => { ...hantera importerad data... };
- * 
- * 5) Klart. Knapparna börjar fungera direkt om element med ID ovan finns.
+ *
+ * 5) Klart. Knappen börjar fungera direkt om element med ID ovan finns.
  */
 
 // Din Apps Script Web App URL (inkl. /exec)
@@ -84,16 +82,9 @@ modalCancel.addEventListener('click', () => (modal.style.display = 'none'));
 if (typeof window.getCurrentJsonForExport !== 'function') {
   window.getCurrentJsonForExport = () => ({ savedAt: new Date().toISOString(), data: window.myAppState || {} });
 }
-if (typeof window.loadImportedJson !== 'function') {
-  window.loadImportedJson = (obj) => { window.myAppState = obj; alert('Import klar.'); };
-}
-
 /* -------- Hjälpfunktioner -------- */
 async function safeJson(res) {
   try { return await res.json(); } catch { return null; }
-}
-function escapeHtml(s) {
-  return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 }
 
 /* -------- Export -------- */
@@ -137,48 +128,7 @@ function setupExport() {
   });
 }
 
-/* -------- Import -------- */
-function setupImport() {
-  const btn = document.getElementById('importOnlineBtn');
-  if (!btn) return;
-  btn.addEventListener('click', async () => {
-    const folderOptions = FOLDERS.map(f => `<option value="${f.key}">${f.label}</option>`).join('');
-    const body = `<label>Mapp:<br/><select id="folderPick">${folderOptions}</select></label>`;
-    openModal('Välj mapp', body, async () => {
-      const folderKey = document.getElementById('folderPick').value;
-
-      const listUrl = `${APPS_URL}?action=list&folderKey=${encodeURIComponent(folderKey)}`;
-      let data;
-      try {
-        const res = await fetch(listUrl);
-        data = await safeJson(res);
-      } catch (err) {
-        console.error('Kunde inte hämta filer', err);
-        return;
-      }
-      const files = (data && data.files) || [];
-      if (!files.length) { console.warn('Inga filer hittades'); return; }
-
-      const options = files.map(f => `<option value="${f.id}">${escapeHtml(f.name)} — ${f.modified}</option>`).join('');
-      const body2 = `<label>Fil:<br/><select id="filePick" size="8" style="width:100%">${options}</select></label>`;
-      openModal('Välj fil', body2, async () => {
-        const fileId = document.getElementById('filePick').value;
-        const getUrl = `${APPS_URL}?action=get&fileId=${encodeURIComponent(fileId)}`;
-        try {
-          const res2 = await fetch(getUrl);
-          const text = await res2.text();
-          const obj = JSON.parse(text);
-          window.loadImportedJson(obj);
-        } catch (err) {
-          console.error('Kunde inte importera filen', err);
-        }
-      });
-    });
-  });
-}
-
 // Init
 document.addEventListener('DOMContentLoaded', () => {
   setupExport();
-  setupImport();
 });

--- a/websave/snippet.html
+++ b/websave/snippet.html
@@ -3,14 +3,13 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Exempel – Export/Import online</title>
+    <title>Exempel – Export online</title>
   </head>
   <body>
     <h1>Exempel</h1>
 
     <div style="display:flex; gap:8px; margin:12px 0;">
       <button id="exportOnlineBtn">Exportera online</button>
-      <button id="importOnlineBtn">Importera</button>
     </div>
 
     <script>
@@ -19,7 +18,6 @@
 
       // Hookar (valfritt – standard finns i JS-filen om dessa saknas)
       window.getCurrentJsonForExport = () => ({ savedAt: new Date().toISOString(), data: window.myAppState });
-      window.loadImportedJson = (obj) => { window.myAppState = obj; alert('Import klar: ' + JSON.stringify(obj)); };
     </script>
 
     <!-- Lägg denna rad precis innan </body> i din riktiga sida -->


### PR DESCRIPTION
## Summary
- drop online import support from shared toolbar and helper scripts
- document and example updates to show only online export

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a49b5f95c8323b9167cb155a2d378