### PR TITLE
Update online import/export link

### DIFF
--- a/js/online-export.js
+++ b/js/online-export.js
@@ -17,7 +17,7 @@
  */
 
 // Din Apps Script Web App URL (inkl. /exec)
-const APPS_URL = 'https://script.google.com/macros/s/AKfycbz7H5mEeUNBqjh1im5fFiRlCcj7PMKyql3oJmGs92KATGaaX6ey7H9j8veSZ5q4mVdI/exec';
+const APPS_URL = 'https://script.google.com/macros/s/AKfycbwmzYExWhTHIjOzvg58n9zzmt9geHnnggBt8O2zRWbQUkmw2S22D_0jCxZMxMLtdHri/exec';
 
 // Ursprung att skicka till Apps Script (inkluderas i alla anrop)
 const ORIGIN = window.location.origin;

--- a/websave/README.md
+++ b/websave/README.md
@@ -15,7 +15,7 @@ Denna paket innehåller:
    - **Who has access**: *Anyone*.
 6. **Deploy** och godkänn Drive-behörigheter.
 7. Kopiera **Web app URL** – du har redan denna:
-    `https://script.google.com/macros/s/AKfycbz7H5mEeUNBqjh1im5fFiRlCcj7PMKyql3oJmGs92KATGaaX6ey7H9j8veSZ5q4mVdI/exec`
+    `https://script.google.com/macros/s/AKfycbwmzYExWhTHIjOzvg58n9zzmt9geHnnggBt8O2zRWbQUkmw2S22D_0jCxZMxMLtdHri/exec`
 
 > Koden skriver över filer med samma filnamn i vald mapp. Rate limit är aktiv: max 60 POST/minut per klientnyckel och 600 globalt.
 

--- a/websave/online-export.js
+++ b/websave/online-export.js
@@ -17,7 +17,7 @@
  */
 
 // Din Apps Script Web App URL (inkl. /exec)
-const APPS_URL = 'https://script.google.com/macros/s/AKfycbz7H5mEeUNBqjh1im5fFiRlCcj7PMKyql3oJmGs92KATGaaX6ey7H9j8veSZ5q4mVdI/exec';
+const APPS_URL = 'https://script.google.com/macros/s/AKfycbwmzYExWhTHIjOzvg58n9zzmt9geHnnggBt8O2zRWbQUkmw2S22D_0jCxZMxMLtdHri/exec';
 
 // Mappar som visas för besökare (keys matchar Apps Script CONFIG.FOLDERS)
 const FOLDERS = [


### PR DESCRIPTION
## Summary
- point online import/export to new Google Apps Script URL
- refresh documentation with updated deployment link

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b2709e71c83239d51774a27da2ff2