### PR TITLE
Disable import button when no hook

### DIFF
--- a/js/online-export.js
+++ b/js/online-export.js
@@ -85,10 +85,11 @@ function openModal(title, bodyHTML, onOk) {
 modalCancel.addEventListener('click', () => (modal.style.display = 'none'));
 
 /* -------- Hookar med standardbeteende -------- */
+const HAS_IMPORT_HOOK = typeof window.loadImportedJson === 'function';
 if (typeof window.getCurrentJsonForExport !== 'function') {
   window.getCurrentJsonForExport = () => ({ savedAt: new Date().toISOString(), data: window.myAppState || {} });
 }
-if (typeof window.loadImportedJson !== 'function') {
+if (!HAS_IMPORT_HOOK) {
   window.loadImportedJson = obj => console.warn('Ingen import-hook definierad', obj);
 }
 /* -------- Hjälpfunktioner -------- */
@@ -142,6 +143,10 @@ function setupExport() {
 function setupImport() {
   const btn = ROOT.getElementById('importOnlineBtn');
   if (!btn) return;
+  if (!HAS_IMPORT_HOOK) {
+    btn.disabled = true;
+    return;
+  }
   btn.addEventListener('click', () => {
     const folderOptions = FOLDERS.map(f => `<option value="${f.key}">${f.label}</option>`).join('');
     const body = `

--- a/websave/snippet.html
+++ b/websave/snippet.html
@@ -18,6 +18,14 @@
 
       // Hookar (valfritt – standard finns i JS-filen om dessa saknas)
       window.getCurrentJsonForExport = () => ({ savedAt: new Date().toISOString(), data: window.myAppState });
+      window.loadImportedJson = obj => {
+        if (obj && obj.data) {
+          window.myAppState = obj.data;
+          alert('Importerade data!');
+        } else {
+          alert('Import stöds inte här');
+        }
+      };
     </script>
 
     <!-- Lägg denna rad precis innan </body> i din riktiga sida -->


### PR DESCRIPTION
## Summary
- add detection for missing import hook and disable import button
- provide demo loadImportedJson in snippet example

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/nederfors.github.io/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689b320692d08323b385a76a821d3db5