### PR TITLE
Disable online import button when no hook

### DIFF
--- a/js/online-export.js
+++ b/js/online-export.js
@@ -89,7 +89,9 @@ if (typeof window.getCurrentJsonForExport !== 'function') {
   window.getCurrentJsonForExport = () => ({ savedAt: new Date().toISOString(), data: window.myAppState || {} });
 }
 if (typeof window.loadImportedJson !== 'function') {
-  window.loadImportedJson = obj => console.warn('Ingen import-hook definierad', obj);
+  const noImport = obj => console.warn('Ingen import-hook definierad', obj);
+  noImport._isDefaultHook = true;
+  window.loadImportedJson = noImport;
 }
 /* -------- Hjälpfunktioner -------- */
 async function safeJson(res) {
@@ -142,6 +144,11 @@ function setupExport() {
 function setupImport() {
   const btn = ROOT.getElementById('importOnlineBtn');
   if (!btn) return;
+  if (!window.loadImportedJson || window.loadImportedJson._isDefaultHook) {
+    btn.disabled = true;
+    btn.title = 'Import stöds inte här';
+    return;
+  }
   btn.addEventListener('click', () => {
     const folderOptions = FOLDERS.map(f => `<option value="${f.key}">${f.label}</option>`).join('');
     const body = `


### PR DESCRIPTION
## Summary
- Mark default `loadImportedJson` hook
- Disable `importOnlineBtn` if no custom import hook is present

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b34af56408323b3574fcadeb8d505