### PR TITLE
feat: replace inventory drag with pointer events

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -250,8 +250,13 @@ input:focus, select:focus, textarea:focus {
   position: relative;
 }
 
-#invList li.card[draggable="true"] {
-  cursor: move;
+#invList li.card {
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+#invList li.card.dragging {
+  cursor: grabbing;
 }
 
 /* särställ "Formaliteter"-kortet med blå kant */


### PR DESCRIPTION
## Summary
- replace HTML5 drag events with pointer-based dragging for inventory items
- drop `draggable` attribute and add custom reorder logic for list items
- add CSS to support touch dragging and prevent unwanted scrolling

## Testing
- `node --check js/inventory-utils.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7b625e4c8323a245d4316e60b87c