### PR TITLE
Separate XP cost from entry titles in info panel

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -221,6 +221,7 @@ function initIndex() {
         }
         const li=document.createElement('li'); li.className='card' + (compact ? ' compact' : '');
         if (spec) li.dataset.trait = spec;
+        if (xpVal != null) li.dataset.xp = xpVal;
         const tagsDiv = (!compact && tagsHtml)
           ? `<div class="tags">${tagsHtml}</div>`
           : '';
@@ -337,8 +338,10 @@ function initIndex() {
     const infoBtn=e.target.closest('button[data-info]');
     if(infoBtn){
       const html=decodeURIComponent(infoBtn.dataset.info||'');
-      const title=infoBtn.closest('li')?.querySelector('.card-title')?.textContent||'';
-      yrkePanel.open(title,html);
+      const liEl = infoBtn.closest('li');
+      const title=liEl?.querySelector('.card-title > span')?.textContent||'';
+      const xpVal = liEl?.dataset.xp != null ? Number(liEl.dataset.xp) : undefined;
+      yrkePanel.open(title,html,xpVal);
       return;
     }
     const btn=e.target.closest('button[data-act]');

--- a/js/yrke-panel.js
+++ b/js/yrke-panel.js
@@ -6,11 +6,9 @@
     panel.id = 'yrkePanel';
     panel.innerHTML = `
       <header class="inv-header">
+        <div class="inv-actions"><span id="yrkeXp" class="xp-cost"></span></div>
         <h2 id="yrkeTitle"></h2>
-        <div class="inv-actions">
-          <span id="yrkeXp" class="xp-cost"></span>
-          <button id="yrkeClose" class="char-btn icon">✕</button>
-        </div>
+        <div class="inv-actions"><button id="yrkeClose" class="char-btn icon">✕</button></div>
       </header>
       <div id="yrkeContent"></div>
     `;


### PR DESCRIPTION
## Summary
- Show XP cost separately from entry titles when opening info panel
- Display XP cost on the left side of the slide-in info menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7bc0f3508323be9e2e4e80d11cee