### PR TITLE
Prevent negative prices in inventory

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -201,9 +201,9 @@
         taggar: { typ: [type.value] },
         vikt: Number(wIn.value)||0,
         grundpris: {
-          daler: Number(dIn.value)||0,
-          skilling: Number(sIn.value)||0,
-          'örtegar': Number(oIn.value)||0
+          daler: Math.max(0, Number(dIn.value)||0),
+          skilling: Math.max(0, Number(sIn.value)||0),
+          'örtegar': Math.max(0, Number(oIn.value)||0)
         },
         beskrivning: desc.value.trim(),
         artifactEffect: effSel ? effSel.value : ''
@@ -386,7 +386,7 @@
       }
     });
     const free = Math.min(Number(row.gratis || 0), row.qty);
-    const totalO = price * row.qty - base * free;
+    const totalO = Math.max(0, price * row.qty - base * free);
     return oToMoney(totalO);
   }
 
@@ -468,6 +468,7 @@
       else if (neut)  price *= 1;
       else            price *= myst ? 10 : 5;
     });
+    price = Math.max(0, price);
     return oToMoney(price);
   }
 
@@ -588,7 +589,7 @@
       });
 
       const free = Math.min(Number(row.gratis || 0), row.qty);
-      const totalO = price * row.qty - base * free;
+      const totalO = Math.max(0, price * row.qty - base * free);
       const m = oToMoney(totalO);
       t.d += m.d; t.s += m.s; t.o += m.o;
       return t;


### PR DESCRIPTION
## Summary
- Ensure custom inventory items can't have negative base prices
- Clamp row and total inventory costs to zero to avoid negative values
- Guard overall price calculations against negative results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7bea09fc832395c11633ac919e88