### PR TITLE
Enumerate duplicate inventory items

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -1,6 +1,7 @@
 (function(window){
   function calcDefense(kvick){
     const inv = storeHelper.getInventory(store);
+    const nameMap = invUtil.makeNameMap(inv);
     const list = storeHelper.getCurrentList(store);
     const rustLvl = storeHelper.abilityLevel(list, 'Rustmästare');
 
@@ -66,7 +67,7 @@
       if(allQ.includes('Smidig') || allQ.includes('Smidigt')) limit += 2;
       if(allQ.includes('Otymplig') || allQ.includes('Otympligt')) limit -= 1;
       if(rustLvl >= 2) limit = 0;
-      out.push({ name: row.name, value: kvick + limit });
+      out.push({ name: nameMap.get(row), value: kvick + limit });
       return out;
     }, []);
 


### PR DESCRIPTION
## Summary
- assign numbered display names to duplicate inventory items
- ensure popups and defense output use unique item names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7c7a3bc8832382c5066c906817bf