### PR TITLE
Remove online import feature

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -8,17 +8,9 @@
 const ROLE   = document.body.dataset.role;           // 'index' | 'character' | 'notes'
 let   store  = storeHelper.load();                   // Lokal lagring
 
-// Hookar för online-export/import
+// Hook för online-export
 window.getCurrentJsonForExport = () =>
   storeHelper.exportCharacterJSON(store, store.current);
-window.loadImportedJson = obj => {
-  const res = storeHelper.importCharacterJSON(store, obj);
-  if (res) {
-    location.reload();
-  } else {
-    alert('Felaktig fil.');
-  }
-};
 
 /* ---------- Snabb DOM-access ---------- */
 const bar  = document.querySelector('shared-toolbar');

--- a/js/online-export.js
+++ b/js/online-export.js
@@ -88,11 +88,6 @@ modalCancel.addEventListener('click', () => (modal.style.display = 'none'));
 if (typeof window.getCurrentJsonForExport !== 'function') {
   window.getCurrentJsonForExport = () => ({ savedAt: new Date().toISOString(), data: window.myAppState || {} });
 }
-if (typeof window.loadImportedJson !== 'function') {
-  const noImport = obj => console.warn('Ingen import-hook definierad', obj);
-  noImport._isDefaultHook = true;
-  window.loadImportedJson = noImport;
-}
 /* -------- Hjälpfunktioner -------- */
 async function safeJson(res) {
   try { return await res.json(); } catch { return null; }
@@ -140,63 +135,7 @@ function setupExport() {
   });
 }
 
-/* -------- Import -------- */
-function setupImport() {
-  const btn = ROOT.getElementById('importOnlineBtn');
-  if (!btn) return;
-  if (!window.loadImportedJson || window.loadImportedJson._isDefaultHook) {
-    btn.disabled = true;
-    btn.title = 'Import stöds inte här';
-    return;
-  }
-  btn.addEventListener('click', () => {
-    const folderOptions = FOLDERS.map(f => `<option value="${f.key}">${f.label}</option>`).join('');
-    const body = `
-      <label>Mapp:<br/><select id="folderPick">${folderOptions}</select></label><br/><br/>
-      <label>Fil:<br/><select id="filePick"></select></label>
-    `;
-    openModal('Importera online', body, async () => {
-      const fileId = document.getElementById('filePick').value;
-      if (!fileId) return;
-      try {
-        const res = await fetch(`${APPS_URL}?action=get&fileId=${encodeURIComponent(fileId)}&origin=${encodeURIComponent(ORIGIN)}&clientKey=${encodeURIComponent(getClientKey())}`);
-        if (!res.ok) throw new Error(res.statusText);
-        const obj = await safeJson(res);
-        if (!obj) throw new Error('Bad JSON');
-        window.loadImportedJson(obj);
-      } catch (err) {
-        console.error('Nedladdning misslyckades', err);
-      }
-    });
-
-    const folderPick = document.getElementById('folderPick');
-    const filePick = document.getElementById('filePick');
-
-    async function loadList() {
-      const key = folderPick.value;
-      filePick.innerHTML = '<option>Laddar...</option>';
-      try {
-        const res = await fetch(`${APPS_URL}?action=list&folderKey=${encodeURIComponent(key)}&origin=${encodeURIComponent(ORIGIN)}&clientKey=${encodeURIComponent(getClientKey())}`);
-        if (!res.ok) throw new Error(res.statusText);
-        const data = await safeJson(res);
-        if (data && Array.isArray(data.files) && data.files.length) {
-          filePick.innerHTML = data.files.map(f => `<option value="${f.id}">${f.name}</option>`).join('');
-        } else {
-          filePick.innerHTML = '<option value="">(tom)</option>';
-        }
-      } catch (err) {
-        console.error('Listning misslyckades', err);
-        filePick.innerHTML = '<option value="">Fel</option>';
-      }
-    }
-
-    folderPick.addEventListener('change', loadList);
-    loadList();
-  });
-}
-
 // Init
 document.addEventListener('DOMContentLoaded', () => {
   setupExport();
-  setupImport();
 });

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -264,7 +264,6 @@ class SharedToolbar extends HTMLElement {
           </ul>
         </div>
         <div class="char-btn-row">
-          <button id="importOnlineBtn" class="char-btn">Importera online</button>
           <button id="exportOnlineBtn" class="char-btn">Exportera online</button>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- remove UI for online import
- drop import logic from online export module
- remove unused online import hook

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b7db5c0d4832399ed21f1859ec6c7