### PR TITLE
Utöka exportpopup med alla karaktärer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sidan fungerar helt offline och sparar all data i din webbläsares lagring.
 
 ## Export och import av rollpersoner
 
-Use the **Exportera** button in the filter panel to open a menu where you can download either the active character or all saved characters as JSON files. When supported by your browser a “Save As” dialog allows you to pick both filename and location; otherwise the files are downloaded normally. The **Importera** button lets you select one or more such files to recreate characters (requires that the database is loaded). Anteckningar följer med vid export så länge något fält är ifyllt.
+Use the **Exportera** button in the filter panel to open a menu where you can download all saved characters or pick a specific one to export as a JSON file. "Alla rollpersoner" ligger alltid överst och den aktiva rollpersonen visas näst högst upp. When supported by your browser a “Save As” dialog allows you to pick both filename and location; otherwise the files are downloaded normally. The **Importera** button lets you select one or more such files to recreate characters (requires that the database is loaded). Anteckningar följer med vid export så länge något fält är ifyllt.
 
 ## Anteckningssidan
 
@@ -63,7 +63,7 @@ Verktygsraden innehåller:
 I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 - **Ny rollperson** skapar en tom karaktär och gör den aktiv.
 - **Ta bort rollperson** raderar den aktuella karaktären.
-- **Exportera** öppnar en meny för att ladda ner den aktiva rollpersonen eller alla sparade rollpersoner som JSON-filer.
+- **Exportera** öppnar en meny där du kan ladda ner alla rollpersoner eller välja en specifik att exportera som JSON-fil.
 - **Importera** återställer en eller flera karaktärer från sparade filer.
 - **⚒️**, **⚗️** och **🏺** anger nivå på smed, alkemist och artefaktmakare i ditt sällskap. Dessa nivåer används för att räkna ut rabatter på priser.
 - **🔭** gör att flera filter kombineras med OR i stället för AND, vilket ger en bredare sökning.
@@ -100,7 +100,7 @@ Både i index-vyn och i din karaktär visas poster som kort.
 - Monstruösa särdrag kan inte staplas.
 
 ### 9. Export och import
-Se avsnittet ovan. Exportera öppnar en meny där du kan spara den aktiva karaktären eller alla karaktärer som JSON-filer. Importera läser in sparade filer och återställer karaktärer. Anteckningar följer med så länge minst ett fält innehåller text. All data sparas i webblagring så inget backend behövs.
+Se avsnittet ovan. Exportera öppnar en meny där du kan spara alla karaktärer eller välja en enskild karaktär som JSON-fil. Importera läser in sparade filer och återställer karaktärer. Anteckningar följer med så länge minst ett fält innehåller text. All data sparas i webblagring så inget backend behövs.
 
 ### 10. Tips och tricks
 - Alla dina val sparas automatiskt i webblagringen på datorn.

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -393,10 +393,7 @@ class SharedToolbar extends HTMLElement {
       <div id="exportPopup">
         <div class="popup-inner">
           <h3>Exportera</h3>
-          <div id="exportOptions">
-            <button id="exportCurrent" class="char-btn">Aktiv rollperson</button>
-            <button id="exportAll" class="char-btn">Alla rollpersoner</button>
-          </div>
+          <div id="exportOptions"></div>
           <button id="exportCancel" class="char-btn danger">Avbryt</button>
         </div>
       </div>


### PR DESCRIPTION
## Sammanfattning
- Gör exportmenyn dynamisk och listar alla sparade rollpersoner
- Aktiv rollperson visas efter alternativet "Alla rollpersoner"
- Uppdatera dokumentation om den nya exportfunktionen

## Testning
- `npm test` *(misslyckas: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b811ddb20832393ce5d80c325c78f