### PR TITLE
Visa notis för Koreograferad strid under Kvick

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -206,6 +206,9 @@
           extra += '<div class="trait-extra">Kan användas som träffsäker för attacker med Övertag</div>';
         }
       }
+      if (k === 'Kvick' && storeHelper.abilityLevel(list, 'Koreograferad strid') >= 1) {
+        extra += '<div class="trait-extra">Kan användas som träffsäker för attacker som utförs efter en förflyttning</div>';
+      }
       if (k === 'Listig' && storeHelper.abilityLevel(list, 'Taktiker') >= 3) {
         extra += '<div class="trait-extra">Kan användas som träffsäker för attacker med allt utom tunga vapen</div>';
       }


### PR DESCRIPTION
## Sammanfattning
- Lägger till logik som visar en notis under karaktärsdraget **Kvick** när rollpersonen har förmågan *Koreograferad strid* på minst novisnivå.
- Notisen informerar att Kvick kan användas som Träffsäker för attacker som utförs efter en förflyttning.

## Testning
- `node --check js/traits-utils.js`


------
https://chatgpt.com/codex/tasks/task_e_689b9610db3c8323b3fad8acf7d564a3