### PR TITLE
Add info popup for tabeller and remove add button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -586,6 +586,20 @@ select.level {
 #yrkePanel   { max-width: 360px; font-size: 1.2rem; line-height: 1.6; }
 #infoPanel   { max-width: 360px; font-size: 1.1rem; line-height: 1.5; }
 #yrkePanel p { margin: 0 0 1rem; }
+#yrkePanel table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: .5rem 0 1rem;
+}
+#yrkePanel th,
+#yrkePanel td {
+  border: 1px solid var(--card-border);
+  padding: .3rem .6rem;
+  text-align: left;
+}
+#yrkePanel th {
+  background: var(--card);
+}
 #infoPanel p { margin: 0 0 1rem; }
 
 /* När klassen .open läggs på – låt panelen glida in */

--- a/data/tabeller.json
+++ b/data/tabeller.json
@@ -2,6 +2,7 @@
   {
     "id": "t1",
     "namn": "Kostnad för Skattletarlicens",
+    "taggar": { "typ": ["Tabell"] },
     "kolumner": [
       "antal personer",
       "kostnad månad",

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -9,9 +9,19 @@ function initIndex() {
   let catsMinimized = false;
 
   const getEntries = () =>
-    DB.concat(storeHelper.getCustomEntries(store));
+    DB
+      .concat(window.TABELLER || [])
+      .concat(storeHelper.getCustomEntries(store));
 
   const FALT_BUNDLE = ['Flinta och stål','Kokkärl','Rep, 10 meter','Sovfäll','Tändved','Vattenskinn'];
+
+  const tabellInfoHtml = p => {
+    const head = `<tr>${p.kolumner.map(c => `<th>${c}</th>`).join('')}</tr>`;
+    const body = p.rader
+      .map(r => `<tr>${p.kolumner.map(c => `<td>${r[c] ?? ''}</td>`).join('')}</tr>`)
+      .join('');
+    return `<table><thead>${head}</thead><tbody>${body}</tbody></table>`;
+  };
 
   /* fyll dropdowns */
   const fillDropdowns = ()=>{
@@ -115,6 +125,22 @@ function initIndex() {
       const listEl=catLi.querySelector('ul');
       detailsEl.addEventListener('toggle', updateCatToggle);
       cats[cat].forEach(p=>{
+        if (p.kolumner && p.rader) {
+          const infoHtml = tabellInfoHtml(p);
+          const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
+          const tagsHtml = (p.taggar?.typ || [])
+            .map(t => `<span class="tag">${t}</span>`)
+            .join(' ');
+          const tagsDiv = tagsHtml ? `<div class="tags">${tagsHtml}</div>` : '';
+          const li = document.createElement('li');
+          li.className = 'card';
+          li.innerHTML = `
+            <div class="card-title"><span>${p.namn}</span></div>
+            ${tagsDiv}
+            <div class="inv-controls">${infoBtn}</div>`;
+          listEl.appendChild(li);
+          return;
+        }
         const isEx = p.namn === 'Exceptionellt karakt\u00e4rsdrag';
         const inChar = isEx ? false : charList.some(c=>c.namn===p.namn);
         const curLvl = charList.find(c=>c.namn===p.namn)?.nivå

--- a/js/main.js
+++ b/js/main.js
@@ -108,6 +108,12 @@ fetch(TABELLER_FILE)
   .then(arr => {
     TABELLER = arr;
     window.TABELLER = TABELLER;
+    if (typeof window.indexViewUpdate === 'function') {
+      window.indexViewUpdate();
+      if (typeof window.indexViewRefreshFilters === 'function') {
+        window.indexViewRefreshFilters();
+      }
+    }
   });
 
 Promise.all(DATA_FILES.map(f => fetch(f).then(r => r.json())))


### PR DESCRIPTION
## Summary
- show tabeller in index view with an info button
- render tabeller as theme-styled table in popup
- add styling for tables in info panel and refresh list after loading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c858c1e8c8323877d8096f1b96be4