### PR TITLE
Add dedicated popup for Tabell entries

### DIFF
--- a/character.html
+++ b/character.html
@@ -16,6 +16,7 @@
   <script src="js/traits-utils.js" defer></script>
   <script src="js/shared-toolbar.js" defer></script>
   <script src="js/yrke-panel.js"  defer></script>
+  <script src="js/tabell-popup.js" defer></script>
   <script src="js/elite-req.js"   defer></script>
   <script src="js/character-view.js" defer></script>
   <script src="js/main.js"            defer></script>

--- a/css/style.css
+++ b/css/style.css
@@ -1424,6 +1424,51 @@ textarea.auto-resize {
 .money-control .char-btn { padding: .3rem .6rem; }
 .cap-food { color: var(--txt); }
 
+/* ---------- Popup för tabeller ---------- */
+#tabellPopup {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 3000;
+}
+#tabellPopup.open { display: flex; }
+#tabellPopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem;
+  box-shadow: var(--shadow);
+  padding: 1.5rem;
+  width: 90%;
+  max-width: 600px;
+  max-height: 90vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  position: relative;
+}
+#tabellPopup #tabellClose {
+  position: absolute;
+  top: .4rem;
+  right: .4rem;
+}
+#tabellPopup table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+#tabellPopup th,
+#tabellPopup td {
+  border: 1px solid var(--card-border);
+  padding: .3rem .6rem;
+  text-align: left;
+  word-break: break-word;
+}
+#tabellPopup th { background: var(--card); }
+
 /* ---------- Online modal ---------- */
 #onlineModal {
   display: none;

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <script src="js/traits-utils.js" defer></script>
   <script src="js/shared-toolbar.js" defer></script>
   <script src="js/yrke-panel.js"  defer></script>
+  <script src="js/tabell-popup.js" defer></script>
   <script src="js/elite-req.js"   defer></script>
   <script src="js/index-view.js"  defer></script>
   <script src="js/main.js"         defer></script>

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -466,6 +466,10 @@ function initCharacter() {
     const infoBtn=e.target.closest('button[data-info]');
     if(infoBtn){
       const html=decodeURIComponent(infoBtn.dataset.info||'');
+      if(infoBtn.dataset.tabell!=null){
+        tabellPopup.open(html);
+        return;
+      }
       const liEl = infoBtn.closest('li');
       const title = liEl?.querySelector('.card-title > span')?.textContent || '';
       const xpVal = liEl?.dataset.xp ? Number(liEl.dataset.xp) : undefined;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -127,7 +127,7 @@ function initIndex() {
       cats[cat].forEach(p=>{
         if (p.kolumner && p.rader) {
           const infoHtml = tabellInfoHtml(p);
-          const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
+          const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1">Info</button>`;
           const tagsHtml = (p.taggar?.typ || [])
             .map(t => `<span class="tag">${t}</span>`)
             .join(' ');
@@ -364,6 +364,10 @@ function initIndex() {
     const infoBtn=e.target.closest('button[data-info]');
     if(infoBtn){
       const html=decodeURIComponent(infoBtn.dataset.info||'');
+      if(infoBtn.dataset.tabell!=null){
+        tabellPopup.open(html);
+        return;
+      }
       const liEl = infoBtn.closest('li');
       const title=liEl?.querySelector('.card-title > span')?.textContent||'';
       const xpVal = liEl?.dataset.xp != null ? Number(liEl.dataset.xp) : undefined;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -508,7 +508,7 @@ class SharedToolbar extends HTMLElement {
     if (path.some(el => toggles.includes(el.id))) return;
 
     // ignore clicks inside popups so panels stay open
-      const popups = ['qualPopup','customPopup','moneyPopup','qtyPopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup'];
+      const popups = ['qualPopup','customPopup','moneyPopup','qtyPopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));

--- a/js/tabell-popup.js
+++ b/js/tabell-popup.js
@@ -1,0 +1,30 @@
+(function(window){
+  function create(){
+    if(document.getElementById('tabellPopup')) return;
+    const wrap = document.createElement('div');
+    wrap.id = 'tabellPopup';
+    wrap.innerHTML = `
+      <div class="popup-inner">
+        <button id="tabellClose" class="char-btn icon">✕</button>
+        <div id="tabellContent"></div>
+      </div>
+    `;
+    document.body.appendChild(wrap);
+    wrap.querySelector('#tabellClose').addEventListener('click', close);
+  }
+
+  function open(html){
+    create();
+    document.getElementById('tabellContent').innerHTML = html || '';
+    document.getElementById('tabellPopup').classList.add('open');
+  }
+
+  function close(){
+    const p = document.getElementById('tabellPopup');
+    if(p) p.classList.remove('open');
+  }
+
+  window.tabellPopup = { open, close };
+  if(document.readyState !== 'loading') create();
+  else document.addEventListener('DOMContentLoaded', create);
+})(window);


### PR DESCRIPTION
## Summary
- Show table entries in a fullscreen popup with close button
- Wire up info buttons tagged as Tabell to open the new popup
- Style popup to wrap horizontally and scroll vertically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c88380dc0832393bf9f666d14b3d8