### PR TITLE
Förbättra tabellpopupens layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1449,21 +1449,28 @@ textarea.auto-resize {
   overflow: auto;
   position: relative;
 }
-#tabellPopup #tabellClose {
-  position: absolute;
-  top: .4rem;
-  right: .4rem;
+#tabellPopup .popup-header {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  margin-bottom: 1rem;
+}
+#tabellPopup #tabellClose { flex-shrink: 0; }
+#tabellPopup #tabellTitle {
+  margin: 0;
+  font-size: 1.2rem;
 }
 #tabellPopup table {
   border-collapse: collapse;
-  width: max-content;
+  width: 100%;
+  table-layout: auto;
 }
 #tabellPopup th,
 #tabellPopup td {
   border: 1px solid var(--card-border);
   padding: .3rem .6rem;
   text-align: left;
-  word-break: normal;
+  word-break: break-word;
 }
 #tabellPopup th { background: var(--card); }
 

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -466,12 +466,12 @@ function initCharacter() {
     const infoBtn=e.target.closest('button[data-info]');
     if(infoBtn){
       const html=decodeURIComponent(infoBtn.dataset.info||'');
-      if(infoBtn.dataset.tabell!=null){
-        tabellPopup.open(html);
-        return;
-      }
       const liEl = infoBtn.closest('li');
       const title = liEl?.querySelector('.card-title > span')?.textContent || '';
+      if(infoBtn.dataset.tabell!=null){
+        tabellPopup.open(html, title);
+        return;
+      }
       const xpVal = liEl?.dataset.xp ? Number(liEl.dataset.xp) : undefined;
       yrkePanel.open(title, html, xpVal);
       return;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -16,7 +16,8 @@ function initIndex() {
   const FALT_BUNDLE = ['Flinta och stål','Kokkärl','Rep, 10 meter','Sovfäll','Tändved','Vattenskinn'];
 
   const tabellInfoHtml = p => {
-    const head = `<tr>${p.kolumner.map(c => `<th>${c}</th>`).join('')}</tr>`;
+    const cap = s => s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
+    const head = `<tr>${p.kolumner.map(c => `<th>${cap(c)}</th>`).join('')}</tr>`;
     const body = p.rader
       .map(r => `<tr>${p.kolumner.map(c => `<td>${r[c] ?? ''}</td>`).join('')}</tr>`)
       .join('');
@@ -364,12 +365,12 @@ function initIndex() {
     const infoBtn=e.target.closest('button[data-info]');
     if(infoBtn){
       const html=decodeURIComponent(infoBtn.dataset.info||'');
-      if(infoBtn.dataset.tabell!=null){
-        tabellPopup.open(html);
-        return;
-      }
       const liEl = infoBtn.closest('li');
       const title=liEl?.querySelector('.card-title > span')?.textContent||'';
+      if(infoBtn.dataset.tabell!=null){
+        tabellPopup.open(html, title);
+        return;
+      }
       const xpVal = liEl?.dataset.xp != null ? Number(liEl.dataset.xp) : undefined;
       yrkePanel.open(title,html,xpVal);
       return;

--- a/js/tabell-popup.js
+++ b/js/tabell-popup.js
@@ -5,17 +5,24 @@
     wrap.id = 'tabellPopup';
     wrap.innerHTML = `
       <div class="popup-inner">
-        <button id="tabellClose" class="char-btn icon">✕</button>
+        <div class="popup-header">
+          <button id="tabellClose" class="char-btn icon">✕</button>
+          <h2 id="tabellTitle"></h2>
+        </div>
         <div id="tabellContent"></div>
       </div>
     `;
     document.body.appendChild(wrap);
     wrap.querySelector('#tabellClose').addEventListener('click', close);
+    wrap.addEventListener('click', e => {
+      if (e.target === wrap) close();
+    });
   }
 
-  function open(html){
+  function open(html, title){
     create();
     document.getElementById('tabellContent').innerHTML = html || '';
+    document.getElementById('tabellTitle').textContent = title || '';
     document.getElementById('tabellPopup').classList.add('open');
   }
 


### PR DESCRIPTION
## Sammanfattning
- Visar nu tabellens namn i popupens topp och flyttar stäng-knappen till övre vänstra hörnet.
- Kolumnrubriker normaliseras så att de alltid börjar med versal.
- Popupen stängs vid klick utanför och tabellens bredd/ordbrytning ger kortare sidscroll.

## Test
- `npm test` *(saknar package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c9559fc6c8323aa94ffcb650dcf21