### PR TITLE
Make tabell popup responsive on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1474,6 +1474,26 @@ textarea.auto-resize {
 }
 #tabellPopup th { background: var(--card); }
 
+@media (max-width: 600px) {
+  #tabellPopup .popup-inner {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
+  }
+
+  #tabellPopup table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+
+  #tabellPopup th,
+  #tabellPopup td {
+    line-height: 1.4;
+    font-size: 1rem;
+  }
+}
+
 /* ---------- Online modal ---------- */
 #onlineModal {
   display: none;


### PR DESCRIPTION
## Summary
- Add responsive styles for `#tabellPopup` to fill viewport on mobile
- Enable horizontal scrolling and improve readability in popup tables

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_689eee9a2f188323a81170972888ce52