### PR TITLE
Add price multiplier popup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1020,6 +1020,42 @@ select.level {
   gap: .4rem;
 }
 
+/* ---------- Popup för pris ---------- */
+#pricePopup {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 3000;
+}
+#pricePopup.open { display: flex; }
+#pricePopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem 1.2rem 0 0;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.4rem 2rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+  transform: translateY(100%);
+  transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: .8rem;
+}
+#pricePopup.open .popup-inner { transform: translateY(0); }
+#pricePopup .popup-inner button { width: 100%; }
+#priceItemList {
+  display: flex;
+  flex-direction: column;
+  gap: .4rem;
+}
+
 /* ---------- Popup för alkemistnivå ---------- */
 #alcPopup {
   position: fixed;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -325,6 +325,17 @@ class SharedToolbar extends HTMLElement {
         </div>
       </div>
 
+      <!-- ---------- Popup Pris ---------- -->
+      <div id="pricePopup">
+        <div class="popup-inner">
+          <h3>Multiplicera pris</h3>
+          <input id="priceFactor" type="number" step="0.1" placeholder="Faktor">
+          <div id="priceItemList"></div>
+          <button id="priceApply" class="char-btn">Verkställ</button>
+          <button id="priceCancel" class="char-btn danger">Avbryt</button>
+        </div>
+      </div>
+
       <!-- ---------- Popup Alkemistniv\u00e5 ---------- -->
       <div id="alcPopup">
         <div class="popup-inner">
@@ -505,7 +516,7 @@ class SharedToolbar extends HTMLElement {
     if (path.some(el => toggles.includes(el.id))) return;
 
     // ignore clicks inside popups so panels stay open
-      const popups = ['qualPopup','customPopup','moneyPopup','qtyPopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup'];
+      const popups = ['qualPopup','customPopup','moneyPopup','qtyPopup','pricePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));


### PR DESCRIPTION
## Summary
- Add "Multiplicera pris" button and popup for bulk price updates
- Implement logic to apply price factors and recalc item costs
- Style new price popup for slide-up behavior

## Testing
- `node --check js/inventory-utils.js`
- `node --check js/shared-toolbar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a48e04bf8083238e915fecc4b9c4e0