### PR TITLE
Improve price multiplier UI and tag

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -57,7 +57,8 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
                padding: .15rem .7rem; border-radius: .55rem;
                font-size: .85rem; white-space: nowrap; }
 .tag.removable { cursor: pointer; }
-.tag.free      { background: var(--accent); color:#fff; }
+.tag.free,
+.tag.price-mult { background: var(--accent); color:#fff; }
 .tag.mystic    { border: 1.5px solid var(--mystic); }
 .tag.neutral   { border: 1.5px solid var(--neutral); }
 .tag.negative  { border: 1.5px solid var(--negative); }
@@ -1054,6 +1055,31 @@ select.level {
   display: flex;
   flex-direction: column;
   gap: .4rem;
+}
+#priceItemList .price-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--card);
+  border: 2px solid var(--card-border);
+  border-radius: .6rem;
+  padding: .4rem .6rem;
+}
+#priceItemList .price-item span {
+  flex: 1;
+}
+#priceItemList .price-item input[type="checkbox"] {
+  appearance: none;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 2px solid var(--card-border);
+  border-radius: .25rem;
+  background: var(--bg);
+  cursor: pointer;
+}
+#priceItemList .price-item input[type="checkbox"]:checked {
+  background: var(--accent);
+  border-color: var(--accent);
 }
 
 /* ---------- Popup för alkemistnivå ---------- */

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -369,7 +369,7 @@
     const nameMap = makeNameMap(inv);
     list.innerHTML = inv
       .map((row,i) => `
-        <label><input type="checkbox" data-idx="${i}"> ${nameMap.get(row)}</label>`)
+        <label class="price-item"><span>${nameMap.get(row)}</span><input type="checkbox" data-idx="${i}"></label>`)
       .join('');
 
     pop.classList.add('open');
@@ -741,6 +741,13 @@ ${moneyRow}
             .map(t => `<span class="tag">${t}</span>`);
           if (rowLevel) tagList.push(`<span class="tag level">${rowLevel}</span>`);
           if (freeCnt) tagList.push(`<span class="tag free removable" data-free="1">Gratis${freeCnt>1?`×${freeCnt}`:''} ✕</span>`);
+          const priceMult = row.priceMult;
+          if (priceMult && Math.abs(priceMult - 1) > 0.001) {
+            const mTxt = Number.isInteger(priceMult)
+              ? priceMult
+              : priceMult.toFixed(2).replace(/\.?0+$/, '');
+            tagList.push(`<span class="tag price-mult removable" data-mult="1">×${mTxt} ✕</span>`);
+          }
           if (tagList.length) {
             desc += `<div class="tags">${tagList.join(' ')}</div>`;
           }
@@ -905,6 +912,8 @@ ${allowQual ? `<button data-act="addQual" class="char-btn">🔨</button>` : ''}
               inv[realIdx].gratisKval = inv[realIdx].gratisKval.filter(x => x !== q);
             }
           }
+        } else if (removeTagBtn.dataset.mult) {
+          delete inv[realIdx].priceMult;
         }
         saveInventory(inv);
         renderInventory();


### PR DESCRIPTION
## Summary
- Give price multiplier popup entries card-like boxes with styled checkboxes.
- Show price multiplier tags on inventory items and allow removing the multiplier.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4919b41488323b2f4bcc9bd864fae