### PR TITLE
Make price popup scrollable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1328,6 +1328,7 @@ select.level {
 #masterPopup .popup-inner,
 #traitPopup .popup-inner,
 #customPopup .popup-inner,
+#pricePopup .popup-inner,
 #alcPopup .popup-inner,
 #smithPopup .popup-inner,
 #artPopup .popup-inner,


### PR DESCRIPTION
## Summary
- Allow the Multiplicera pris popup to scroll when its content exceeds the viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a1abeabc83238fe2a5ad09a88131