### PR TITLE
Increase hold-to-drag delay for inventory items

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1183,7 +1183,9 @@ ${allowQual ? `<button data-act="addQual" class="char-btn">🔨</button>` : ''}
           window.removeEventListener('pointerup', onUp);
         };
 
-        pressTimer = setTimeout(startDrag, 200);
+        // Require a slightly longer press before drag to avoid
+        // accidental drags when scrolling on touch devices
+        pressTimer = setTimeout(startDrag, 400);
 
         window.addEventListener('pointerup', onUp);
       });


### PR DESCRIPTION
## Summary
- lengthen press duration before enabling drag-and-drop to reduce accidental drags on touch devices

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a5a1e1cb1483239756386ea1719861