### PR TITLE
feat: manage nested vehicle inventories

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -336,6 +336,17 @@ class SharedToolbar extends HTMLElement {
         </div>
       </div>
 
+      <!-- ---------- Popup Färdmedel ---------- -->
+      <div id="vehiclePopup">
+        <div class="popup-inner">
+          <h3>Flytta till färdmedel</h3>
+          <select id="vehicleSelect"></select>
+          <div id="vehicleItemList"></div>
+          <button id="vehicleApply" class="char-btn">Verkställ</button>
+          <button id="vehicleCancel" class="char-btn danger">Avbryt</button>
+        </div>
+      </div>
+
       <!-- ---------- Popup Alkemistniv\u00e5 ---------- -->
       <div id="alcPopup">
         <div class="popup-inner">
@@ -528,7 +539,7 @@ class SharedToolbar extends HTMLElement {
     if (path.some(el => toggles.includes(el.id))) return;
 
     // ignore clicks inside popups so panels stay open
-      const popups = ['qualPopup','customPopup','moneyPopup','qtyPopup','pricePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup'];
+      const popups = ['qualPopup','customPopup','moneyPopup','qtyPopup','pricePopup','vehiclePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));


### PR DESCRIPTION
## Summary
- detect vehicles in inventory and expose load buttons with emojis
- enable moving items into and out of vehicles with new popup
- render nested inventory lists and handle nested weight calculations

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a497070c83238b5469c011306fdb