### PR TITLE
Add carrying capacity for vehicles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,7 @@
   --neutral:     #5e9cff;
   --negative:    #8b4513;
   --danger:      #e74c3c;
+  --danger-bg:   #3c1a1a;
   --shadow:      0 4px 16px #0007;
 }
 
@@ -249,6 +250,10 @@ input:focus, select:focus, textarea:focus {
   flex-direction: column;
   gap: .45rem;
   position: relative;
+}
+
+.card.vehicle-over {
+  background: var(--danger-bg);
 }
 
 #invList li.card {


### PR DESCRIPTION
## Summary
- Track weight per vehicle and exclude vehicle contents from character's carry weight
- Display vehicle capacity and remaining load, highlighting overloaded vehicles
- Add styling for vehicle overcapacity backgrounds

## Testing
- `node --check js/inventory-utils.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a84d774883238babbacb36ba22b8