### PR TITLE
Treat vehicles as individual inventory items

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -419,7 +419,7 @@ function initIndex() {
           FALT_BUNDLE.forEach(namn => {
             const ent = invUtil.getEntry(namn);
             if (!ent.namn) return;
-            const indivItem = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter']
+            const indivItem = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter','Färdmedel']
               .some(t=>ent.taggar.typ.includes(t));
             const existing = inv.find(r => r.name === ent.namn);
             if (indivItem || !existing) {
@@ -431,7 +431,7 @@ function initIndex() {
           invUtil.saveInventory(inv); invUtil.renderInventory();
           renderList(filtered());
         } else {
-          const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt'].some(t=>p.taggar.typ.includes(t));
+          const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Färdmedel'].some(t=>p.taggar.typ.includes(t));
           const rowBase = { name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
           if (p.artifactEffect) rowBase.artifactEffect = p.artifactEffect;
           const addRow = trait => {

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -355,7 +355,7 @@
 
       const row   = inv[realIdx];
       const entry = getEntry(row.name);
-      const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter']
+      const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter','Färdmedel']
         .some(t => entry.taggar?.typ?.includes(t));
 
       if (indiv) {
@@ -901,7 +901,7 @@ ${moneyRow}
           }
 
           /* — knappar — */
-          const isGear = ['Vapen', 'Sköld', 'Rustning', 'L\u00e4gre Artefakt', 'Artefakter'].some(t => tagTyp.includes(t));
+          const isGear = ['Vapen', 'Sköld', 'Rustning', 'L\u00e4gre Artefakt', 'Artefakter', 'Färdmedel'].some(t => tagTyp.includes(t));
           const allowQual = ['Vapen','Sköld','Pil/Lod','Rustning','Artefakter'].some(t => tagTyp.includes(t));
  const btnRow = isGear
   ? `<button data-act="del" class="char-btn danger">🗑</button>`
@@ -1121,7 +1121,7 @@ ${moneyRow}
             bundle.forEach(namn => {
               const ent = getEntry(namn);
               if (!ent.namn) return;
-              const indivItem = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter'].some(t => ent.taggar.typ.includes(t));
+              const indivItem = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter','Färdmedel'].some(t => ent.taggar.typ.includes(t));
               const existing = inv.findIndex(r => r.name === ent.namn);
               if (indivItem || existing === -1) {
                 inv.push({ name: ent.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] });
@@ -1132,7 +1132,7 @@ ${moneyRow}
             saveInventory(inv);
             renderInventory();
           } else {
-            const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter'].some(t => entry.taggar.typ.includes(t));
+            const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter','Färdmedel'].some(t => entry.taggar.typ.includes(t));
             const addRow = trait => {
               const obj = { name: entry.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
               if (trait) obj.trait = trait;


### PR DESCRIPTION
## Summary
- handle vehicles as individual items when adding to inventory
- ensure vehicles get numbered entries like "Färdmedel 1"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ab7b095c8323a645d21a939e3811