### PR TITLE
Allow expanding nested entries in collapsed vehicles

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1112,6 +1112,13 @@ ${moneyRow}
       if (cardTitle) {
         const li = cardTitle.closest('li.card');
         li.classList.toggle('compact');
+        if (!li.classList.contains('compact')) {
+          let parent = li.parentElement.closest('li.card.compact');
+          while (parent) {
+            parent.classList.remove('compact');
+            parent = parent.parentElement.closest('li.card.compact');
+          }
+        }
         updateCollapseBtnState();
         return;
       }


### PR DESCRIPTION
## Summary
- ensure inventory entries open even inside collapsed vehicles by auto-expanding ancestor cards

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ad03bcf883239dbaf470518569ad