### PR TITLE
Hindra att färdmedel expanderar när nestade entries öppnas

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1178,13 +1178,6 @@ ${moneyRow}
       if (cardTitle) {
         const li = cardTitle.closest('li.card');
         li.classList.toggle('compact');
-        if (!li.classList.contains('compact')) {
-          let parent = li.parentElement.closest('li.card.compact');
-          while (parent) {
-            parent.classList.remove('compact');
-            parent = parent.parentElement.closest('li.card.compact');
-          }
-        }
         updateCollapseBtnState();
         return;
       }


### PR DESCRIPTION
## Sammanfattning
- Tillåt att kollapsade poster inuti färdmedel expanderas utan att överordnade kort påverkas.

## Testning
- `node --check js/inventory-utils.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5afd0fd3c8323aecc4baa96f105b6