### PR TITLE
Toggle drag-and-drop in inventory

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -20,6 +20,7 @@
   const moneyToO = m => (m.daler||0)*SBASE*OBASE + (m.skilling||0)*OBASE + (m['örtegar']||0);
   let dragIdx = null;
   let dragEl = null;
+  let dragEnabled = false;
 
   const oToMoney = o => {
     const d = Math.floor(o / (SBASE * OBASE)); o %= SBASE * OBASE;
@@ -1150,6 +1151,13 @@ ${moneyRow}
         updateCollapseBtnState();
       };
     }
+    if (dom.dragToggle) {
+      dom.dragToggle.classList.toggle('danger', dragEnabled);
+      dom.dragToggle.onclick = () => {
+        dragEnabled = !dragEnabled;
+        dom.dragToggle.classList.toggle('danger', dragEnabled);
+      };
+    }
     const getRowInfo = (inv, li) => {
       const idx = Number(li.dataset.idx);
       if (!Number.isNaN(idx)) return { row: inv[idx], parentArr: inv, idx };
@@ -1441,6 +1449,7 @@ ${moneyRow}
     };
 
       dom.invList.addEventListener('pointerdown', e => {
+        if (!dragEnabled) return;
         const li = e.target.closest('li[data-idx]');
         if (!li || e.target.closest('button')) return;
 

--- a/js/main.js
+++ b/js/main.js
@@ -30,6 +30,7 @@ const dom  = {
   moneyAddBtn: $T('moneyAddBtn'),
   invTypeSel : $T('invTypeFilter'),
   collapseAllBtn: $T('collapseAllInv'),
+  dragToggle: $T('dragToggle'),
   unusedOut: $T('unusedOut'),
 
   /* smith filter */

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -135,6 +135,7 @@ class SharedToolbar extends HTMLElement {
           <h2>Inventarie</h2>
 
           <div class="inv-actions">
+            <button id="dragToggle" class="char-btn icon" title="Ändra ordning">🔀</button>
             <button id="collapseAllInv" class="char-btn icon" title="Kollapsa alla">▶</button>
             <button class="char-btn icon" data-close="invPanel">✕</button>
           </div>


### PR DESCRIPTION
## Summary
- Add 🔀 button to inventory header to toggle drag-and-drop mode
- Track drag toggle state and enable/disable dragging accordingly
- Expose drag toggle through main DOM cache

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b2c2c4a4832394362091bc1a1b62