### PR TITLE
Make popup menus scrollable

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1436,20 +1436,7 @@ select.level {
 }
 
 /* Gör samtliga popups scrollbara om innehållet blir för högt */
-#qualPopup .popup-inner,
-#masterPopup .popup-inner,
-#traitPopup .popup-inner,
-#customPopup .popup-inner,
-#pricePopup .popup-inner,
-#vehiclePopup .popup-inner,
-#deleteContainerPopup .popup-inner,
-#alcPopup .popup-inner,
-#smithPopup .popup-inner,
-#artPopup .popup-inner,
-#defensePopup .popup-inner,
-#exportPopup .popup-inner,
-#nilasPopup .popup-inner,
-#charPopup .popup-inner {
+.popup-inner {
   max-height: 100%;
   overflow-y: auto;
 }
@@ -1686,6 +1673,8 @@ textarea.auto-resize {
   margin: 10vh auto;
   padding: 1.6rem;
   color: var(--txt);
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 #onlineModal .modal-actions {


### PR DESCRIPTION
## Summary
- Ensure all popups use a shared `.popup-inner` style with scrolling when content overflows
- Allow the online modal panel to scroll by capping its height and enabling overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e42eaeb08323a6d08d9cf26d5b2a