### PR TITLE
Enable touch scrolling for inventory lists

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -258,8 +258,11 @@ input:focus, select:focus, textarea:focus {
 
 #invList li.card {
   cursor: grab;
-  touch-action: none;
+  touch-action: pan-y;
   user-select: none;
+}
+#invList.drag-mode li.card {
+  touch-action: none;
 }
 #invList li.card.dragging {
   cursor: grabbing;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1153,9 +1153,11 @@ ${moneyRow}
     }
     if (dom.dragToggle) {
       dom.dragToggle.classList.toggle('danger', dragEnabled);
+      if (dom.invList) dom.invList.classList.toggle('drag-mode', dragEnabled);
       dom.dragToggle.onclick = () => {
         dragEnabled = !dragEnabled;
         dom.dragToggle.classList.toggle('danger', dragEnabled);
+        if (dom.invList) dom.invList.classList.toggle('drag-mode', dragEnabled);
       };
     }
     const getRowInfo = (inv, li) => {


### PR DESCRIPTION
## Summary
- allow vertical scrolling for inventory cards while preserving drag-only mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e5d94c048323b4ab4ae13168a180