### PR TITLE
Enable inertial scrolling on off-canvas panels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -579,6 +579,7 @@ select.level {
   transition: right .25s ease;
   z-index: 1000;
   overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
   padding: 1.2rem 1rem 2rem;
   font-size: 1rem;
 }


### PR DESCRIPTION
## Summary
- Allow inertial scrolling on off-canvas panels by adding `-webkit-overflow-scrolling: touch`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e5dec49c832390283d57224f3ecd