### PR TITLE
Move drag toggle into Formaliteter controls

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -979,6 +979,7 @@ function openVehiclePopup(preselectId) {
             <button id="multiPriceBtn" class="char-btn icon" title="Multiplicera pris">💸</button>
             <button id="squareBtn" class="char-btn icon" title="x²">x²</button>
             ${vehicleBtns}
+            <button id="dragToggle" class="char-btn icon" title="Ändra ordning">🔀</button>
             <button id="clearInvBtn" class="char-btn icon danger" title="Rensa inventarie">🧹</button>
           </div>
           <div class="formal-section">
@@ -1105,6 +1106,7 @@ ${moneyRow}
     if (dom.slOut) dom.slOut.textContent = formatWeight(maxCapacity);
     dom.invBadge.textContent    = allInv.reduce((s, r) => s + r.qty, 0);
     dom.unusedOut = $T('unusedOut');
+    dom.dragToggle = $T('dragToggle');
     if (dom.unusedOut) dom.unusedOut.textContent = diffText;
     if (dom.collapseAllBtn) updateCollapseBtnState();
     bindInv();

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -135,7 +135,6 @@ class SharedToolbar extends HTMLElement {
           <h2>Inventarie</h2>
 
           <div class="inv-actions">
-            <button id="dragToggle" class="char-btn icon" title="Ändra ordning">🔀</button>
             <button id="collapseAllInv" class="char-btn icon" title="Kollapsa alla">▶</button>
             <button class="char-btn icon" data-close="invPanel">✕</button>
           </div>


### PR DESCRIPTION
## Summary
- Relocate inventory drag-and-drop toggle into the Formaliteter button group
- Remove old drag toggle from inventory panel header
- Refresh drag toggle reference after rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e41f4ecc83239be50aa33d81a93a