### PR TITLE
Wrap formaliteter buttons on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -548,7 +548,7 @@ select.level {
     padding: .15rem .25rem;
     font-size: .45rem;
   }
-  .inv-buttons { gap: .3rem; flex-wrap: nowrap; }
+  .inv-buttons { gap: .3rem; flex-wrap: wrap; }
   .inv-buttons .char-btn {
     padding: .35rem .6rem;
     font-size: .9rem;


### PR DESCRIPTION
## Summary
- Ensure inventory buttons (including Formaliteter) wrap onto new lines on narrow viewports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5eb7e32908323903b17e9e87f9948