### PR TITLE
Rename app to Symbapedia and show character on index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Symbaroum Companion
+# Symbapedia
 
-A static web app for managing characters and inventory for the Symbaroum RPG. Open `index.html` to browse items and `character.html` to manage a character sheet locally in your browser.
+Symbapedia is a static web app for managing characters and inventory for the Symbaroum RPG. Open `index.html` to browse items and `character.html` to manage a character sheet locally in your browser.
 
 ## Innehåll
 - [Kom igång](#kom-igång)

--- a/character.html
+++ b/character.html
@@ -6,7 +6,7 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">
-  <title>Rollperson</title>
+  <title>Symbapedia - Rollperson</title>
 
   <link rel="stylesheet" href="css/style.css">
   <script src="js/text-format.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">
-  <title>Symbaroum: DA</title>
+  <title>Symbapedia</title>
 
   <link rel="stylesheet" href="css/style.css">
   <script src="js/text-format.js" defer></script>
@@ -30,12 +30,15 @@
 </head>
 <body data-role="index">
 
-  <h1 class="app-title">SYMBAROUM V.18</h1>
+  <h1 class="app-title">Symbapedia</h1>
 
   <div id="activeFilters" class="tags"></div>
 
   <!-- Resultatpanel -->
   <div class="panel">
+    <div class="panel-header">
+      <h2 id="charName" style="margin:0;"></h2>
+    </div>
     <ul id="lista" class="card-list"></ul>
   </div>
 

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1,5 +1,6 @@
 (function(window){
 function initIndex() {
+  dom.cName.textContent = store.characters.find(c=>c.id===store.current)?.name||'';
   const F = { search:[], typ:[], ark:[], test:[] };
   let sTemp = '';
   let union = storeHelper.getFilterUnion(store);

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Symbaroum Companion",
-  "short_name": "Symbaroum",
+  "name": "Symbapedia",
+  "short_name": "Symbapedia",
   "start_url": "index.html",
   "display": "standalone",
   "background_color": "#121416",

--- a/notes.html
+++ b/notes.html
@@ -6,7 +6,7 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">
-  <title>ANTECKNINGAR</title>
+  <title>Symbapedia - Anteckningar</title>
 
   <link rel="stylesheet" href="css/style.css">
   <script src="js/text-format.js" defer></script>

--- a/webapp.html
+++ b/webapp.html
@@ -6,7 +6,7 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">
-  <title>Installera som webapp</title>
+  <title>Symbapedia - Installera som webapp</title>
   <link rel="stylesheet" href="css/style.css">
   <style>
     main { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; }


### PR DESCRIPTION
## Summary
- Rebrand site and web app to **Symbapedia** across manifest and page titles.
- Update index view to display selected character's name like the character view.
- Refresh documentation to reference the new app name.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62b8b3798832393d175da09dcbca6