### PR TITLE
Fix massFreeAndSave not preserving leftover money

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -669,7 +669,11 @@ function openVehiclePopup(preselectId) {
     tot.d += Math.floor(tot.s / SBASE); tot.s %= SBASE;
     const diffO = moneyToO(cash) - (tot.d * SBASE * OBASE + tot.s * OBASE + tot.o);
     const diff  = oToMoney(Math.max(0, diffO));
-    storeHelper.setMoney(store, diff);
+    storeHelper.setMoney(store, {
+      daler: diff.d,
+      skilling: diff.s,
+      'örtegar': diff.o
+    });
 
     flat.forEach(row => {
       row.gratis = row.qty;


### PR DESCRIPTION
## Summary
- Map `oToMoney` result to expected money keys before saving in `massFreeAndSave`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a635a37bf08323af42b9f11437cb18