### PR TITLE
Fix Privilegierad money and center save-free popup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1001,7 +1001,7 @@ select.level {
   width: 100%;
   height: 100%;
   display: none;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
   background: rgba(0,0,0,.6);
   z-index: 3000;
@@ -1010,19 +1010,19 @@ select.level {
 #saveFreePopup .popup-inner {
   background: var(--panel);
   border: 1.5px solid var(--border);
-  border-radius: 1.2rem 1.2rem 0 0;
+  border-radius: 1.2rem;
   box-shadow: var(--shadow);
   padding: 1.5rem 1.4rem 2rem;
   width: 100%;
   max-width: 420px;
   text-align: center;
-  transform: translateY(100%);
+  transform: scale(.8);
   transition: transform .25s ease;
   display: flex;
   flex-direction: column;
   gap: .8rem;
 }
-#saveFreePopup.open .popup-inner { transform: translateY(0); }
+#saveFreePopup.open .popup-inner { transform: scale(1); }
 #saveFreePopup .popup-inner button { width: 100%; }
 #saveFreePopup .confirm-row {
   display: flex;

--- a/js/store.js
+++ b/js/store.js
@@ -103,9 +103,9 @@
 
   /* ---------- 3. Förmåge­lista per karaktär ---------- */
   function getCurrentList(store) {
-    return store.current
-      ? (store.data[store.current]?.list || [])
-      : [];
+    if (!store.current) return [];
+    const list = store.data[store.current]?.list || [];
+    return list.map(x => ({ ...x }));
   }
 
   function applyDarkBloodEffects(list) {


### PR DESCRIPTION
## Summary
- Ensure Privilegierad grants its starting money by cloning current ability list before updates
- Center "Spara och gör allt gratis" popup in viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c8e445708323813c6e631f564d08