### PR TITLE
Replace native alerts with styled popups

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1519,6 +1519,50 @@ select.level {
   overflow-y: auto;
 }
 
+/* ---------- Generell popup-stil ---------- */
+.popup {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 3000;
+}
+.popup.open { display: flex; }
+.popup-bottom { align-items: flex-end; }
+
+/* Rad med två knappar */
+.confirm-row {
+  display: flex;
+  gap: .8rem;
+}
+.confirm-row button {
+  flex: 1;
+  width: auto;
+}
+
+/* Dialog-popup som ersätter alert/confirm */
+#dialogPopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.4rem 2rem;
+  width: 90%;
+  max-width: 420px;
+  text-align: center;
+  transform: scale(.8);
+  transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: .8rem;
+}
+#dialogPopup.open .popup-inner { transform: scale(1); }
+#dialogPopup .popup-inner button { width: 100%; }
+
 /* ---------- Form-grid för anteckningar på karaktärsbladet ---------- */
 .field-row {
   display: flex;

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -478,7 +478,7 @@ function initCharacter() {
   }
 
   /* ta bort & nivåbyte */
-  dom.valda.addEventListener('click',e=>{
+  dom.valda.addEventListener('click', async e=>{
     const conflictBtn = e.target.closest('.conflict-btn');
     if(conflictBtn){
       const currentName = conflictBtn.dataset.name;
@@ -523,14 +523,14 @@ function initCharacter() {
     let list;
         if(actBtn.dataset.act==='add'){
           if(name==='Korruptionskänslig' && before.some(x=>x.namn==='Dvärg')){
-            alert('Dvärgar kan inte ta Korruptionskänslig.');
+            await alertPopup('Dvärgar kan inte ta Korruptionskänslig.');
             return;
           }
           if(!multi) return;
           const cnt = before.filter(x=>x.namn===name && !x.trait).length;
           const limit = storeHelper.monsterStackLimit(before, name);
           if(cnt >= limit){
-            alert(`Denna fördel eller nackdel kan bara tas ${limit} gånger.`);
+            await alertPopup(`Denna fördel eller nackdel kan bara tas ${limit} gånger.`);
             return;
           }
         const lvlSel = liEl.querySelector('select.level');
@@ -554,11 +554,11 @@ function initCharacter() {
             (hamLvl >= 2 && lvl === 'Novis' && ['Naturligt vapen','Pansar'].includes(baseName)) ||
             (hamLvl >= 3 && lvl === 'Novis' && ['Regeneration','Robust'].includes(baseName));
           if(!monsterOk){
-            if(!confirm('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?'))
+            if(!(await confirmPopup('Monstruösa särdrag kan normalt inte väljas. Lägga till ändå?')))
               return;
           }
           if (storeHelper.hamnskifteNoviceLimit(before, p, lvl)) {
-            alert('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
+            await alertPopup('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
             return;
           }
         }
@@ -566,27 +566,27 @@ function initCharacter() {
           const robust=before.find(x=>x.namn==='Robust');
           const hasRobust=!!robust && (robust.nivå===undefined || robust.nivå!=='');
           if(!hasRobust){
-            if(!confirm('Råstyrka kräver Robust på minst Novis-nivå. Lägga till ändå?'))
+            if(!(await confirmPopup('Råstyrka kräver Robust på minst Novis-nivå. Lägga till ändå?')))
               return;
           }
         }
         if(name==='Mörkt förflutet' && before.some(x=>x.namn==='Jordnära')){
-          alert('Jordnära karaktärer kan inte ta Mörkt förflutet.');
+          await alertPopup('Jordnära karaktärer kan inte ta Mörkt förflutet.');
           return;
         }
         list = [...before, { ...p, nivå: lvl }];
         const disAfter = storeHelper.countDisadvantages(list);
         if (disAfter === 5 && disBefore < 5) {
-          alert('Nu har du försökt gamea systemet för mycket, framtida nackdelar ger +0 erfarenhetspoäng');
+          await alertPopup('Nu har du försökt gamea systemet för mycket, framtida nackdelar ger +0 erfarenhetspoäng');
         }
     }else if(actBtn.dataset.act==='rem'){
       if(name==='Bestialisk' && before.some(x=>x.namn==='Mörkt blod')){
-        if(!confirm('Bestialisk hänger ihop med Mörkt blod. Ta bort ändå?'))
+        if(!(await confirmPopup('Bestialisk hänger ihop med Mörkt blod. Ta bort ändå?')))
           return;
       }
       const baseRem = storeHelper.HAMNSKIFTE_BASE[p.namn] || p.namn;
       if(isMonstrousTrait(p) && storeHelper.DARK_BLOOD_TRAITS.includes(baseRem) && before.some(x=>x.namn==='Mörkt blod')){
-        if(!confirm(name+' hänger ihop med Mörkt blod. Ta bort ändå?'))
+        if(!(await confirmPopup(name+' hänger ihop med Mörkt blod. Ta bort ändå?')))
           return;
       }
       if(multi){
@@ -604,11 +604,11 @@ function initCharacter() {
       const removed = before.find(it => it.namn===name && (tr?it.trait===tr:!it.trait));
       const remDeps = storeHelper.getDependents(before, removed);
       if(name==='Mörkt blod' && remDeps.length){
-        if(confirm(`Ta bort även: ${remDeps.join(', ')}?`)){
+        if(await confirmPopup(`Ta bort även: ${remDeps.join(', ')}?`)){
           list = list.filter(x => !remDeps.includes(x.namn));
         }
       } else if(remDeps.length){
-        if(!confirm(`F\u00f6rm\u00e5gan kr\u00e4vs f\u00f6r: ${remDeps.join(', ')}. Ta bort \u00e4nd\u00e5?`)) return;
+        if(!(await confirmPopup(`F\u00f6rm\u00e5gan kr\u00e4vs f\u00f6r: ${remDeps.join(', ')}. Ta bort \u00e4nd\u00e5?`))) return;
       }
       if(eliteReq.canChange(before) && !eliteReq.canChange(list)){
         const deps = before
@@ -618,7 +618,7 @@ function initCharacter() {
         const msg = deps.length
           ? `F\u00f6rm\u00e5gan kr\u00e4vs f\u00f6r: ${deps.join(', ')}. Ta bort \u00e4nd\u00e5?`
           : 'F\u00f6rm\u00e5gan kr\u00e4vs f\u00f6r ett valt elityrke. Ta bort \u00e4nd\u00e5?';
-        if(!confirm(msg))
+        if(!(await confirmPopup(msg)))
           return;
       }
     } else {
@@ -632,7 +632,7 @@ function initCharacter() {
       if (actBtn.dataset.act === 'add') {
         const amount = Math.floor(Math.random() * 10) + 11;
         storeHelper.setPossessionMoney(store, { daler: amount, skilling: 0, 'örtegar': 0 });
-        alert(`Grattis! Din besittning har tjänat dig ${amount} daler!`);
+        await alertPopup(`Grattis! Din besittning har tjänat dig ${amount} daler!`);
       } else {
         storeHelper.setPossessionMoney(store, { daler: 0, skilling: 0, 'örtegar': 0 });
       }
@@ -653,7 +653,7 @@ function initCharacter() {
     renderTraits();
 
   });
-  dom.valda.addEventListener('change',e=>{
+  dom.valda.addEventListener('change', async e=>{
     if(!e.target.matches('select.level')) return;
     const name=e.target.dataset.name;
     const tr=e.target.dataset.trait || e.target.closest('li').dataset.trait || null;
@@ -664,13 +664,13 @@ function initCharacter() {
       const old = ent.nivå;
       ent.nivå=e.target.value;
       if(eliteReq.canChange(before) && !eliteReq.canChange(list)){
-        alert('Förmågan krävs för ett valt elityrke och kan inte ändras.');
+        await alertPopup('Förmågan krävs för ett valt elityrke och kan inte ändras.');
         ent.nivå = old;
         e.target.value = old;
         return;
       }
       if (storeHelper.hamnskifteNoviceLimit(list, ent, ent.nivå)) {
-        alert('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
+        await alertPopup('Särdraget kan inte tas högre än Novis utan Blodvadare eller motsvarande.');
         ent.nivå = old;
         e.target.value = old;
         return;

--- a/js/elite-add.js
+++ b/js/elite-add.js
@@ -3,6 +3,7 @@
     if(document.getElementById('masterPopup')) return;
     const div=document.createElement('div');
     div.id='masterPopup';
+    div.className='popup popup-bottom';
     div.innerHTML=`<div class="popup-inner"><h3 id="masterTitle">V\u00e4lj niv\u00e5</h3><div id="masterOpts"></div><div id="masterBtns"><button id="masterAdd" class="char-btn">L\u00e4gg till</button><button id="masterCancel" class="char-btn danger">Avbryt</button></div></div>`;
     document.body.appendChild(div);
   }
@@ -207,8 +208,8 @@
     return (entry?.taggar?.typ||[]).includes('Ritual');
   }
 
-  function addReq(entry, levels){
-    if(!store.current) return alert('Ingen rollperson vald.');
+  async function addReq(entry, levels){
+    if(!store.current){ await alertPopup('Ingen rollperson vald.'); return; }
     const names=parseNames(entry.krav_formagor||'');
     const listNames = new Set(names);
     if(levels && typeof levels==='object'){
@@ -230,32 +231,32 @@
     storeHelper.setCurrentList(store,list);
   }
 
-  function addElite(entry){
-    if(!store.current) return alert('Ingen rollperson vald.');
+  async function addElite(entry){
+    if(!store.current){ await alertPopup('Ingen rollperson vald.'); return; }
     const list = storeHelper.getCurrentList(store);
     if(list.some(x=>x.namn===entry.namn)) return;
-    if(list.some(isElityrke)){
-      if(!confirm('Du kan bara välja ett elityrke. Lägga till ändå?')) return;
+      if(list.some(isElityrke)){
+      if(!(await confirmPopup('Du kan bara välja ett elityrke. Lägga till ändå?'))) return;
     }
     const res = eliteReq.check(entry, list);
-    if(!res.ok){
+      if(!res.ok){
       const msg = 'Krav ej uppfyllda:\n' +
         (res.missing.length ? 'Saknar: ' + res.missing.join(', ') + '\n' : '') +
         (res.master ? '' : 'Ingen av kraven på Mästare-nivå.\n') +
         'Lägga till ändå?';
-      if(!confirm(msg)) return;
+      if(!(await confirmPopup(msg))) return;
     }
     list.push({ ...entry });
     storeHelper.setCurrentList(store, list);
   }
 
-  function handle(btn){
+  async function handle(btn){
     const name=btn.dataset.eliteReq;
     const entry=DB.find(x=>x.namn===name);
     if(!entry) return;
     const groups=parseGroupRequirements(entry.krav_formagor||'');
     if(!groups.length){
-      addReq(entry); addElite(entry); updateXP(); location.reload(); return;
+      await addReq(entry); await addElite(entry); updateXP(); location.reload(); return;
     }
     openPopup(groups, levels=>{
       if(!levels) return;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1312,7 +1312,7 @@ ${moneyRow}
       }
       return { row: null, parentArr: inv, idx: -1 };
     };
-    dom.invList.onclick = e => {
+    dom.invList.onclick = async e => {
       // 1) Klick på kryss för att ta bort en enskild kvalitet eller gratisstatus
       const removeTagBtn = e.target.closest('.tag.removable');
       if (removeTagBtn) {
@@ -1325,7 +1325,7 @@ ${moneyRow}
             .some(x => x.namn === 'Välutrustad');
           const pg = row.perkGratis || 0;
           if (perkActive && row.perk === 'Välutrustad' && pg > 0) {
-            if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) return;
+            if (!(await confirmPopup('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?'))) return;
           }
           row.gratis = 0;
           if (pg > 0) row.perkGratis = 0;
@@ -1399,7 +1399,7 @@ ${moneyRow}
             .some(x => x.namn === 'Välutrustad');
           const pg = row.perkGratis || 0;
           if (perkActive && row.perk === 'Välutrustad' && pg > 0) {
-            if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) return;
+            if (!(await confirmPopup('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?'))) return;
           }
           const entry  = getEntry(row.name);
           const tagTyp = entry.taggar?.typ || [];
@@ -1467,9 +1467,9 @@ ${moneyRow}
             };
             if (entry.traits && window.maskSkill) {
               const used = inv.filter(it => it.name===entry.namn).map(it=>it.trait).filter(Boolean);
-              maskSkill.pickTrait(used, trait => {
+              maskSkill.pickTrait(used, async trait => {
                 if(!trait) return;
-                if (used.includes(trait) && !confirm('Samma karakt\u00e4rsdrag finns redan. L\u00e4gga till \u00e4nd\u00e5?')) return;
+                if (used.includes(trait) && !(await confirmPopup('Samma karakt\u00e4rsdrag finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
                 addRow(trait);
               });
             } else {
@@ -1486,7 +1486,7 @@ ${moneyRow}
           const pg = row.perkGratis || 0;
           const removingPerkItem = (row.qty - 1) < pg;
           if (perkActive && row.perk === 'Välutrustad' && removingPerkItem) {
-            if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) return;
+            if (!(await confirmPopup('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?'))) return;
           }
           if (row.qty > 1) {
             row.qty--;
@@ -1569,7 +1569,7 @@ ${moneyRow}
             newGratis < (row.gratis || 0) &&
             newGratis < (row.perkGratis || 0)
           ) {
-            if (!confirm('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?')) {
+            if (!(await confirmPopup('Utrustningen kommer från fördelen “Välutrustad”. Ta bort ändå?'))) {
               return;
             }
           }
@@ -1678,8 +1678,8 @@ ${moneyRow}
       const hasAdv = priv.daler || priv.skilling || priv['örtegar'] || pos.daler || pos.skilling || pos['örtegar'];
       if (hasAdv) openAdvMoneyPopup(doReset); else doReset();
     };
-    clearBtn.onclick = () => {
-      if (confirm('Du håller på att tömma hela inventariet, är du säker?')) {
+    clearBtn.onclick = async () => {
+      if (await confirmPopup('Du håller på att tömma hela inventariet, är du säker?')) {
         saveInventory([]);
         renderInventory();
       }

--- a/js/main.js
+++ b/js/main.js
@@ -227,7 +227,7 @@ function bindToolbar() {
   });
 
   /* one–time delegation för alla knappar i toolbar + paneler */
-  bar.shadowRoot.addEventListener('click', e => {
+  bar.shadowRoot.addEventListener('click', async e => {
     const id = e.target.closest('button, a')?.id;
     if (!id) return;
 
@@ -248,7 +248,7 @@ function bindToolbar() {
 
     /* Kopiera rollperson ----------------------------------- */
     if (id === 'duplicateChar') {
-      if (!store.current) return alert('Ingen rollperson vald.');
+      if (!store.current) { await alertPopup('Ingen rollperson vald.'); return; }
       const newId = storeHelper.duplicateCharacter(store, store.current);
       if (newId) {
         store.current = newId;
@@ -259,7 +259,7 @@ function bindToolbar() {
 
     /* Byt namn på rollperson -------------------------------- */
     if (id === 'renameChar') {
-      if (!store.current) return alert('Ingen rollperson vald.');
+      if (!store.current) { await alertPopup('Ingen rollperson vald.'); return; }
       const char = store.characters.find(c => c.id === store.current);
       const newName = prompt('Nytt namn?', char ? char.name : '');
       if (!newName) return;
@@ -270,7 +270,7 @@ function bindToolbar() {
 
     /* Exportera rollperson --------------------------------- */
     if (id === 'exportChar') {
-      if (!store.characters.length) return alert('Inga rollpersoner att exportera.');
+      if (!store.characters.length) { await alertPopup('Inga rollpersoner att exportera.'); return; }
       openExportPopup(async choice => {
         if (choice === 'all') {
           await exportAllCharacters();
@@ -317,10 +317,10 @@ function bindToolbar() {
               if (res) {
                 ok = true;
               } else {
-                alert('Felaktig fil.');
+                await alertPopup('Felaktig fil.');
               }
             } catch {
-              alert('Felaktig fil.');
+              await alertPopup('Felaktig fil.');
             }
           }
           if (ok) {
@@ -328,7 +328,7 @@ function bindToolbar() {
           }
         } catch (err) {
           if (err && err.name !== 'AbortError') {
-            alert('Felaktig fil.');
+            await alertPopup('Felaktig fil.');
           }
         }
       })();
@@ -336,9 +336,9 @@ function bindToolbar() {
 
     /* Ta bort rollperson ----------------------------------- */
     if (id === 'deleteChar') {
-      if (!store.current) return alert('Ingen rollperson vald.');
+      if (!store.current) { await alertPopup('Ingen rollperson vald.'); return; }
       const char = store.characters.find(c => c.id === store.current);
-      if (!confirm(`Ta bort “${char.name}”?`)) return;
+      if (!(await confirmPopup(`Ta bort “${char.name}”?`))) return;
 
       const idToDel = store.current;
       storeHelper.deleteCharacter(store, idToDel);
@@ -572,7 +572,7 @@ async function saveJsonFile(jsonText, suggested) {
       await writable.close();
     } catch (err) {
       if (err && err.name !== 'AbortError') {
-        alert('Sparande misslyckades');
+        await alertPopup('Sparande misslyckades');
       }
     }
   } else {
@@ -729,10 +729,10 @@ function ensureCharacterSelected() {
             if (res) {
               ok = true;
             } else {
-              alert('Felaktig fil.');
+              await alertPopup('Felaktig fil.');
             }
           } catch {
-            alert('Felaktig fil.');
+            await alertPopup('Felaktig fil.');
           }
         }
         if (ok) {

--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -47,8 +47,8 @@
     }
   }
 
-  function cancelEdit(){
-    if(confirm('Nu stängs redigering utan att spara, är du säker?')){
+  async function cancelEdit(){
+    if(await confirmPopup('Nu stängs redigering utan att spara, är du säker?')){
       showView();
     }
   }
@@ -103,8 +103,8 @@
       showView();
     });
 
-    if(clearBtn) clearBtn.onclick = ()=>{
-      if(!isEditing || confirm('Du håller på att sudda ut alla dina anteckningar, är du säker?')){
+    if(clearBtn) clearBtn.onclick = async ()=>{
+      if(!isEditing || await confirmPopup('Du håller på att sudda ut alla dina anteckningar, är du säker?')){
         fields.forEach(id=>{
           const el=form.querySelector('#'+id);
           if(el) el.value='';
@@ -112,8 +112,8 @@
       }
     };
 
-    if(charLink) charLink.addEventListener('click',e=>{
-      if(isEditing && !confirm('Nu stängs redigering utan att spara, är du säker?')){
+    if(charLink) charLink.addEventListener('click',async e=>{
+      if(isEditing && !(await confirmPopup('Nu stängs redigering utan att spara, är du säker?'))){
         e.preventDefault();
       }
     });

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -27,6 +27,9 @@ class SharedToolbar extends HTMLElement {
     const nativeGetElementById = document.getElementById.bind(document);
     document.getElementById = id =>
       nativeGetElementById(id) || this.shadowRoot.getElementById(id);
+
+    window.alertPopup = msg => this.openDialog(msg);
+    window.confirmPopup = msg => this.openDialog(msg, { cancel: true });
   }
 
   /* ------------------------------------------------------- */
@@ -266,7 +269,7 @@ class SharedToolbar extends HTMLElement {
       </aside>
 
       <!-- ---------- Popup Kvalitet ---------- -->
-      <div id="qualPopup">
+      <div id="qualPopup" class="popup">
         <div class="popup-inner">
           <h3 id="qualTitle">Välj kvalitet</h3>
           <div id="qualOptions"></div>
@@ -275,7 +278,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Custom ---------- -->
-      <div id="customPopup">
+      <div id="customPopup" class="popup popup-bottom">
         <div class="popup-inner">
           <h3>Nytt föremål</h3>
           <input id="customName" placeholder="Namn">
@@ -300,7 +303,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Pengar ---------- -->
-      <div id="moneyPopup">
+      <div id="moneyPopup" class="popup popup-bottom">
         <div class="popup-inner">
           <h3>Hantera pengar</h3>
           <div class="money-row">
@@ -316,7 +319,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Spara & Gratis ---------- -->
-      <div id="saveFreePopup">
+      <div id="saveFreePopup" class="popup">
         <div class="popup-inner">
           <p>Du håller på att markera allt i ditt inventarie som gratis och spara dina oanvända pengar som dina enda pengar. Är du säker på att du vill fortsätta?</p>
           <div class="confirm-row">
@@ -327,7 +330,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Varning Fördelspengar ---------- -->
-      <div id="advMoneyPopup">
+      <div id="advMoneyPopup" class="popup">
         <div class="popup-inner">
           <p>Du håller på att ändra pengar du fått från en fördel.</p>
           <div class="confirm-row">
@@ -338,7 +341,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Antal ---------- -->
-      <div id="qtyPopup">
+      <div id="qtyPopup" class="popup popup-bottom">
         <div class="popup-inner">
           <h3>Lägg till antal</h3>
           <input id="qtyInput" type="number" min="1" step="1" placeholder="Antal">
@@ -348,7 +351,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Pris ---------- -->
-      <div id="pricePopup">
+      <div id="pricePopup" class="popup popup-bottom">
         <div class="popup-inner">
           <h3>Multiplicera pris</h3>
           <input id="priceFactor" type="number" step="0.1" placeholder="Faktor">
@@ -359,7 +362,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Färdmedel ---------- -->
-      <div id="vehiclePopup">
+      <div id="vehiclePopup" class="popup popup-bottom">
         <div class="popup-inner">
           <h3>Flytta till färdmedel</h3>
           <select id="vehicleSelect"></select>
@@ -370,7 +373,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Ta bort föremål med innehåll ---------- -->
-      <div id="deleteContainerPopup">
+      <div id="deleteContainerPopup" class="popup popup-bottom">
         <div class="popup-inner">
           <p>Du håller på att ta bort ett föremål som innehåller föremål. Vill du ta bort föremålen i föremålet?</p>
           <button id="deleteContainerAll" class="char-btn danger">Ja, ta bort allt</button>
@@ -380,7 +383,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Alkemistniv\u00e5 ---------- -->
-      <div id="alcPopup">
+      <div id="alcPopup" class="popup popup-bottom">
         <div class="popup-inner">
           <h3>Alkemistniv\u00e5</h3>
           <div id="alcOptions">
@@ -394,7 +397,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Smedsniv\u00e5 ---------- -->
-      <div id="smithPopup">
+      <div id="smithPopup" class="popup popup-bottom">
         <div class="popup-inner">
           <h3>Smedsniv\u00e5</h3>
           <div id="smithOptions">
@@ -408,7 +411,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Artefaktmakarniv\u00e5 ---------- -->
-      <div id="artPopup">
+      <div id="artPopup" class="popup popup-bottom">
         <div class="popup-inner">
           <h3>Artefaktmakarniv\u00e5</h3>
           <div id="artOptions">
@@ -422,7 +425,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Försvarskaraktärsdrag ---------- -->
-      <div id="defensePopup">
+      <div id="defensePopup" class="popup popup-bottom">
         <div class="popup-inner">
           <h3>Försvarskaraktärsdrag</h3>
           <div id="defenseOptions">
@@ -441,7 +444,7 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Popup Export ---------- -->
-      <div id="exportPopup">
+      <div id="exportPopup" class="popup">
         <div class="popup-inner">
           <h3>Exportera</h3>
           <div id="exportOptions"></div>
@@ -450,12 +453,23 @@ class SharedToolbar extends HTMLElement {
       </div>
 
       <!-- ---------- Nilas Popup ---------- -->
-      <div id="nilasPopup">
+      <div id="nilasPopup" class="popup">
         <div class="popup-inner">
           <h3>Nilas \u00e4r b\u00e4st. H\u00e5ller du med?</h3>
           <div class="button-row">
             <button id="nilasNo" class="char-btn">Nej!</button>
             <button id="nilasYes" class="char-btn">Ja!</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- ---------- Dialog Popup ---------- -->
+      <div id="dialogPopup" class="popup">
+        <div class="popup-inner">
+          <p id="dialogMessage"></p>
+          <div class="confirm-row">
+            <button id="dialogCancel" class="char-btn danger">Avbryt</button>
+            <button id="dialogOk" class="char-btn">OK</button>
           </div>
         </div>
       </div>
@@ -574,7 +588,7 @@ class SharedToolbar extends HTMLElement {
     if (path.some(el => toggles.includes(el.id))) return;
 
     // ignore clicks inside popups so panels stay open
-      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','pricePopup','vehiclePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup'];
+      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','pricePopup','vehiclePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup','dialogPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));
@@ -602,6 +616,37 @@ class SharedToolbar extends HTMLElement {
     }
   }
   close(id) { this.panels[id]?.classList.remove('open'); }
+
+  openDialog(message, opts = {}) {
+    const { cancel = false, okText = 'OK', cancelText = 'Avbryt' } = opts;
+    return new Promise(resolve => {
+      const pop   = this.shadowRoot.getElementById('dialogPopup');
+      const msgEl = this.shadowRoot.getElementById('dialogMessage');
+      const okBtn = this.shadowRoot.getElementById('dialogOk');
+      const cancelBtn = this.shadowRoot.getElementById('dialogCancel');
+      msgEl.textContent = message;
+      cancelBtn.style.display = cancel ? '' : 'none';
+      okBtn.textContent = okText;
+      cancelBtn.textContent = cancelText;
+      pop.classList.add('open');
+      pop.querySelector('.popup-inner').scrollTop = 0;
+      const close = res => {
+        pop.classList.remove('open');
+        okBtn.removeEventListener('click', onOk);
+        cancelBtn.removeEventListener('click', onCancel);
+        pop.removeEventListener('click', onOutside);
+        resolve(res);
+      };
+      const onOk = () => close(true);
+      const onCancel = () => close(false);
+      const onOutside = e => {
+        if (!pop.querySelector('.popup-inner').contains(e.target)) close(false);
+      };
+      okBtn.addEventListener('click', onOk);
+      cancelBtn.addEventListener('click', onCancel);
+      pop.addEventListener('click', onOutside);
+    });
+  }
 
   updateToolbarLinks() {
     const role = document.body.dataset.role;


### PR DESCRIPTION
## Summary
- Introduce global `alertPopup` and `confirmPopup` utilities backed by a new dialog popup component
- Add generic popup styles and dialog markup so all modals match site design
- Refactor scripts to use the new async popups instead of browser `alert`/`confirm`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a70c491db08323b90683f2c2dd7ab1