### PR TITLE
feat: highlight dragging cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -250,6 +250,7 @@ input:focus, select:focus, textarea:focus {
   flex-direction: column;
   gap: .45rem;
   position: relative;
+  transition: outline .1s ease, outline-offset .1s ease, box-shadow .1s ease;
 }
 
 .card.vehicle-over {
@@ -266,6 +267,8 @@ input:focus, select:focus, textarea:focus {
 }
 #invList li.card.dragging {
   cursor: grabbing;
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
 }
 
 /* särställ "Formaliteter"-kortet med blå kant */


### PR DESCRIPTION
## Summary
- visually highlight inventory cards while dragging with outline
- add transition to card styling for smoother highlight

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a78b584ab88323aa9b8e1772f36ad6