### PR TITLE
Fix async syntax for index level change

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -772,7 +772,7 @@ function initIndex() {
   });
 
   /* level-byte i listan */
-  dom.lista.addEventListener('change',e=>{
+  dom.lista.addEventListener('change', async e=>{
     if(!e.target.matches('select.level')) return;
     const name = e.target.dataset.name;
     const tr = e.target.closest('li').dataset.trait || null;


### PR DESCRIPTION
## Summary
- Fix missing async keyword in level change handler causing SyntaxError

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a78cdb44308323b295ccb9a2227cad