### PR TITLE
Prevent scrolling behind open menus

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -38,6 +38,10 @@ body {
   align-items: center;
   margin-bottom: 90px;         /* plats för toolbar */
 }
+
+body.menu-open {
+  overflow: hidden;
+}
 shared-toolbar {
   display: block;
 }

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -30,6 +30,30 @@ class SharedToolbar extends HTMLElement {
 
     window.alertPopup = msg => this.openDialog(msg);
     window.confirmPopup = msg => this.openDialog(msg, { cancel: true });
+
+    /* ----- Lås bakgrunds-scroll när panel eller popup är öppen ----- */
+    this.updateScrollLock = () => {
+      const panelOpen = Object.values(this.panels).some(p => p.classList.contains('open'));
+      const shadowPop = this.shadowRoot.querySelector('.popup.open');
+      const docPop = document.querySelector('.popup.open');
+      const anyOpen = panelOpen || shadowPop || docPop;
+      document.body.classList.toggle('menu-open', anyOpen);
+    };
+    window.updateScrollLock = () => this.updateScrollLock();
+
+    const obsCfg = { attributes: true, attributeFilter: ['class'], subtree: true };
+    this._bodyObserver = new MutationObserver(this.updateScrollLock);
+    this._bodyObserver.observe(document.body, obsCfg);
+    this._shadowObserver = new MutationObserver(this.updateScrollLock);
+    this._shadowObserver.observe(this.shadowRoot, obsCfg);
+
+    this.updateScrollLock();
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener('click', this._outsideHandler);
+    this._bodyObserver?.disconnect();
+    this._shadowObserver?.disconnect();
   }
 
   /* ------------------------------------------------------- */

--- a/js/tabell-popup.js
+++ b/js/tabell-popup.js
@@ -26,11 +26,15 @@
     const pop = document.getElementById('tabellPopup');
     pop.classList.add('open');
     pop.querySelector('.popup-inner').scrollTop = 0;
+    window.updateScrollLock?.();
   }
 
   function close(){
     const p = document.getElementById('tabellPopup');
-    if(p) p.classList.remove('open');
+    if(p) {
+      p.classList.remove('open');
+      window.updateScrollLock?.();
+    }
   }
 
   window.tabellPopup = { open, close };


### PR DESCRIPTION
## Summary
- Disable page scroll when offcanvas panels or popups are open
- Observe open state changes to toggle body `menu-open` class automatically
- Ensure table popups also update scroll lock

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d79ab95c8323aed542a9d3030081