### PR TITLE
Add flash animations for inventory updates

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -415,6 +415,21 @@ input:focus, select:focus, textarea:focus {
 #invBadge { background: var(--danger); border-radius: 50%;
             padding: 0 .45rem; font-size: .75rem; margin-left: .25rem; }
 
+/* animation when inventory items change */
+.inv-flash { animation: invFlash .6s ease; }
+@keyframes invFlash {
+  from { background: var(--accent); }
+  to   { background: var(--card); }
+}
+
+/* pulse effect for inventory badge */
+#invBadge.badge-pulse { animation: invBadgePulse .6s ease; }
+@keyframes invBadgePulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(1.3); }
+  100% { transform: scale(1); }
+}
+
 /* XP-räknare i verktygsrad */
 .toolbar .exp-counter {
   display: flex;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1244,6 +1244,8 @@ ${moneyRow}
     if (dom.wtOut) dom.wtOut.textContent = formatWeight(usedWeight);
     if (dom.slOut) dom.slOut.textContent = formatWeight(maxCapacity);
     dom.invBadge.textContent    = allInv.reduce((s, r) => s + r.qty, 0);
+    dom.invBadge.classList.add('badge-pulse');
+    setTimeout(() => dom.invBadge.classList.remove('badge-pulse'), 600);
     dom.unusedOut = $T('unusedOut');
     dom.dragToggle = $T('dragToggle');
     if (dom.unusedOut) dom.unusedOut.textContent = diffText;
@@ -1448,22 +1450,40 @@ ${moneyRow}
             });
             saveInventory(inv);
             renderInventory();
+            bundle.forEach(namn => {
+              const i = inv.findIndex(r => r.name === namn);
+              const li = dom.invList?.querySelector(`li[data-name="${CSS.escape(namn)}"][data-idx="${i}"]`);
+              if (li) {
+                li.classList.add('inv-flash');
+                setTimeout(() => li.classList.remove('inv-flash'), 600);
+              }
+            });
           } else {
             const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakter','Färdmedel'].some(t => entry.taggar.typ.includes(t));
             const addRow = trait => {
               const obj = { name: entry.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
               if (trait) obj.trait = trait;
+              let flashIdx;
               if (indiv) {
                 parentArr.push(obj);
+                flashIdx = parentArr.length - 1;
               } else if (row && (!trait || row.trait === trait)) {
                 row.qty++;
+                flashIdx = idx;
               } else if (row && trait && row.trait !== trait) {
                 parentArr.push(obj);
+                flashIdx = parentArr.length - 1;
               } else {
                 parentArr.push(obj);
+                flashIdx = parentArr.length - 1;
               }
               saveInventory(inv);
               renderInventory();
+              const li = dom.invList?.querySelector(`li[data-name="${CSS.escape(entry.namn)}"][data-idx="${flashIdx}"]`);
+              if (li) {
+                li.classList.add('inv-flash');
+                setTimeout(() => li.classList.remove('inv-flash'), 600);
+              }
             };
             if (entry.traits && window.maskSkill) {
               const used = inv.filter(it => it.name===entry.namn).map(it=>it.trait).filter(Boolean);
@@ -1497,6 +1517,11 @@ ${moneyRow}
           }
           saveInventory(inv);
           renderInventory();
+          const li = dom.invList?.querySelector(`li[data-name="${CSS.escape(itemName)}"][data-idx="${idx}"]`);
+          if (li) {
+            li.classList.add('inv-flash');
+            setTimeout(() => li.classList.remove('inv-flash'), 600);
+          }
         }
         return;
       }


### PR DESCRIPTION
## Summary
- Add `.inv-flash` animation and badge pulse styles
- Flash inventory items on add/sub actions
- Pulse inventory count badge when totals change

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9701bcd3c8323bbdb05f8c4f21186