### PR TITLE
Flash inventory items from index and soften animation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -416,10 +416,11 @@ input:focus, select:focus, textarea:focus {
             padding: 0 .45rem; font-size: .75rem; margin-left: .25rem; }
 
 /* animation when inventory items change */
-.inv-flash { animation: invFlash .6s ease; }
+.inv-flash { animation: invFlash 1s ease-out; }
 @keyframes invFlash {
-  from { background: var(--accent); }
-  to   { background: var(--card); }
+  0% { background: var(--accent); }
+  50% { background: rgba(61, 124, 255, 0.35); }
+  100% { background: var(--card); }
 }
 
 /* pulse effect for inventory badge */

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -433,21 +433,41 @@ function initIndex() {
           });
           invUtil.saveInventory(inv); invUtil.renderInventory();
           renderList(filtered());
+          FALT_BUNDLE.forEach(namn => {
+            const i = inv.findIndex(r => r.name === namn);
+            const li = dom.invList?.querySelector(`li[data-name="${CSS.escape(namn)}"][data-idx="${i}"]`);
+            if (li) {
+              li.classList.add('inv-flash');
+              setTimeout(() => li.classList.remove('inv-flash'), 1000);
+            }
+          });
         } else {
           const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Färdmedel'].some(t=>p.taggar.typ.includes(t));
           const rowBase = { name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
           if (p.artifactEffect) rowBase.artifactEffect = p.artifactEffect;
           const addRow = trait => {
             if (trait) rowBase.trait = trait;
+            let flashIdx;
             if (indiv) {
               inv.push(rowBase);
+              flashIdx = inv.length - 1;
             } else {
               const match = inv.find(x => x.name===p.namn && (!trait || x.trait===trait));
-              if (match) match.qty++;
-              else inv.push(rowBase);
+              if (match) {
+                match.qty++;
+                flashIdx = inv.indexOf(match);
+              } else {
+                inv.push(rowBase);
+                flashIdx = inv.length - 1;
+              }
             }
             invUtil.saveInventory(inv); invUtil.renderInventory();
             renderList(filtered());
+            const li = dom.invList?.querySelector(`li[data-name="${CSS.escape(p.namn)}"][data-idx="${flashIdx}"]`);
+            if (li) {
+              li.classList.add('inv-flash');
+              setTimeout(() => li.classList.remove('inv-flash'), 1000);
+            }
           };
           if (p.traits && window.maskSkill) {
             const used = inv.filter(it => it.name===p.namn).map(it=>it.trait).filter(Boolean);


### PR DESCRIPTION
## Summary
- Flash newly added inventory items when adding from the index view
- Smooth out inventory flash animation with slower fade

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a98636c714832386912504b1eccbb9