### PR TITLE
Lock scroll behind all overlay menus

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -33,10 +33,10 @@ class SharedToolbar extends HTMLElement {
 
     /* ----- Lås bakgrunds-scroll när panel eller popup är öppen ----- */
     this.updateScrollLock = () => {
-      const panelOpen = Object.values(this.panels).some(p => p.classList.contains('open'));
-      const shadowPop = this.shadowRoot.querySelector('.popup.open');
-      const docPop = document.querySelector('.popup.open');
-      const anyOpen = panelOpen || shadowPop || docPop;
+      const selector = '[id$="Panel"].open, [id$="Popup"].open, .popup.open';
+      const docOpen = document.querySelector(selector);
+      const shadowOpen = this.shadowRoot.querySelector(selector);
+      const anyOpen = docOpen || shadowOpen;
       document.body.classList.toggle('menu-open', anyOpen);
     };
     window.updateScrollLock = () => this.updateScrollLock();

--- a/js/yrke-panel.js
+++ b/js/yrke-panel.js
@@ -37,6 +37,7 @@
 
     panel.classList.add('open');
     panel.scrollTop = 0;
+    window.updateScrollLock?.();
     outsideHandler = e => {
       if(!panel.contains(e.target)){
         close();
@@ -47,7 +48,10 @@
 
   function close(){
     const p = document.getElementById('yrkePanel');
-    if(p) p.classList.remove('open');
+    if(p) {
+      p.classList.remove('open');
+      window.updateScrollLock?.();
+    }
     if(outsideHandler){
       document.removeEventListener('click', outsideHandler);
       outsideHandler = null;


### PR DESCRIPTION
## Summary
- Broaden scroll-lock detection to include any open panel or popup across the document or toolbar shadow DOM.
- Trigger scroll lock when `yrkePanel` opens or closes to keep background content fixed.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a986b1b0a0832387f4e902fb83bf08