### PR TITLE
Reduce inventory flash opacity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -418,7 +418,7 @@ input:focus, select:focus, textarea:focus {
 /* animation when inventory items change */
 .inv-flash { animation: invFlash .6s ease-out; }
 @keyframes invFlash {
-  0% { background: rgba(61, 124, 255, 0.5); }
+  0% { background: rgba(61, 124, 255, 0.25); }
   100% { background: var(--card); }
 }
 


### PR DESCRIPTION
## Summary
- Make inventory addition flash more subtle by lowering background opacity to 25%

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a98b7bad8c8323afab6fdae6ed915d