### PR TITLE
Implement add/remove entry flashes and lower flash opacity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -417,8 +417,13 @@ input:focus, select:focus, textarea:focus {
 
 /* animation when inventory items change */
 .inv-flash { animation: invFlash .6s ease-out; }
+.rm-flash { animation: rmFlash .6s ease-out; }
 @keyframes invFlash {
-  0% { background: rgba(61, 124, 255, 0.25); }
+  0% { background: rgba(61, 124, 255, 0.05); }
+  100% { background: var(--card); }
+}
+@keyframes rmFlash {
+  0% { background: rgba(255, 61, 61, 0.05); }
   100% { background: var(--card); }
 }
 

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -39,6 +39,13 @@ function initCharacter() {
     }
   };
 
+  const flashRemoved = li => {
+    if (li) {
+      li.classList.add('rm-flash');
+      setTimeout(() => li.classList.remove('rm-flash'), 1000);
+    }
+  };
+
   function conflictEntryHtml(p){
     const compact = storeHelper.getCompactEntries(store);
     const maxIdx = LVL.indexOf(p.nivå || LVL[0]);
@@ -631,6 +638,8 @@ function initCharacter() {
         if(!(await confirmPopup(msg)))
           return;
       }
+      flashRemoved(liEl);
+      await new Promise(r => setTimeout(r, 100));
     } else {
       return;
     }
@@ -709,6 +718,7 @@ function initCharacter() {
       storeHelper.setCurrentList(store,list); updateXP();
     }
     renderSkills(filtered()); renderTraits();
+    flashAdded(name, tr);
   });
 }
 

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -29,6 +29,17 @@ function initIndex() {
     }
   };
 
+  const flashRemoved = (name, trait) => {
+    const selector = `li[data-name="${CSS.escape(name)}"]${trait ? `[data-trait="${CSS.escape(trait)}"]` : ''}`;
+    const root = dom.lista || document;
+    const items = root.querySelectorAll(selector);
+    const li = items?.[items.length - 1];
+    if (li) {
+      li.classList.add('rm-flash');
+      setTimeout(() => li.classList.remove('rm-flash'), 1000);
+    }
+  };
+
   const tabellInfoHtml = p => {
     const cap = s => s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
     const head = `<tr>${p.kolumner.map(c => `<th>${cap(c)}</th>`).join('')}</tr>`;
@@ -403,6 +414,7 @@ function initIndex() {
       return;
     }
     const name = btn.dataset.name;
+    const tr = btn.closest('li').dataset.trait || null;
     const p  = getEntries().find(x=>x.namn===name);
     const act = btn.dataset.act;
     const lvlSel = btn.closest('li').querySelector('select.level');
@@ -816,6 +828,11 @@ function initIndex() {
     }
     renderList(filtered());
     renderTraits();
+    if (act==='add') {
+      flashAdded(name, tr);
+    } else if (act==='sub' || act==='del' || act==='rem') {
+      flashRemoved(name, tr);
+    }
   });
 
   /* level-byte i listan */
@@ -895,6 +912,8 @@ function initIndex() {
       }
       storeHelper.setCurrentList(store,list); updateXP();
     }
+    renderList(filtered()); renderTraits();
+    flashAdded(name, tr);
   });
 }
 

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1407,6 +1407,8 @@ ${moneyRow}
           const tagTyp = entry.taggar?.typ || [];
           const isVeh  = tagTyp.includes('F\u00e4rdmedel');
           const hasStuff = Array.isArray(row.contains) && row.contains.length > 0;
+          li.classList.add('rm-flash');
+          await new Promise(r => setTimeout(r, 100));
           if (isVeh && hasStuff) {
             openDeleteContainerPopup(
               () => {
@@ -1519,8 +1521,8 @@ ${moneyRow}
           renderInventory();
           const li = dom.invList?.querySelector(`li[data-name="${CSS.escape(itemName)}"][data-idx="${idx}"]`);
           if (li) {
-            li.classList.add('inv-flash');
-            setTimeout(() => li.classList.remove('inv-flash'), 600);
+            li.classList.add('rm-flash');
+            setTimeout(() => li.classList.remove('rm-flash'), 600);
           }
         }
         return;


### PR DESCRIPTION
## Summary
- Lower add flash opacity to 5% and introduce red remove flash
- Flash entries on add, remove, and level changes across views
- Highlight inventory changes with color-coded animations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a75579388323bbb33e1ad74a48f4