### PR TITLE
Include vehicle contents in inventory count

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1303,7 +1303,7 @@ ${moneyRow}
     dom.invList.innerHTML       = formalCard + itemCards;
     if (dom.wtOut) dom.wtOut.textContent = formatWeight(usedWeight);
     if (dom.slOut) dom.slOut.textContent = formatWeight(maxCapacity);
-    dom.invBadge.textContent    = allInv.reduce((s, r) => s + r.qty, 0);
+    dom.invBadge.textContent    = flatInv.reduce((s, r) => s + r.qty, 0);
     dom.invBadge.classList.add('badge-pulse');
     setTimeout(() => dom.invBadge.classList.remove('badge-pulse'), 600);
     dom.unusedOut = $T('unusedOut');


### PR DESCRIPTION
## Summary
- Count items stored inside vehicles when updating the inventory badge

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b6b9c4108323a8511d6d667594fc