### PR TITLE
Add vehicle unload popup matching move popup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1205,7 +1205,8 @@ select.level {
   z-index: 3000;
 }
 #vehiclePopup.open { display: flex; }
-#vehiclePopup .popup-inner {
+#vehiclePopup .popup-inner,
+#vehicleRemovePopup .popup-inner {
   background: var(--panel);
   border: 1.5px solid var(--border);
   border-radius: 1.2rem 1.2rem 0 0;
@@ -1220,7 +1221,8 @@ select.level {
   flex-direction: column;
   gap: .8rem;
 }
-#vehiclePopup.open .popup-inner { transform: translateY(0); }
+#vehiclePopup.open .popup-inner,
+#vehicleRemovePopup.open .popup-inner { transform: translateY(0); }
 #vehiclePopup .popup-inner button,
 #vehicleRemovePopup .popup-inner button { width: 100%; }
 #vehicleItemList,

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -396,10 +396,11 @@ class SharedToolbar extends HTMLElement {
         </div>
       </div>
 
-      <!-- ---------- Popup Töm färdmedel ---------- -->
+      <!-- ---------- Popup Ta ut ur färdmedel ---------- -->
       <div id="vehicleRemovePopup" class="popup popup-bottom">
         <div class="popup-inner">
-          <h3>Ta ur från färdmedel</h3>
+          <h3>Ta ut ur färdmedel</h3>
+          <select id="vehicleRemoveSelect"></select>
           <div id="vehicleRemoveItemList"></div>
           <button id="vehicleRemoveApply" class="char-btn">Verkställ</button>
           <button id="vehicleRemoveCancel" class="char-btn danger">Avbryt</button>


### PR DESCRIPTION
## Summary
- Add "Ta ut ur färdmedel" popup mirroring the existing vehicle move popup
- Implement logic to select vehicles and remove items back to inventory
- Share styling between move and unload popups for consistent look

## Testing
- `node --check js/shared-toolbar.js`
- `node --check js/inventory-utils.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b684c3a0832392ef506a083c9434