### PR TITLE
Add Hafspackare carry capacity and exclusivity

### DIFF
--- a/data/nackdel.json
+++ b/data/nackdel.json
@@ -430,7 +430,7 @@
   {
     "id": "na36",
     "namn": "Hafspackare",
-    "beskrivning": "Remmar ligger snett, vikter hamnar fel och tyngden biter där den inte borde. Orken att organisera och packa effektivt saknas helt. Rollpersonens bärkapacitet räknas ut med Stark*0.5, avrundat uppåt.",
+    "beskrivning": "Remmar ligger snett, vikter hamnar fel och tyngden biter där den inte borde. Orken att organisera och packa effektivt saknas helt. Rollpersonens bärkapacitet beräknas med Stark ×0,5 + 3, avrundat uppåt.",
     "taggar": {
       "typ": ["Nackdel"],
       "test": ["Stark"]

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -591,6 +591,14 @@ function initCharacter() {
           await alertPopup('Jordnära karaktärer kan inte ta Mörkt förflutet.');
           return;
         }
+        if(name==='Packåsna' && before.some(x=>x.namn==='Hafspackare')){
+          await alertPopup('Karaktärer med Hafspackare kan inte ta Packåsna.');
+          return;
+        }
+        if(name==='Hafspackare' && before.some(x=>x.namn==='Packåsna')){
+          await alertPopup('Karaktärer med Packåsna kan inte ta Hafspackare.');
+          return;
+        }
         list = [...before, { ...p, nivå: lvl }];
         const disAfter = storeHelper.countDisadvantages(list);
         if (disAfter === 5 && disBefore < 5) {

--- a/js/store.js
+++ b/js/store.js
@@ -855,8 +855,12 @@ function defaultTraits() {
   function calcCarryCapacity(strength, list) {
     const str = Number(strength || 0);
     let base = str + 3;
-    if (Array.isArray(list) && list.some(e => e.namn === 'Packåsna')) {
-      base = Math.ceil(str * 1.5) + 3;
+    if (Array.isArray(list)) {
+      if (list.some(e => e.namn === 'Packåsna')) {
+        base = Math.ceil(str * 1.5) + 3;
+      } else if (list.some(e => e.namn === 'Hafspackare')) {
+        base = Math.ceil(str * 0.5) + 3;
+      }
     }
     return base;
   }


### PR DESCRIPTION
## Summary
- calculate reduced carry capacity for Hafspackare
- prevent taking Packåsna and Hafspackare together
- document Hafspackare disadvantage rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0e1538f88323b338a20c01bf950b