### PR TITLE
Show experience cost as left-aligned tag

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -311,6 +311,9 @@ input:focus, select:focus, textarea:focus {
   color: var(--subtxt);
   font-weight: 500;
 }
+.tag.xp-cost {
+  font-size: .85rem;
+}
 .conflict-btn {
   padding: .2rem .5rem;
   font-size: 1.1rem;

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -364,9 +364,14 @@ function initCharacter() {
             : `<br><strong>Karaktärsdrag:</strong> ${p.trait}`;
           infoHtml += traitInfo;
         }
-        const tagsHtml = (p.taggar?.typ || [])
-          .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
-          .map(t=>`<span class="tag">${t}</span>`).join(' ');
+        const xpVal = storeHelper.calcEntryXP(p, storeHelper.getCurrentList(store));
+        const xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
+        const xpTag = `<span class="tag xp-cost">Erf: ${xpText}</span>`;
+        const tagsHtml = [xpTag]
+          .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
+          .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
+          .join(' ');
         if (tagsHtml) {
           infoHtml = `<div class="tags">${tagsHtml}</div><br>${infoHtml}`;
         }
@@ -380,9 +385,6 @@ function initCharacter() {
         const total = storeHelper.getCurrentList(store).filter(x=>x.namn===p.namn && !x.trait).length;
         const limit = storeHelper.monsterStackLimit(storeHelper.getCurrentList(store), p.namn);
         const badge = g.count>1 ? ` <span class="count-badge">×${g.count}</span>` : '';
-        const xpVal = storeHelper.calcEntryXP(p, storeHelper.getCurrentList(store));
-        const xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
-        const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
         const activeLvls = LVL.filter((l, i) => i <= LVL.indexOf(p.nivå || LVL[0]) && p.taggar?.handling?.[l]?.includes('Aktiv'));
         const conflictBtn = activeLvls.length
           ? `<button class="char-btn icon conflict-btn" data-name="${p.namn}" title="Aktiva nivåer: ${activeLvls.join(', ')}">💔</button>`
@@ -401,7 +403,7 @@ function initCharacter() {
         const tagsDiv = (!compact && tagsHtml)
           ? `<div class="tags">${tagsHtml}</div>`
           : '';
-        li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span><span class="title-actions">${xpHtml}</span></div>
+        li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span></div>
         ${tagsDiv}
         ${lvlSel}
         ${descHtml}

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -241,9 +241,15 @@ function initIndex() {
             infoHtml += t;
           }
         }
-        const tagsHtml = (p.taggar?.typ || [])
-          .concat(explodeTags(p.taggar?.ark_trad), p.taggar?.test || [])
-          .map(t=>`<span class="tag">${t}</span>`).join(' ');
+        const xpVal = (isInv(p) || isEmployment(p) || isService(p)) ? null : storeHelper.calcEntryXP(p, charList);
+        const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
+        const xpTag = xpVal != null ? `<span class="tag xp-cost">Erf: ${xpText}</span>` : '';
+        const tagsHtml = [xpTag]
+          .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
+          .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
+          .filter(Boolean)
+          .join(' ');
         if (tagsHtml) {
           infoHtml = `<div class="tags">${tagsHtml}</div><br>${infoHtml}`;
         }
@@ -262,10 +268,6 @@ function initIndex() {
         }
         const limit = isInv(p) ? Infinity : storeHelper.monsterStackLimit(charList, p.namn);
         const badge = multi && count>0 ? ` <span class="count-badge">×${count}</span>` : '';
-        const xpVal = (isInv(p) || isEmployment(p) || isService(p)) ? null : storeHelper.calcEntryXP(p, charList);
-        const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
-        const xpHtml = xpVal != null ? `<span class="xp-cost">Erf: ${xpText}</span>` : '';
-        const titleActions = xpHtml ? `<span class="title-actions">${xpHtml}</span>` : '';
         const showInfo = compact || hideDetails;
         const eliteBtn = isElityrke(p)
           ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
@@ -304,7 +306,7 @@ function initIndex() {
         const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
         const priceHtml = priceText ? `<div class="card-price">${priceLabel} ${priceText}</div>` : '';
         li.innerHTML = `
-          <div class="card-title"><span>${p.namn}${badge}</span>${titleActions}</div>
+          <div class="card-title"><span>${p.namn}${badge}</span></div>
           ${tagsDiv}
           ${levelHtml}
           ${descHtml}


### PR DESCRIPTION
## Summary
- Render experience cost as a tag on the left for entry listings.
- Style XP tag to match existing tag appearance.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac594e54248323a35fa341901ce91c