### PR TITLE
Display XP in card headers and simplify info panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -311,6 +311,9 @@ input:focus, select:focus, textarea:focus {
   color: var(--subtxt);
   font-weight: 500;
 }
+.card-title .xp-cost {
+  margin-left: auto;
+}
 .tag.xp-cost {
   font-size: .85rem;
 }

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -367,13 +367,21 @@ function initCharacter() {
         const xpVal = storeHelper.calcEntryXP(p, storeHelper.getCurrentList(store));
         const xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
         const xpTag = `<span class="tag xp-cost">Erf: ${xpText}</span>`;
-        const tagsHtml = [xpTag]
+        const infoTagsHtml = [xpTag]
           .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
           .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
           .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
+          .filter(Boolean)
           .join(' ');
-        if (tagsHtml) {
-          infoHtml = `<div class="tags">${tagsHtml}</div><br>${infoHtml}`;
+        const tagsHtml = []
+          .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
+          .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
+          .filter(Boolean)
+          .join(' ');
+        const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
+        if (infoTagsHtml) {
+          infoHtml = `<div class="tags">${infoTagsHtml}</div><br>${infoHtml}`;
         }
         const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
 
@@ -403,7 +411,7 @@ function initCharacter() {
         const tagsDiv = (!compact && tagsHtml)
           ? `<div class="tags">${tagsHtml}</div>`
           : '';
-        li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span></div>
+        li.innerHTML = `<div class="card-title"><span>${p.namn}${badge}</span>${xpHtml}</div>
         ${tagsDiv}
         ${lvlSel}
         ${descHtml}
@@ -525,8 +533,7 @@ function initCharacter() {
         tabellPopup.open(html, title);
         return;
       }
-      const xpVal = liEl?.dataset.xp ? Number(liEl.dataset.xp) : undefined;
-      yrkePanel.open(title, html, xpVal);
+      yrkePanel.open(title, html);
       return;
     }
     const actBtn=e.target.closest('button[data-act]');

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -244,14 +244,21 @@ function initIndex() {
         const xpVal = (isInv(p) || isEmployment(p) || isService(p)) ? null : storeHelper.calcEntryXP(p, charList);
         const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
         const xpTag = xpVal != null ? `<span class="tag xp-cost">Erf: ${xpText}</span>` : '';
-        const tagsHtml = [xpTag]
+        const infoTagsHtml = [xpTag]
           .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
           .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
           .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
           .filter(Boolean)
           .join(' ');
-        if (tagsHtml) {
-          infoHtml = `<div class="tags">${tagsHtml}</div><br>${infoHtml}`;
+        const tagsHtml = []
+          .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
+          .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
+          .filter(Boolean)
+          .join(' ');
+        const xpHtml = xpVal != null ? `<span class="xp-cost">Erf: ${xpText}</span>` : '';
+        if (infoTagsHtml) {
+          infoHtml = `<div class="tags">${infoTagsHtml}</div><br>${infoHtml}`;
         }
         const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}">Info</button>`;
         const multi = isInv(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
@@ -306,7 +313,7 @@ function initIndex() {
         const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
         const priceHtml = priceText ? `<div class="card-price">${priceLabel} ${priceText}</div>` : '';
         li.innerHTML = `
-          <div class="card-title"><span>${p.namn}${badge}</span></div>
+          <div class="card-title"><span>${p.namn}${badge}</span>${xpHtml}</div>
           ${tagsDiv}
           ${levelHtml}
           ${descHtml}
@@ -422,8 +429,7 @@ function initIndex() {
         tabellPopup.open(html, title);
         return;
       }
-      const xpVal = liEl?.dataset.xp != null ? Number(liEl.dataset.xp) : undefined;
-      yrkePanel.open(title,html,xpVal);
+      yrkePanel.open(title, html);
       return;
     }
     const btn=e.target.closest('button[data-act]');

--- a/js/yrke-panel.js
+++ b/js/yrke-panel.js
@@ -6,7 +6,6 @@
     panel.id = 'yrkePanel';
     panel.innerHTML = `
       <header class="inv-header">
-        <div class="inv-actions"><span id="yrkeXp" class="xp-cost"></span></div>
         <h2 id="yrkeTitle"></h2>
         <div class="inv-actions"><button id="yrkeClose" class="char-btn icon">✕</button></div>
       </header>
@@ -16,17 +15,9 @@
     panel.querySelector('#yrkeClose').addEventListener('click', close);
   }
 
-  function open(title, html, xp){
+  function open(title, html){
     create();
     document.getElementById('yrkeTitle').textContent = title || '';
-    const xpEl = document.getElementById('yrkeXp');
-    if (xpEl) {
-      if (xp === undefined || xp === null) xpEl.textContent = '';
-      else {
-        const xpText = xp < 0 ? `+${-xp}` : xp;
-        xpEl.textContent = `Erf: ${xpText}`;
-      }
-    }
     document.getElementById('yrkeContent').innerHTML = html || '';
     const panel = document.getElementById('yrkePanel');
 


### PR DESCRIPTION
## Summary
- Move XP cost display out of tag lists and into card headers in index and character views
- Drop XP from slide-in panel header and adjust API accordingly
- Style XP cost in headers for right alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc1b517908323bd810516df3b3d5a