### PR TITLE
Fix back button behaviour for menu overlays

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -60,7 +60,8 @@
     if (el) {
       isPop = true;
       el.classList.remove('open');
-      isPop = false;
+      // Vänta tills MutationObserver hunnit reagera innan flaggan återställs
+      setTimeout(() => { isPop = false; });
     }
   });
 })();


### PR DESCRIPTION
## Summary
- Keep `isPop` true until mutation observers handle overlay close

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc1fd9a848323a25e589ff4ac2c4d