### PR TITLE
Fix XP indicator update in index view

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -241,7 +241,9 @@ function initIndex() {
             infoHtml += t;
           }
         }
-        const xpVal = (isInv(p) || isEmployment(p) || isService(p)) ? null : storeHelper.calcEntryXP(p, charList);
+        const charEntry = charList.find(c => c.namn === p.namn);
+        const xpSource = charEntry ? charEntry : { ...p, nivå: curLvl };
+        const xpVal = (isInv(p) || isEmployment(p) || isService(p)) ? null : storeHelper.calcEntryXP(xpSource, charList);
         const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
         const xpTag = xpVal != null ? `<span class="tag xp-cost">Erf: ${xpText}</span>` : '';
         const infoTagsHtml = [xpTag]


### PR DESCRIPTION
## Summary
- ensure XP cost in index view uses character's current level when calculating

## Testing
- `node --check js/index-view.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc4684fa0832396f5aaf18f9f9ef4