### PR TITLE
Allow level selection with XP update in index

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -938,9 +938,29 @@ function initIndex() {
         storeHelper.setHamnskifteRemoved(store, rem);
       }
       storeHelper.setCurrentList(store,list); updateXP();
+      renderList(filtered()); renderTraits();
+      flashAdded(name, tr);
+      return;
     }
-    renderList(filtered()); renderTraits();
-    flashAdded(name, tr);
+
+    /* uppdatera pris om förmågan inte lagts till */
+    const p = getEntries().find(x=>x.namn===name);
+    if(!p) return;
+    const lvl = e.target.value;
+    const xpVal = (isInv(p) || isEmployment(p) || isService(p))
+      ? null
+      : storeHelper.calcEntryXP({ ...p, nivå:lvl }, list);
+    const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
+    const liEl = e.target.closest('li');
+    if (xpVal != null) liEl.dataset.xp = xpVal; else delete liEl.dataset.xp;
+    const xpSpan = liEl.querySelector('.card-title .xp-cost');
+    if (xpSpan) xpSpan.textContent = `Erf: ${xpText}`;
+    const infoBtn = liEl.querySelector('button[data-info]');
+    if (infoBtn?.dataset.info) {
+      const infoHtml = decodeURIComponent(infoBtn.dataset.info);
+      const newInfo = infoHtml.replace(/(<span class="tag xp-cost">Erf: )[^<]*/, `$1${xpText}`);
+      infoBtn.dataset.info = encodeURIComponent(newInfo);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Update index view to let users change ability levels before adding them to a character
- Adjust XP cost preview in index when level changes, keeping info popups consistent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc73df23c832390f13dc05395c896