### PR TITLE
Clean up artefact descriptions

### DIFF
--- a/data/artefakter.json
+++ b/data/artefakter.json
@@ -1,554 +1,553 @@
-[{
-  "id": "ar01",
-  "namn": "Opadias ormstav",
-  "beskrivning": "Den ormhövdade runstav som nyligen försvann från Ordo Magicas kapitel i Tistla Fäste sägs ha tillhört Opadia, en nu avliden stavmagiker – mäktiga magiker som enligt legenden verkade som livvakter åt den siste symbariske kejsaren. Opadia var bekant med Lasifor Nattbäcka och levde en tid i Tistla Fäste. Hon stupade i strid mot anfallande alver och staven såldes till Ordo Magica, varifrån den alltså har försvunnit.",
-  "kvalitet": [
-    "Trubbigt"
-  ],
-  "taggar": {
-    "typ": [
-      "Artefakt",
-      "Vapen"
+[
+  {
+    "id": "ar01",
+    "namn": "Opadias ormstav",
+    "beskrivning": "Den ormhövdade runstav som nyligen försvann från Ordo Magicas kapitel i Tistla Fäste sägs ha tillhört Opadia, en nu avliden stavmagiker – mäktiga magiker som enligt legenden verkade som livvakter åt den siste symbariske kejsaren. Opadia var bekant med Lasifor Nattbäcka och levde en tid i Tistla Fäste. Hon stupade i strid mot anfallande alver och staven såldes till Ordo Magica, varifrån den alltså har försvunnit.",
+    "kvalitet": [
+      "Trubbigt"
     ],
-    "handling": {
-      "Förmåga 1": [
-        "Reaktiv"
+    "taggar": {
+      "typ": [
+        "Artefakt",
+        "Vapen"
       ],
-      "Förmåga 2": [
-        "Aktiv"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Reaktiv"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Stavbett. Den som bundit staven till sig kan låta den bita giftigt vid träff i närstrid. Stavslaget måste orsaka skada för att giftet ska verka. Giftet är medelstarkt och ger 1T6 skada i 1T6 rundor. Handling: Reaktiv. Korruption: 1T4.",
+      "Förmåga 2": "Bitande fjättrar. Om bäraren har förmågan Stångverkan kan staven användas mot ett offer i närstrid som träffas automatiskt. Staven slingrar sig runt offret och biter det varje runda. Bäraren måste klara [Viljestark←Stark] varje runda för att greppet ska hållas kvar. Offret får agera men drabbas av en bettattack varje runda, 1T6 i skada. Om skadan penetrerar rustning aktiveras ett gift (1T6 skada i 1T6 rundor). Giftet verkar endast en gång, men betten fortsätter. Om offret kommer loss faller staven till marken och återgår till att vara en runstav. Handling: Aktiv. Korruption: 1T6."
+    },
+    "stat": {
+      "skada": "1T8",
+      "vikt": 1.5
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Stavbett. Den som bundit staven till sig kan låta den bita giftigt vid träff i närstrid. Stavslaget måste orsaka skada för att giftet ska verka. Giftet är medelstarkt och ger 1T6 skada i 1T6 rundor. Handling: Reaktiv. Korruption: 1T4.",
-    "Förmåga 2": "Bitande fjättrar. Om bäraren har förmågan Stångverkan kan staven användas mot ett offer i närstrid som träffas automatiskt. Staven slingrar sig runt offret och biter det varje runda. Bäraren måste klara [Viljestark←Stark] varje runda för att greppet ska hållas kvar. Offret får agera men drabbas av en bettattack varje runda, 1T6 i skada. Om skadan penetrerar rustning aktiveras ett gift (1T6 skada i 1T6 rundor). Giftet verkar endast en gång, men betten fortsätter. Om offret kommer loss faller staven till marken och återgår till att vara en runstav. Handling: Aktiv. Korruption: 1T6."
-  },
-  "stat": {
-    "skada": "1T8",
-    "vikt": 1.5
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar02",
-  "namn": "Skymningsvatten",
-  "beskrivning": "Skymningsvatten är ett exempel på en artefakt som spelledaren kan använda i något av sina egna äventyr, och med den som inspiration kan spelledaren även utveckla egna mytiska eller mystiska föremål. Just skymningsvatten sägs ha skapats för första gången på ett slagfält under Det stora kriget, just innan Mörkermästarnas horder skulle välla in i Alberetor. Numera skapas det av Prios högsta präster och skickligaste teurger i samband med sommarsolståndet.\nNär den döende solens sista strålar flödar genom ljusgården i Tempelvalls mäktiga katedral fångas det i de heliga gråterskornas tårar, för att därefter droppas i en kristallflaska, helgad för ändamålet. Endast en sådan flaska skapas per år och dess kraft innehåller Prios välsignelse och dom, destillerad till en handfull droppar.\nDetta ljusbringande elixir sägs kunna bota sjukdomar, skrämma styggelser och – om flaskan krossas – förbränna det oheliga från förbannade platser. Skymningsvattnet går förstås inte att köpa eller tillskansa sig genom förhandlingar, utan föräras alltid kyrkans mest trogna tjänare inför viktiga uppdrag. Det är däremot möjligt att en eller annan flaska har kommit på avvägar sedan ljusets förkämpar fallit i strid mot mörkret.\nDet heliga skymningsvattnet går inte att binda till sig med korruption, det krävs ett permanent Erfarenhet för att komma i åtnjutande av vattnets kraft. Rollpersoner som binder sig till vattnet tar direkt skada, 1t4 per poäng av permanent korruption de besitter. Om rollpersonen går ner till 0 Tålighet förbränns rollpersonen till en hög med aska – här gäller inte regeln om dödsslag! Rollpersoner med permanent Korruption får slå ett slag för [Vaksam -permanent Korruption] för att inse att vattnet kommer att döma dem hårt. Vattnet bränner också bort den permanenta Korruption rollpersonen har.\nSkymningsvatten har därtill följande egenskaper och krafter:",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Fri"
+  {
+    "id": "ar02",
+    "namn": "Skymningsvatten",
+    "beskrivning": "Skymningsvatten är ett exempel på en artefakt som spelledaren kan använda i något av sina egna äventyr, och med den som inspiration kan spelledaren även utveckla egna mytiska eller mystiska föremål. Just skymningsvatten sägs ha skapats för första gången på ett slagfält under Det stora kriget, just innan Mörkermästarnas horder skulle välla in i Alberetor. Numera skapas det av Prios högsta präster och skickligaste teurger i samband med sommarsolståndet. När den döende solens sista strålar flödar genom ljusgården i Tempelvalls mäktiga katedral fångas det i de heliga gråterskornas tårar, för att därefter droppas i en kristallflaska, helgad för ändamålet. Endast en sådan flaska skapas per år och dess kraft innehåller Prios välsignelse och dom, destillerad till en handfull droppar. Detta ljusbringande elixir sägs kunna bota sjukdomar, skrämma styggelser och – om flaskan krossas – förbränna det oheliga från förbannade platser. Skymningsvattnet går förstås inte att köpa eller tillskansa sig genom förhandlingar, utan föräras alltid kyrkans mest trogna tjänare inför viktiga uppdrag. Det är däremot möjligt att en eller annan flaska har kommit på avvägar sedan ljusets förkämpar fallit i strid mot mörkret. Det heliga skymningsvattnet går inte att binda till sig med korruption, det krävs ett permanent Erfarenhet för att komma i åtnjutande av vattnets kraft. Rollpersoner som binder sig till vattnet tar direkt skada, 1t4 per poäng av permanent korruption de besitter. Om rollpersonen går ner till 0 Tålighet förbränns rollpersonen till en hög med aska – här gäller inte regeln om dödsslag! Rollpersoner med permanent Korruption får slå ett slag för [Vaksam -permanent Korruption] för att inse att vattnet kommer att döma dem hårt. Vattnet bränner också bort den permanenta Korruption rollpersonen har. Skymningsvatten har därtill följande egenskaper och krafter:",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 2": [
-        "Aktiv"
-      ],
-      "Förmåga 3": [
-        "Reaktiv"
-      ],
-      "Förmåga 4": [
-        "Fri"
-      ],
-      "Förmåga 5": [
-        "Automatisk"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Fri"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ],
+        "Förmåga 3": [
+          "Reaktiv"
+        ],
+        "Förmåga 4": [
+          "Fri"
+        ],
+        "Förmåga 5": [
+          "Automatisk"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Solens sken. I handen på den som underkastat sig ljuset och bundit det till sig kan flaskan flamma upp med solens ljuskraft, så att omgivningen badar i ljus likt en molnfri dag med solen mitt på himlen. Handling: Fri. Korruption: Ingen.",
+      "Förmåga 2": "Solens droppar. Flaskan innehåller 1t10 droppar heligt ljusvatten, vilka kan droppas på en sjuk eller skadad person och bota denne. Varje droppe gör allt nedanstående när det droppas på en varelse. När alla droppar har använts är flaskan tom och Prios ljus borta. ◆ Helar 1t10 Tålighet ◆ Fungerar som ett medelstarkt motgift ◆ Renar ett poäng permanent Korruption ◆ Ger varelsen dess Korruption i skada, om den har någon sådan. Handling: Aktiv. Korruption: Ingen.",
+      "Förmåga 3": "Helig synergi. Den som har bundit skymningsvattnet till sig kan använda dess ljus för att förstärka teurgiska krafter. Dessa får sin effekttärning höjd ett steg. Synergin kan göras en gång per scen. Handling: Reaktiv. Korruption: Ingen.",
+      "Förmåga 4": "Ljusbringarens rättarting. Den som underkastat sig skymningsvattnet kan med en tanke krossa flaskan och släppa lös dess dömande ljus. Alla närvarande varelser med minst ett (1) i Korruption tar sin Korruption i skada, medan varelser som tillhör kategorin styggelser tar 1t10 + 10 i skada. Detta drabbar såklart även bäraren själv. Handling: Fri. Korruption: Ingen.",
+      "Förmåga 5": "Skinande undergång. Om den som bär och som har bundit skymningsvatten till sig någonsin blir styggelsemärkt detonerar flaskan, med samma effekt som för kraften Ljusbringarens rättarting."
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 1
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Solens sken. I handen på den som underkastat sig ljuset och bundit det till sig kan flaskan flamma upp med solens ljuskraft, så att omgivningen badar i ljus likt en molnfri dag med solen mitt på himlen. Handling: Fri. Korruption: Ingen.",
-    "Förmåga 2": "Solens droppar. Flaskan innehåller 1t10 droppar heligt ljusvatten, vilka kan droppas på en sjuk eller skadad person och bota denne. Varje droppe gör allt nedanstående när det droppas på en varelse. När alla droppar har använts är flaskan tom och Prios ljus borta.\n◆ Helar 1t10 Tålighet\n◆ Fungerar som ett medelstarkt motgift\n◆ Renar ett poäng permanent Korruption\n◆ Ger varelsen dess Korruption i skada, om den har någon sådan.\nHandling: Aktiv. Korruption: Ingen.",
-    "Förmåga 3": "Helig synergi. Den som har bundit skymningsvattnet till sig kan använda dess ljus för att förstärka teurgiska krafter. Dessa får sin effekttärning höjd ett steg. Synergin kan göras en gång per scen. Handling: Reaktiv. Korruption: Ingen.",
-    "Förmåga 4": "Ljusbringarens rättarting. Den som underkastat sig skymningsvattnet kan med en tanke krossa flaskan och släppa lös dess dömande ljus. Alla närvarande varelser med minst ett (1) i Korruption tar sin Korruption i skada, medan varelser som tillhör kategorin styggelser tar 1t10 + 10 i skada. Detta drabbar såklart även bäraren själv. Handling: Fri. Korruption: Ingen.",
-    "Förmåga 5": "Skinande undergång. Om den som bär och som har bundit skymningsvatten till sig någonsin blir styggelsemärkt detonerar flaskan, med samma effekt som för kraften Ljusbringarens rättarting."
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 1
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar03",
-  "namn": "Eldstenen",
-  "beskrivning": "Forntida ordensmagiker har bundit en yster eldsjäl i stenen. Vanligen glöder den endast med ett svagt ljus och genererar en svag värme (nog för att värma den som bär den en kall vinterdag). Den som binder stenen till sig kan väcka eldens ande och få den att göra mer dramatiska saker.\nFöljande saker kan göras med eldstenen:",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Aktiv"
+  {
+    "id": "ar03",
+    "namn": "Eldstenen",
+    "beskrivning": "Forntida ordensmagiker har bundit en yster eldsjäl i stenen. Vanligen glöder den endast med ett svagt ljus och genererar en svag värme (nog för att värma den som bär den en kall vinterdag). Den som binder stenen till sig kan väcka eldens ande och få den att göra mer dramatiska saker. Följande saker kan göras med eldstenen:",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 2": [
-        "Fri"
-      ],
-      "Förmåga 3": [
-        "Aktiv"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Aktiv"
+        ],
+        "Förmåga 2": [
+          "Fri"
+        ],
+        "Förmåga 3": [
+          "Aktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Slå med eld. Eldstenens herre kan med ett lyckat Viljestark få eldstenens hjälp att sätta eld på något brännbart inom synhåll – inklusive plagg på en fiende. Elden brinner 1t4 rundor och gör 1t4 i skada per runda. Rustning skyddar som vanligt. En brinnande varelse kan släcka elden genom att rulla runt på marken (förflyttningshandling) och lyckas med ett Kvick. Handling: Aktiv. Korruption: 1T4.",
+      "Förmåga 2": "Förstärka flamma. Om eldstenens herre behärskar krafter som producerar eld kan denne med ett lyckat Viljestark använda eldstenens till att förstärka en av sina eldbesvärjelser. Effekttärningen ökas ett steg (ex från 1t6 till 1t8, eller med +1 om den redan är 1t12). Handling: Fri. Korruption: 1T4.",
+      "Förmåga 3": "Eldens ande. Eldstenens herre kan med ett lyckat Viljestark krossa eldstenen och släppa loss den fångade eldanden. Detta förstör också eldstenen. Eldanden manifesteras som en reslig människoskepnad av flammor och sot. Den är tacksam mot mästaren och lyder denne under resten av scenen. Anden kan ges enkla kommandon (fria handlingar) som ”vakta den här platsen”, ”anfall den där fienden” eller ”skydda mig”. Handling: Aktiv. Korruption: 1T6. eldenS ande Motstånd Utmanande Särdrag Andeform (II), Naturlig vapen (III) Diskret 5 (+5), Kvick 13 (−3) Listig 10 (0), Stark 11 (−1), Träffsäker 15 (−5), Vaksam 10 (0), Viljestark 9 (+1), Övertygande 7 (+3) Förmågor Naturlig krigare (III) Beväpning Brinnande omfamning 9 (Långt), två attacker mot samma mål Rustning Ingen (tar halv skada av attacker) Försvar −3 (Undvika) Tålighet 11 Smärtgräns 6"
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 0.5
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Slå med eld. Eldstenens herre kan med ett lyckat Viljestark få eldstenens hjälp att sätta eld på något brännbart inom synhåll – inklusive plagg på en fiende. Elden brinner 1t4 rundor och gör 1t4 i skada per runda. Rustning skyddar som vanligt. En brinnande varelse kan släcka elden genom att rulla runt på marken (förflyttningshandling) och lyckas med ett Kvick. Handling: Aktiv. Korruption: 1T4.",
-    "Förmåga 2": "Förstärka flamma. Om eldstenens herre behärskar krafter som pro-\nducerar eld kan denne med ett lyckat Viljestark använda eldstenens till att förstärka en av sina eldbesvärjelser. Effekttärningen ökas ett steg (ex från 1t6 till 1t8, eller med +1 om den redan är 1t12). Handling: Fri. Korruption: 1T4.",
-    "Förmåga 3": "Eldens ande. Eldstenens herre kan med ett lyckat Viljestark krossa eldstenen och släppa loss den fångade eldanden. Detta förstör också eldstenen. Eldanden manifesteras som en reslig människoskepnad av flammor och sot. Den är tacksam mot mästaren och lyder denne under resten av scenen. Anden kan ges enkla kommandon (fria handlingar) som ”vakta den här platsen”, ”anfall den där fienden” eller ”skydda mig”. Handling: Aktiv. Korruption: 1T6.\n\neldenS ande\nMotstånd Utmanande\nSärdrag Andeform (II), Naturlig vapen (III)\nDiskret 5 (+5), Kvick 13 (−3) Listig 10 (0),\nStark 11 (−1), Träffsäker 15 (−5), Vaksam 10 (0),\nViljestark 9 (+1), Övertygande 7 (+3)\nFörmågor Naturlig krigare (III)\nBeväpning Brinnande omfamning 9 (Långt), två attacker mot samma mål\nRustning Ingen (tar halv skada av attacker)\nFörsvar −3 (Undvika)\nTålighet 11 Smärtgräns 6"
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 0.5
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-
-{
-  "id": "ar04",
-  "namn": "Eldreds fyrfat",
-  "beskrivning": "eldreds fyrfat, artefakt\nI en sällan berättad legend om den Symbariska\nstaden Dakovak figurerar mystikern och förhörs-\nledaren Eldred, eller möjligen Eloderad. Det påstås\natt denne kunde tvinga fram sanningen ur vem\nsom helst, även sanningar om sådant som upp-\ngiftslämnaren har förträngt, glömt eller tvingats\natt glömma. Den som binder sig till detta fyrfat får\ntillgång till mystikerns hemlighet.atet är av sprucken keramik med invävda järntrå-\ndar, stort som en vanlig sopptallrik. Vid användning\nmåste oljan vara antänd och mästaren själv hålla art-\nefakten i sina kupade händer, och det är även denne\nsom drabbas av korruption när krafterna aktiveras.",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Hel runda"
+  {
+    "id": "ar04",
+    "namn": "Eldreds fyrfat",
+    "beskrivning": "eldreds fyrfat, artefakt I en sällan berättad legend om den Symbariska staden Dakovak figurerar mystikern och förhörsledaren Eldred, eller möjligen Eloderad. Det påstås att denne kunde tvinga fram sanningen ur vem som helst, även sanningar om sådant som uppgiftslämnaren har förträngt, glömt eller tvingats att glömma. Den som binder sig till detta fyrfat får tillgång till mystikerns hemlighet.atet är av sprucken keramik med invävda järntrådar, stort som en vanlig sopptallrik. Vid användning måste oljan vara antänd och mästaren själv hålla artefakten i sina kupade händer, och det är även denne som drabbas av korruption när krafterna aktiveras.",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 2": [
-        "Hel runda"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Hel runda"
+        ],
+        "Förmåga 2": [
+          "Hel runda"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Lögnarens dom. Mästaren kan ställa en fråga (öppen eller ja/nej) till en utvald person. När denne har levererat sitt svar förs eller tvingas dess hand in i lågan. Om personen inte talade sanning bränns denne svårt (1t4 i skada); annars känns elden bara sval och behaglig. Handling: Hel runda. Korruption: 1T4.",
+      "Förmåga 2": "Minnesväckare. Mästaren kan använda fyrfatets eld för att väcka glömda eller förträngda minnen hos en annan person, som svar på en fråga eller en uppmaning att beskriva en viss situation eller händelse. Personen för in handen i elden och tar skada (1t4) men kommer sedan att minnas händelsen/svaret med full klarhet. Handling: Hel runda. Korruption: 1T4."
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 1
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Lögnarens dom. Mästaren kan ställa en fråga\n(öppen eller ja/nej) till en utvald person. När denne\nhar levererat sitt svar förs eller tvingas dess hand\nin i lågan. Om personen inte talade sanning bränns\ndenne svårt (1t4 i skada); annars känns elden bara\nsval och behaglig.\nHandling: Hel runda. Korruption: 1T4.",
-    "Förmåga 2": "Minnesväckare. Mästaren kan använda fyr-\nfatets eld för att väcka glömda eller förträngda\nminnen hos en annan person, som svar på en fråga\neller en uppmaning att beskriva en viss situation\neller händelse. Personen för in handen i elden och\ntar skada (1t4) men kommer sedan att minnas\nhändelsen/svaret med full klarhet.\nHandling: Hel runda. Korruption: 1T4."
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 1
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar05",
-  "namn": "Algsar-Maras kätting",
-  "beskrivning": "algsar-maras kätting, artefakt\nAlgsar-Mara omnämns såvitt känt bara i en enda\nstrof, tillskriven Aroaleta, och då endast med hän-\nvisning till dennes bakslughet, mordiska sinnelag\noch ”bitande kätting”. Vem han eller hon var och\nvad som gör denne förtjänt av omnämnandet är ett\nlika stort mysterium som frågan om huruvida just\ndenna kätting var hans. Eller hennes.\nKättingen med sina tunna men urstarka länkar\när nära två meter lång och väger inte mer än ett\nmotsvarande rep. Den tycks vara ingjuten med en\nhungrande eller rent av svulten makt. Vid sidan\nom nedanstående krafter kan den svingas som en\nLångpiska (ledat, snärjande och djupverkande).",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt",
-      "Vapen"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Aktiv"
+  {
+    "id": "ar05",
+    "namn": "Algsar-Maras kätting",
+    "beskrivning": "algsar-maras kätting, artefakt Algsar-Mara omnämns såvitt känt bara i en enda strof, tillskriven Aroaleta, och då endast med hänvisning till dennes bakslughet, mordiska sinnelag och ”bitande kätting”. Vem han eller hon var och vad som gör denne förtjänt av omnämnandet är ett lika stort mysterium som frågan om huruvida just denna kätting var hans. Eller hennes. Kättingen med sina tunna men urstarka länkar är nära två meter lång och väger inte mer än ett motsvarande rep. Den tycks vara ingjuten med en hungrande eller rent av svulten makt. Vid sidan om nedanstående krafter kan den svingas som en Långpiska (ledat, snärjande och djupverkande).",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt",
+        "Vapen"
       ],
-      "Förmåga 2": [
-        "Aktiv"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Aktiv"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Omslingra. Den som har bundit sig till kättingen kan med ett lyckat anfallsslag kasta artefakten mot en fiende som den har Övertag emot. Oavsett hur den kastas snärjer sig kättingen blixtsnabbt kring offret och hindrar dess rörelser totalt under följande runda. Därefter krävs det ett slag mot [10←Stark] varje runda för att vidmakthålla effekten; misslyckas slaget sliter sig fienden fri. Handling: Aktiv. Korruption: 1T4.",
+      "Förmåga 2": "Krypande fälla. Artefaktens mästare kan placera den som en levande fälla som täcker av ett större område (en palatsruin, en skogsdunge eller området kring en lägerplats). Kättingen kommer automatiskt att söka sig till annalkande varelser, undantaget sådana som sedan tidigare har varit i kontakt med den, och snärja sig kring dem som ovan (max två inom närstridsavstånd från varandra). Kättingens rasslande är ljudligt nog för att varsko mästaren även om denne sover [Vaksam]. Handling: Aktiv. Korruption: 1T4."
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 1.5
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Omslingra. Den som har bundit sig till kättingen\nkan med ett lyckat anfallsslag kasta artefakten\nmot en fiende som den har Övertag emot. Oavsett\nhur den kastas snärjer sig kättingen blixtsnabbt\nkring offret och hindrar dess rörelser totalt\nunder följande runda. Därefter krävs det ett slag\nmot [10←Stark] varje runda för att vidmakthålla\neffekten; misslyckas slaget sliter sig fienden fri.\nHandling: Aktiv. Korruption: 1T4.",
-    "Förmåga 2": "Krypande fälla. Artefaktens mästare kan pla-\ncera den som en levande fälla som täcker av ett\nstörre område (en palatsruin, en skogsdunge eller\nområdet kring en lägerplats). Kättingen kommer\nautomatiskt att söka sig till annalkande varelser,\nundantaget sådana som sedan tidigare har varit i\nkontakt med den, och snärja sig kring dem som ovan\n(max två inom närstridsavstånd från varandra).\nKättingens rasslande är ljudligt nog för att varsko\nmästaren även om denne sover [Vaksam].\nHandling: Aktiv. Korruption: 1T4."
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 1.5
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar06",
-  "namn": "Nidvatten",
-  "beskrivning": "niDvattnEt\nNidvatten består av ren korruption, som ett inver-\nterat Skymningsvatten (se sidan 186 i grundboken).\nDet ser ut som svart kvicksilver och ger ifrån sig\nsvarta dunster av korruption om den inte innesluts i\nett kärl. I konungagraven finns vätskan samlad i en\nliten karaff av halvgenomskinligt vulkaniskt glas.\nDet går enbart att binda artefakten till sig genom\natt acceptera ett permanent poäng i korruption.\nNidvattnet har följande egenskaper och krafter:",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Fri"
+  {
+    "id": "ar06",
+    "namn": "Nidvatten",
+    "beskrivning": "niDvattnEt Nidvatten består av ren korruption, som ett inverterat Skymningsvatten (se sidan 186 i grundboken). Det ser ut som svart kvicksilver och ger ifrån sig svarta dunster av korruption om den inte innesluts i ett kärl. I konungagraven finns vätskan samlad i en liten karaff av halvgenomskinligt vulkaniskt glas. Det går enbart att binda artefakten till sig genom att acceptera ett permanent poäng i korruption. Nidvattnet har följande egenskaper och krafter:",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 2": [
-        "Aktiv"
-      ],
-      "Förmåga 3": [
-        "Reaktiv"
-      ],
-      "Förmåga 4": [
-        "Fri"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Fri"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ],
+        "Förmåga 3": [
+          "Reaktiv"
+        ],
+        "Förmåga 4": [
+          "Fri"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Mörkerlykta. I handen på den som accepterat mörkret kan krukan blöda med underjordens mörker, så att omgivningen drunknar i svärta även om solen står mitt på himlen. Effekten blir att en plats (exempel- vis ett rum inomhus) läggs i mörker under resten av scenen, svart som en natt utan stjärnor eller månsken. Handling: Fri. Korruption: Ingen.",
+      "Förmåga 2": "Nattens insikt. Flaskan innehåller 10 droppar nidvatten, vilka kan droppas på levande hud. Varje droppe ger 1T12 erfarenhet som kan användas som mottagaren önskar, till priset av permanent korruption. När alla droppar har använts är karaffen tom och arte- fakten förbrukad. Handling: Aktiv. Korruption: 1 permanent korruption/droppe.",
+      "Förmåga 3": "Svart synergi. Den som bugar för mörkrets övermakt kan använda dess svärta för att förstärka svartkonster. Dessa får sin effekttärning höjd ett steg. Synergin kan göras en gång per scen. Handling: Reaktiv. Korruption: Ingen.",
+      "Förmåga 4": "Mörkrets frälsning. Den som bundit sig till mörkret kan med en tanke krossa krukan och släppa loss dess mörker. Alla närvarande varelser med minst 1 korruption (temporär eller permanent) får omedelbart 1T12 permanent korruption. Varelser som redan har permanent korruption påverkas endast om slaget överstiger deras nuvarande korruption – de drabbas då av mellanskillnaden. Om slaget är lika med eller lägre än varelsens nuvarande korruption händer ingenting. Varelser helt utan korruption påverkas inte alls. Effekten drabbar förstås även bäraren själv, om denne har korruption. Handling: Fri. Korruption: 1T12 (se dock beskrivning)."
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 1
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Mörkerlykta. I handen på den som accepterat mörkret kan krukan blöda med underjordens mörker, så att omgivningen drunknar i svärta även om solen står mitt på himlen. Effekten blir att en plats (exempel- vis ett rum inomhus) läggs i mörker under resten av scenen, svart som en natt utan stjärnor eller månsken. Handling: Fri. Korruption: Ingen.",
-    "Förmåga 2": "Nattens insikt. Flaskan innehåller 10 droppar nidvatten, vilka kan droppas på levande hud. Varje droppe ger 1T12 erfarenhet som kan användas som mottagaren önskar, till priset av permanent korruption. När alla droppar har använts är karaffen tom och arte- fakten förbrukad. Handling: Aktiv. Korruption: 1 permanent korruption/droppe.",
-    "Förmåga 3": "Svart synergi. Den som bugar för mörkrets övermakt kan använda dess svärta för att förstärka svartkonster. Dessa får sin effekttärning höjd ett steg. Synergin kan göras en gång per scen. Handling: Reaktiv. Korruption: Ingen.",
-    "Förmåga 4": "Mörkrets frälsning. Den som bundit sig till mörkret kan med en tanke krossa krukan och släppa loss dess mörker. Alla närvarande varelser med minst 1 korruption (temporär eller permanent) får omedelbart 1T12 permanent korruption. Varelser som redan har permanent korruption påverkas endast om slaget överstiger deras nuvarande korruption – de drabbas då av mellanskillnaden. Om slaget är lika med eller lägre än varelsens nuvarande korruption händer ingenting. Varelser helt utan korruption påverkas inte alls. Effekten drabbar förstås även bäraren själv, om denne har korruption. Handling: Fri. Korruption: 1T12 (se dock beskrivning)."
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 1
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-}
-,{
-  "id": "ar07",
-  "namn": "Fullangra, kungstjänaren",
-  "beskrivning": "Fullangra, kungstjänarEn\nDen krumma dvärgen Fullangra – eller Långnog\nsom hon kallar sig själv – fångades av forntida\nsvartkonstnärer och bands i den snidade träask\nsom bär hennes avbild. Hon har genom seklen tjänat\nmånga mästare, krigsherrar och småkungar, alltid\ntroget men aldrig utan att knota och gnälla. Hennes\ndåliga humör fick den senaste ägaren, konung\nHurian Lo-Apak att tröttna och stoppa in skrinet\ni skattkammaren istället för att utnyttja hennes\ntjänster. Sekler av ensamt surande i skrinet har\nfått Fullangra att mjukna något och hon kommer\ntjäna sin nästa mästare med mer av muttranden\noch viskat gnäll än högljutt missnöje.\nFullangra talar en urgammal symbarisk dialekt\noch kan varken läsa eller skriva. I och med att någon\nbinder artefakten till sig uppstår ett mystiskt band\nmellan denne och dvärgen som innebär att de kan\nkommunicera på telepatisk väg, men för andra\nkrävs förmågan Lärd till mästarnivå samt ett lyckat\nslag mot Listig för att möjliggöra ett samtal. Noteras\nbör också att hon inte anger sitt dopnamn till någon,\ninte ens till sin mästare: hon använder istället sitt\nbruksnamn, Långnog.\nFullangra har följande egenskaper och krafter,\nvilka skrinets mästare kan utnyttja:",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Aktiv"
+  {
+    "id": "ar07",
+    "namn": "Fullangra, kungstjänaren",
+    "beskrivning": "Fullangra, kungstjänarEn Den krumma dvärgen Fullangra – eller Långnog som hon kallar sig själv – fångades av forntida svartkonstnärer och bands i den snidade träask som bär hennes avbild. Hon har genom seklen tjänat många mästare, krigsherrar och småkungar, alltid troget men aldrig utan att knota och gnälla. Hennes dåliga humör fick den senaste ägaren, konung Hurian Lo-Apak att tröttna och stoppa in skrinet i skattkammaren istället för att utnyttja hennes tjänster. Sekler av ensamt surande i skrinet har fått Fullangra att mjukna något och hon kommer tjäna sin nästa mästare med mer av muttranden och viskat gnäll än högljutt missnöje. Fullangra talar en urgammal symbarisk dialekt och kan varken läsa eller skriva. I och med att någon binder artefakten till sig uppstår ett mystiskt band mellan denne och dvärgen som innebär att de kan kommunicera på telepatisk väg, men för andra krävs förmågan Lärd till mästarnivå samt ett lyckat slag mot Listig för att möjliggöra ett samtal. Noteras bör också att hon inte anger sitt dopnamn till någon, inte ens till sin mästare: hon använder istället sitt bruksnamn, Långnog. Fullangra har följande egenskaper och krafter, vilka skrinets mästare kan utnyttja:",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 2": [
-        "Aktiv"
-      ],
-      "Förmåga 3": [
-        "Aktiv"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Aktiv"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ],
+        "Förmåga 3": [
+          "Aktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Trotjänare Fullangra kan beordras att agera livvakt, vakta en plats, hämta något, lämna bud, hantera en spak eller kort och gott dra till staden för att sälja rov. Hon utför uppdraget plikttroget och behöver inte äta eller sova. Hon tar inga initiativ utöver givna direktiv. Om uppdraget tar slut men hon saknar order kommer hon att återvända till skrinet på mystisk väg och vänta där. Om uppdraget placerar Fullangra i närheten av skrinets mästare fungerar hon som en andra rollperson åt denne. Fullangra rör sig alltid i dödsmarsch-tempo, utan vila. Varje längre uppdrag kräver sålunda ett slag med 1T20: 20 innebär att Fullangra fångats av monster eller förolyckats på annat sätt. Då återvänder hon mystiskt till skrinet och vägrar surande att lämna det på en vecka. Handling: Aktiv Korruption: 1 Fullangra, Kungstjänaren ”Begrav mig stående, jag har levt på knä” Manér Muttrar mycket för sig själv och betraktar omvärlden med bister blick Släkte Dvärg Motstånd Ordinärt Särdrag Jordnära (se sidan 39), Minnesmästare (se sidan 39) Diskret 10 (0), Kvick 10 (0), Listig 13 (−3), Stark 15 (−5), Träffsäker 5 (−5), Vaksam 11 (−1), Viljestark 9 (−1), Övertygande 7 (+3) Förmågor Järnäve (Novis), Naturlig krigare (Gesäll), Stryparkonst (Novis) Beväpning Hårda nypor 1T6+1T4 , två attacker mot samma mål Stypning 1T6 per runda Bepansring Ingen Försvar 10 Tålighet 15 Smärtgräns 6 Utrustning Ingen Skugga Som dimma över Davokars gölar, med enstaka sotflagor irrande i det vita (korruption: 3) Taktik: Fullangra lyder order, till punkt och pricka. Om Fullangra dödas (når 0 i Tålighet, hon slår inga dödsslag) återvänder hon till skrinet och slickar sin sår i dagarna sju.",
+      "Förmåga 2": "Tabell 2: Fullangras chans att lyckas med ett mördarstråt motstånD chans att lyckas Svagt Slå 1T20, Fullangra lyckas på allt utom 20. Ordinärt Slå 1T20, Fullangra lyckas om slaget är 10 eller lägre (misslyckas på 11–20) Utmanande Slå 1T20, Fullangra lyckas om slaget är 5 eller under (misslyckas på 6–20) Starkt Slå 1T20, Fullangra lyckas endast om slaget är 1 (misslyckas på 2–20 Mördarstråt Fullangra kan också bevekas att göra grymmare dåd, men då mot kravet att hon släpps fri. Om skrinets mästare låter henne gå efter en sista illgärning kan hon fås att ge sig ut på strypargöra. Hon söker då upp en av mästaren angiven fiende och försöker dräpa denne. Tidsåtgången är densamma som om rollpersonen själv försökte göra det. Fullangras chans att lyckas beror på vilket offrets motstånd är, se tabell 2. Om Fullangra misslyckas med uppdraget innebär det att hon dödats eller fångats in, och då återkommer hon inte till skrinet. Överlever hon kommer hon så snart uppdraget är utfört att söka upp närmaste dvärgfränder, vilket troligen är i Yndaros. Handling: Aktiv Korruption: 1T4, varav ett permanent.",
+      "Förmåga 3": "Frihetens gengåva För den mästare som ger Fullangra hennes frihet åter utan krav på motprestation kommer dvärgen att åkalla de gamla makter hon fortfarande känner namnet på och genom dem ge sin befriare en av nedanstående gåvor: Ärva korruption: Fullangra tar på sig 1T6 av befriarens permanenta korruption, som tack för sin frihet. Övernaturligt beskydd: Fullangras bön till gamla makter ger befriaren beskydd. Skyddet kommer i form av 1T6 erfarenhet som endast får användas i enlighet med den alternativa regeln Omslag för erfarenhet (sidan 179 i Grundboken). Vad Fullangra gör med sin frihet är upp till spelledaren."
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 2
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Trotjänare\nFullangra kan beordras att agera livvakt, vakta en\nplats, hämta något, lämna bud, hantera en spak\neller kort och gott dra till staden för att sälja rov.\nHon utför uppdraget plikttroget och behöver inte\näta eller sova. Hon tar inga initiativ utöver givna\ndirektiv. Om uppdraget tar slut men hon saknar\norder kommer hon att återvända till skrinet på\nmystisk väg och vänta där.\nOm uppdraget placerar Fullangra i närheten\nav skrinets mästare fungerar hon som en andra\nrollperson åt denne. Fullangra rör sig alltid i döds-\nmarsch-tempo, utan vila. Varje längre uppdrag\nkräver sålunda ett slag med 1T20: 20 innebär att\nFullangra fångats av monster eller förolyckats på\nannat sätt. Då återvänder hon mystiskt till skrinet\noch vägrar surande att lämna det på en vecka.\nHandling: Aktiv\nKorruption: 1\nFullangra, Kungstjänaren\n”Begrav mig stående, jag har levt på knä”\nManér Muttrar mycket för sig själv och\nbetraktar omvärlden med bister\nblick\nSläkte Dvärg\nMotstånd Ordinärt\nSärdrag Jordnära (se sidan 39),\nMinnesmästare (se sidan 39)\nDiskret 10 (0), Kvick 10 (0), Listig 13 (−3),\nStark 15 (−5), Träffsäker 5 (−5), Vaksam 11 (−1),\nViljestark 9 (−1), Övertygande 7 (+3)\nFörmågor Järnäve (Novis), Naturlig krigare\n(Gesäll), Stryparkonst (Novis)\nBeväpning Hårda nypor 1T6+1T4 , två\nattacker mot samma mål\nStypning 1T6 per runda\nBepansring Ingen\nFörsvar 10\nTålighet 15 Smärtgräns 6\nUtrustning Ingen\nSkugga Som dimma över Davokars gölar,\nmed enstaka sotflagor irrande i\ndet vita (korruption: 3)\nTaktik: Fullangra lyder order, till punkt och pricka.\nOm Fullangra dödas (når 0 i Tålighet, hon slår inga\ndödsslag) återvänder hon till skrinet och slickar\nsin sår i dagarna sju.",
-    "Förmåga 2": "Tabell 2: Fullangras chans att lyckas med ett mördarstråt\nmotstånD chans att lyckas\nSvagt Slå 1T20, Fullangra lyckas på allt utom 20.\nOrdinärt Slå 1T20, Fullangra lyckas om slaget är 10 eller lägre (misslyckas på 11–20)\nUtmanande Slå 1T20, Fullangra lyckas om slaget är 5 eller under (misslyckas på 6–20)\nStarkt Slå 1T20, Fullangra lyckas endast om slaget är 1 (misslyckas på 2–20\n\nMördarstråt\nFullangra kan också bevekas att göra grymmare\ndåd, men då mot kravet att hon släpps fri. Om skri-\nnets mästare låter henne gå efter en sista illgärning\nkan hon fås att ge sig ut på strypargöra. Hon söker\ndå upp en av mästaren angiven fiende och försöker\ndräpa denne. Tidsåtgången är densamma som om\nrollpersonen själv försökte göra det. Fullangras\nchans att lyckas beror på vilket offrets motstånd\när, se tabell 2.\nOm Fullangra misslyckas med uppdraget inne-\nbär det att hon dödats eller fångats in, och då\nåterkommer hon inte till skrinet. Överlever hon\nkommer hon så snart uppdraget är utfört att söka\nupp närmaste dvärgfränder, vilket troligen är i\nYndaros.\nHandling: Aktiv\nKorruption: 1T4, varav ett permanent.",
-    "Förmåga 3": "Frihetens gengåva\nFör den mästare som ger Fullangra hennes frihet\nåter utan krav på motprestation kommer dvärgen\natt åkalla de gamla makter hon fortfarande känner\nnamnet på och genom dem ge sin befriare en av\nnedanstående gåvor:\nÄrva korruption: Fullangra tar på sig 1T6 av\nbefriarens permanenta korruption, som tack för\nsin frihet.\nÖvernaturligt beskydd: Fullangras bön till\ngamla makter ger befriaren beskydd. Skyddet\nkommer i form av 1T6 erfarenhet som endast får\nanvändas i enlighet med den alternativa regeln\nOmslag för erfarenhet (sidan 179 i Grundboken).\nVad Fullangra gör med sin frihet är upp till spel-\nledaren."
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 2
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-}
-,{
-  "id": "ar08",
-  "namn": "Själaslukaren",
-  "beskrivning": "själaslukarEn\nStridshammaren Själaslukaren ska enligt legen-\nderna ha skapats i österlandet bortom Ravennerna\ni syfte att tillfredsställa en anonym krigsherres\nhärsklystnad. Vapnet var illa omtalat redan i\nSymbaroum om man får tro de krönikor där\ndet omnämns, ofta med påståenden som att det”smiddes i avundsjuka och härdades i missunn-\nsamhet”. Ingen av dess ägare i gamla Symbaroum\npåstås heller ha gått goda öden till mötes.\nNär Själaslukaren hittas i mausoleet har den en\nmystisk kraft lagrad från ett tidigare offer: Helig\naura (Novis).",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt",
-      "Vapen"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Reaktiv"
+  {
+    "id": "ar08",
+    "namn": "Själaslukaren",
+    "beskrivning": "själaslukarEn Stridshammaren Själaslukaren ska enligt legenderna ha skapats i österlandet bortom Ravennerna i syfte att tillfredsställa en anonym krigsherres härsklystnad. Vapnet var illa omtalat redan i Symbaroum om man får tro de krönikor där det omnämns, ofta med påståenden som att det”smiddes i avundsjuka och härdades i missunnsamhet”. Ingen av dess ägare i gamla Symbaroum påstås heller ha gått goda öden till mötes. När Själaslukaren hittas i mausoleet har den en mystisk kraft lagrad från ett tidigare offer: Helig aura (Novis).",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt",
+        "Vapen"
       ],
-      "Förmåga 2": [
-        "Samma som den lagrade kraften"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Reaktiv"
+        ],
+        "Förmåga 2": [
+          "Samma som den lagrade kraften"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Liktjuv. Själaslukaren kan ”suga åt sig” en mystisk kraft som involverar karaktärsdraget Viljestark från en varelse den dräper och lagra den i sitt runristade huvud. För att det ska hända måste hammaren fälla det dödande slaget och dess mästare måste välja att ersätta den redan lagrade förmågan med en från det nya offret. Handling: Reaktiv. Korruption: 1T4.",
+      "Förmåga 2": "Parasitens storhet. Vapnets mästare kan använda den mystiska kraft som har lagrats i vapnet, som om den var mästarens egen. Bärarens Viljestark räknas som 15 i sammanhang som har med användningen av den lagrade kraften att göra, dock utan att ha någon inverkan på bärarens korruptionströskel. Handling: Samma som den lagrade kraften. Korruption: 1T4."
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 2
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Liktjuv. Själaslukaren kan ”suga åt sig” en mystisk kraft som involverar karaktärsdraget Viljestark från en varelse den dräper och lagra den i sitt runristade huvud. För att det ska hända måste hammaren fälla det dödande slaget och dess mästare måste välja att ersätta den redan lagrade förmågan med en från det nya offret. Handling: Reaktiv. Korruption: 1T4.",
-    "Förmåga 2": "Parasitens storhet. Vapnets mästare kan använda den mystiska kraft som har lagrats i vapnet, som om den var mästarens egen. Bärarens Viljestark räknas som 15 i sammanhang som har med användningen av den lagrade kraften att göra, dock utan att ha någon inverkan på bärarens korruptionströskel. Handling: Samma som den lagrade kraften. Korruption: 1T4."
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 2
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar09",
-  "namn": "Brandskär",
-  "beskrivning": "branDskär\nKastyxan Brandskär hyser vilda andar av eld\noch aska vilka låter den flamma upp och också\nflyga genom luften tillbaka till kastarens hand.\nLegenderna är märkligt tysta om vapnets ursprung,\nmen det är inte otänkbart att vapnet är den brin-\nnande yxa som sades svingas av monsterjägaren\nKsandukha, hon som enligt legenderna dräpte\nDavokars sista drake.\nVapnets huvud glöder och osar svagt och ger\n+1T4 i skada på alla attacker. Vapnets mästare är\nmärkligt opåverkad av dess hetta och kan hantera\ndet som en vanlig kastyxa.\nDet eldfängda vapnet söker sig alltid tillbaka till\nmästaren, om inte denne vill ha det annorlunda.\nNär yxan kastas eller tappas återvänder den till\nmästarens hand som en fri handling, utan någon\nkostnad i korruption.",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt",
-      "Vapen"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Aktiv"
+  {
+    "id": "ar09",
+    "namn": "Brandskär",
+    "beskrivning": "branDskär Kastyxan Brandskär hyser vilda andar av eld och aska vilka låter den flamma upp och också flyga genom luften tillbaka till kastarens hand. Legenderna är märkligt tysta om vapnets ursprung, men det är inte otänkbart att vapnet är den brinnande yxa som sades svingas av monsterjägaren Ksandukha, hon som enligt legenderna dräpte Davokars sista drake. Vapnets huvud glöder och osar svagt och ger +1T4 i skada på alla attacker. Vapnets mästare är märkligt opåverkad av dess hetta och kan hantera det som en vanlig kastyxa. Det eldfängda vapnet söker sig alltid tillbaka till mästaren, om inte denne vill ha det annorlunda. När yxan kastas eller tappas återvänder den till mästarens hand som en fri handling, utan någon kostnad i korruption.",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt",
+        "Vapen"
       ],
-      "Förmåga 2": [
-        "Aktiv"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Aktiv"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Lavakniv. När vapnet kastas glöder yxeggen som bergens brinnande blod och vapnet bränner lätt genom bepansring av alla slag – attacken ignorerar rustning. Handling: Aktiv. Korruption: 1T4.",
+      "Förmåga 2": "Eldregn. Brandskär slår ut mot en rad fiender i en kedjeattack. Yxan kastas mot en fiende och om det träffar denne flyger vapnet vidare till ett ytterligare mål, och så vidare tills ett anfallsslag misslyckas. Då återvänder vapnet till mästarens hand. Handling: Aktiv. Korruption: 1T6."
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 0.5
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Lavakniv. När vapnet kastas glöder yxeggen som bergens brinnande blod och vapnet bränner lätt genom bepansring av alla slag – attacken ignorerar rustning. Handling: Aktiv. Korruption: 1T4.",
-    "Förmåga 2": "Eldregn. Brandskär slår ut mot en rad fiender i en kedje-\nattack. Yxan kastas mot en fiende och om det träffar\ndenne flyger vapnet vidare till ett ytterligare mål,\noch så vidare tills ett anfallsslag misslyckas. Då\nåtervänder vapnet till mästarens hand. Handling: Aktiv. Korruption: 1T6."
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 0.5
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar10",
-  "namn": "Ellas trollkors",
-  "beskrivning": "Ellas trollkors\nEtt trollkors graverat på en plåt av meteoritjärn,\nsmitt av trollhaggan Ella som hjälp mot hennes\närkefiende, den styggelsefödda barbarhärskaren\nOdalbagar. Antingen hjälpte korset inte trollkonan,\neller så stupade trollet i senare strider. Oavsett\nvilket har hennes skyddstalisman vandrat vidare\ntill andra händer.\nTrollkorset är av lämplig smyckesstorlek för\nett fullvuxet ärketroll och alltså i storlek som en\nbucklare för en människa. Trollkorset går de facto\natt använda som just en bucklare, med de regler\nsom grundboken anger (sidan 150). Detta kräver\ninte heller att rollpersonen binder artefakten till\nsig. För trollkorsets övriga krafter måste artefakten\nbindas till bäraren på vanligt vis.",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Reaktiv"
+  {
+    "id": "ar10",
+    "namn": "Ellas trollkors",
+    "beskrivning": "Ellas trollkors Ett trollkors graverat på en plåt av meteoritjärn, smitt av trollhaggan Ella som hjälp mot hennes ärkefiende, den styggelsefödda barbarhärskaren Odalbagar. Antingen hjälpte korset inte trollkonan, eller så stupade trollet i senare strider. Oavsett vilket har hennes skyddstalisman vandrat vidare till andra händer. Trollkorset är av lämplig smyckesstorlek för ett fullvuxet ärketroll och alltså i storlek som en bucklare för en människa. Trollkorset går de facto att använda som just en bucklare, med de regler som grundboken anger (sidan 150). Detta kräver inte heller att rollpersonen binder artefakten till sig. För trollkorsets övriga krafter måste artefakten bindas till bäraren på vanligt vis.",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 2": [
-        "Reaktiv"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Reaktiv"
+        ],
+        "Förmåga 2": [
+          "Reaktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Sinnets sköld. Trollkorsets mästare kan låta Ellas ålderdomliga signerier skydda mot sinnespåverkande krafter. Bäraren får en andra chans att lyckas motstå en kraft som involverar Viljestark. Om kraften verkar över tid får trollkorsets bärare dessutom slå omslag för att bryta en pågående effekt. Detta räknas som ett användande av artefaktens kraft. Handling: Reaktiv. Korruption: 1.",
+      "Förmåga 2": "Hämnande spegel. Bäraren tar stöd i trollsmedens djupaste kunnande för att försöka vända tillbaka anfallande magi mot kastaren. Alla offensiva krafter som inkluderar trollkorsets bärare som måltavla påverkas. Den hämnande speglingen fungerar regeltekniskt som om bäraren av trollkorset attackerade kastaren med kraften i fråga. Om kraften exempelvis kräver ett slag mot Viljestark är det alltså bärarens Viljestark som används för att avgöra om spelgingen lyckas, modifierat av kastarens karaktärsdrag om modifiering ska göras. Speglingen är dock riskfylld. En misslyckad spegling drar ännu mer korruption till bäraren. Handling: Reaktiv Korruption: 1T4 om försöket lyckas, 1T6 om det miss lyckas"
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 1.5
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Sinnets sköld. Trollkorsets mästare kan låta Ellas ålderdomliga signerier skydda mot sinnespåverkande krafter. Bäraren får en andra chans att lyckas motstå en kraft som involverar Viljestark. Om kraften verkar över tid får trollkorsets bärare dessutom slå omslag för att bryta en pågående effekt. Detta räknas som ett användande av artefaktens kraft. Handling: Reaktiv. Korruption: 1.",
-    "Förmåga 2": "Hämnande spegel. Bäraren tar stöd i trollsmedens djupaste kunnande för att försöka vända tillbaka anfallande magi mot kastaren. Alla offensiva krafter som inkluderar trollkorsets bärare som måltavla påverkas.\nDen hämnande speglingen fungerar regeltek-\nniskt som om bäraren av trollkorset attackerade\nkastaren med kraften i fråga. Om kraften exem-\npelvis kräver ett slag mot Viljestark är det alltså\nbärarens Viljestark som används för att avgöra om\nspelgingen lyckas, modifierat av kastarens karak-\ntärsdrag om modifiering ska göras.\nSpeglingen är dock riskfylld. En misslyckad\nspegling drar ännu mer korruption till bäraren.\nHandling: Reaktiv\nKorruption: 1T4 om försöket lyckas, 1T6 om det miss\nlyckas"
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 1.5
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar11",
-  "namn": "Haganorskinnet",
-  "beskrivning": "haganorskinnEt\nDenna regnbågsskimrande mantel av lindorms-\nskinn sägs stamma från en orm som dräptes nära\nHaganors kolonner, i den urtid då kolonnerna\nännu glänste av guld och silver. Manteln lånar\nfortfarande magisk kraft till sin bärare – förlänar\ndenne en röst som likt drakormars hypnotiska kraft\ntrollbinder lyssnarnas vilja; eller en betvingande\nstämma som med stormens tordön knäcker viljor\noch gör ståndaktiga krigare till slavar.\nManteln ger som passiv kraft ett extra skydd\ntill sin ägare (+1T4), och kan bäras ovanpå annan\nrustning utan att addera ytterligare begränsning.\nDenna skyddande effekt kräver inte heller att\nbäraren binder artefakten till sig, vilket däremot\nkrafterna som beskrivs nedan gör.\nMen Haganorskinnet för också med sig en\nnegativ effekt: om en nu levande lindorm får syn\npå manteln kommer denne att minnas de förned-\nrande tider då Symbaroums furstar jagade dess\nförfärder för nöjes skull och genast – å alla stolta\nlindormars vägnar – utse bäraren till sin personliga\ndödsfiende. I sammanhanget bör också noteras att\nalla lindormar är opåverkade av skinnets krafter.",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Aktiv"
+  {
+    "id": "ar11",
+    "namn": "Haganorskinnet",
+    "beskrivning": "haganorskinnEt Denna regnbågsskimrande mantel av lindormsskinn sägs stamma från en orm som dräptes nära Haganors kolonner, i den urtid då kolonnerna ännu glänste av guld och silver. Manteln lånar fortfarande magisk kraft till sin bärare – förlänar denne en röst som likt drakormars hypnotiska kraft trollbinder lyssnarnas vilja; eller en betvingande stämma som med stormens tordön knäcker viljor och gör ståndaktiga krigare till slavar. Manteln ger som passiv kraft ett extra skydd till sin ägare (+1T4), och kan bäras ovanpå annan rustning utan att addera ytterligare begränsning. Denna skyddande effekt kräver inte heller att bäraren binder artefakten till sig, vilket däremot krafterna som beskrivs nedan gör. Men Haganorskinnet för också med sig en negativ effekt: om en nu levande lindorm får syn på manteln kommer denne att minnas de förnedrande tider då Symbaroums furstar jagade dess förfärder för nöjes skull och genast – å alla stolta lindormars vägnar – utse bäraren till sin personliga dödsfiende. I sammanhanget bör också noteras att alla lindormar är opåverkade av skinnets krafter.",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 2": [
-        "Aktiv"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Aktiv"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Drakviskning. Skinnets mästare kan låta sin stämma spela på själasträngar och trollbinda alla åhörare med ett [Övertygande←Viljestark]. De närvarande fiender som trollbinds ägnar en av sina nästkommande handlingar åt att göra ingenting – under inneva- rande runda om de inte redan har agerat, annars under rundan som följer. Handling: Aktiv. Korruption: 1.",
+      "Förmåga 2": "Kommenderande stämma. Haganorskinnets bärare kan med ett lyckat [Övertygande←Viljestark] ta kontroll över en varelse. Kontrollen sitter i tills bäraren misslyckas med ett [Övertygande←Viljestark] (slås på bärarens initiativ) eller tills koncentrationen bryts [Viljestark – Skada]. Den kontrollerade varelsen har endast en handling per runda och kan inte använda aktiva förmågor eller krafter under kontrollen. Handling: Aktiv. Korruption: 1T4."
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 0.5
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Drakviskning. Skinnets mästare kan låta sin stämma spela på själasträngar och trollbinda alla åhörare med ett [Övertygande←Viljestark]. De närvarande fiender som trollbinds ägnar en av sina nästkommande handlingar åt att göra ingenting – under inneva- rande runda om de inte redan har agerat, annars under rundan som följer. Handling: Aktiv. Korruption: 1.",
-    "Förmåga 2": "Kommenderande stämma. Haganorskinnets bärare kan med ett lyckat [Övertygande←Viljestark] ta kontroll över en varelse. Kontrollen sitter i tills bäraren misslyckas med ett [Övertygande←Viljestark] (slås på bärarens initiativ) eller tills koncentrationen bryts [Viljestark – Skada]. Den kontrollerade varelsen har endast en handling per runda och kan inte använda aktiva förmågor eller krafter under kontrollen. Handling: Aktiv. Korruption: 1T4."
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 0.5
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar12",
-  "namn": "Hymne",
-  "beskrivning": "Hymne\nI legenderna talas det om trollkrigarkonan Oramox\noch hennes strid mot ulvahövdingen Fergos.\nDen senare ska ha fått sin intelligens i gåva av\nSpindelkonungen just för att straffa Oramox stam,\nsedan trollen allierat sig med en människobosätt-\nning. Enligt sägnen ska Oramox ha fallit offer för\nHymnes korrumperande verkan, men först efter\n\natt hon låtit den väldiga dubbelyxan sjunga sitt\nfolk till seger och klyva skallen på den listige ulven\ni två delar.",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt",
-      "Vapen"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Aktiv"
+  {
+    "id": "ar12",
+    "namn": "Hymne",
+    "beskrivning": "Hymne I legenderna talas det om trollkrigarkonan Oramox och hennes strid mot ulvahövdingen Fergos. Den senare ska ha fått sin intelligens i gåva av Spindelkonungen just för att straffa Oramox stam, sedan trollen allierat sig med en människobosättning. Enligt sägnen ska Oramox ha fallit offer för Hymnes korrumperande verkan, men först efter att hon låtit den väldiga dubbelyxan sjunga sitt folk till seger och klyva skallen på den listige ulven i två delar.",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt",
+        "Vapen"
       ],
-      "Förmåga 2": [
-        "Aktiv"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Aktiv"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Eggande genklang: När artefaktens mästare spenderar en stridhandling på att upprepade gånger slå Hymne mot något hårt (sten, träd eller bergvägg) byggs en bastonig genklang upp. Under en runda framåt har mästarens allierade +1 på Stark och Viljestark. Handling: Aktiv Korruption: 1T4",
+      "Förmåga 2": "Förstärkande harmoni: Kräver att mästaren behärskar Kampsång. Efter att ha byggt upp genklangen enligt ovan kan den kombineras med hjältens egen sång och då hållas vid liv i 1T4 rundor. Under denna tid har mästaren själv och dess allierade +2 på Kvick, Stark och Träffsäker. Dessutom återfår mästaren och de allierade 1T8 Tålighet när effekten träder i kraft. Handling: Aktiv Korruption: 1T6"
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 2
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Eggande genklang: När artefaktens mästare\nspenderar en stridhandling på att upprepade\ngånger slå Hymne mot något hårt (sten, träd eller\nbergvägg) byggs en bastonig genklang upp. Under\nen runda framåt har mästarens allierade +1 på Stark\noch Viljestark.\nHandling: Aktiv\nKorruption: 1T4",
-    "Förmåga 2": "Förstärkande harmoni: Kräver att mästa-\nren behärskar Kampsång. Efter att ha byggt upp\ngenklangen enligt ovan kan den kombineras med\nhjältens egen sång och då hållas vid liv i 1T4 run-\ndor. Under denna tid har mästaren själv och dess\nallierade +2 på Kvick, Stark och Träffsäker. Dessutom\nåterfår mästaren och de allierade 1T8 Tålighet när\neffekten träder i kraft.\nHandling: Aktiv\nKorruption: 1T6"
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 2
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar13",
-  "namn": "Arvalams bindel",
-  "beskrivning": "arvalams Bindel\nArvalam ska ha varit hovmystiker vid ståthållare\nGrabandos hov och en av det sena Symbaroums\nskickligaste demonologer, kapabel att både åkalla\noch tämja vidunder som andra mystiker aldrig\nskulle kunna kontrollera. Men hans skicklighet\ntillskrevs inte talang eller djuplodande skolning\nutan den ögonbindel han bar vid kontakter med\novärlden – enligt ryktet erhållen genom en pakt\nmed daemonen Lukofei.",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Aktiv"
+  {
+    "id": "ar13",
+    "namn": "Arvalams bindel",
+    "beskrivning": "arvalams Bindel Arvalam ska ha varit hovmystiker vid ståthållare Grabandos hov och en av det sena Symbaroums skickligaste demonologer, kapabel att både åkalla och tämja vidunder som andra mystiker aldrig skulle kunna kontrollera. Men hans skicklighet tillskrevs inte talang eller djuplodande skolning utan den ögonbindel han bar vid kontakter med ovärlden – enligt ryktet erhållen genom en pakt med daemonen Lukofei.",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 2": [
-        "Aktiv"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Aktiv"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Genomskåda daemon: När artefaktens mästare frammanar en daemon kan denne se varelsens svaghet eller svarta böjelser och får därför lättare att betvinga den: +5 på slaget mot [Viljestark←Viljestark], som gäller båda försöken om ett blodsoffer används. Handling: Aktiv Korruption: 1",
+      "Förmåga 2": "Föraning av ovärlden: Om artefaktens mästare behärskar kraften Förvisning kan bindeln förläna denne en föraning om vad som finns på andra sidan om den reva som öppnas. Det innebär dels att mästaren själv kan välja om det ska komma in en daemon genom revan eller inte, dels att offret tar 1T6 i skada per runda, i stället för 1T4. För att dra nytta av bindelns kraft måste den vara dragen för ögonen vilket inverkar menligt på bärarens omvärldsuppfattning. Så länge artefakten används har mästaren två chanser att misslyckas med alla framgångsslag som inte är kopplade till mystiska krafter (oavsett handlingstyp). Handling: Aktiv Korruption: +1"
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 0.5
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Genomskåda daemon: När artefaktens\nmästare frammanar en daemon kan denne se\nvarelsens svaghet eller svarta böjelser och får\ndärför lättare att betvinga den: +5 på slaget mot\n[Viljestark←Viljestark], som gäller båda försöken\nom ett blodsoffer används.\nHandling: Aktiv\nKorruption: 1",
-    "Förmåga 2": "Föraning av ovärlden: Om artefaktens mästare\nbehärskar kraften Förvisning kan bindeln förläna\ndenne en föraning om vad som finns på andra\nsidan om den reva som öppnas. Det innebär dels\natt mästaren själv kan välja om det ska komma in\nen daemon genom revan eller inte, dels att offret\ntar 1T6 i skada per runda, i stället för 1T4.\nFör att dra nytta av bindelns kraft måste den\nvara dragen för ögonen vilket inverkar menligt på\nbärarens omvärldsuppfattning. Så länge artefakten\nanvänds har mästaren två chanser att misslyckas\nmed alla framgångsslag som inte är kopplade till\nmystiska krafter (oavsett handlingstyp).\nHandling: Aktiv\nKorruption: +1"
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 0.5
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar14",
-  "namn": "Spinneldräpa",
-  "beskrivning": "spinneldräpa\nDen artefakt som Elmendra misstog för att vara den\nså kallade Häxhammaren är i själva verket ingenting\nmindre än det vapen som storhövding Maiesticar\nsvingade mot och genom Spindelkonungens hjärta.\nSedan Angatal Taars död har häxorna hållit det\ni förvar, i väntan på att nästa fientligt inställda\nspindelväsen ska dyka upp. Spinneldräpa är oavsett\nform (se nedan) ett mästartillverkat föremål med\nkvaliteterna Balanserat, Djupverkande och Precist.",
-  "kvalitet": [
-    "Balanserat",
-    "Djupverkande",
-    "Precist"
-  ],
-  "taggar": {
-    "typ": [
-      "Artefakt",
-      "Vapen"
+  {
+    "id": "ar14",
+    "namn": "Spinneldräpa",
+    "beskrivning": "spinneldräpa Den artefakt som Elmendra misstog för att vara den så kallade Häxhammaren är i själva verket ingenting mindre än det vapen som storhövding Maiesticar svingade mot och genom Spindelkonungens hjärta. Sedan Angatal Taars död har häxorna hållit det i förvar, i väntan på att nästa fientligt inställda spindelväsen ska dyka upp. Spinneldräpa är oavsett form (se nedan) ett mästartillverkat föremål med kvaliteterna Balanserat, Djupverkande och Precist.",
+    "kvalitet": [
+      "Balanserat",
+      "Djupverkande",
+      "Precist"
     ],
-    "handling": {
-      "Förmåga 1": [
-        "Aktiv"
+    "taggar": {
+      "typ": [
+        "Artefakt",
+        "Vapen"
       ],
-      "Förmåga 2": [
-        "Fri"
-      ],
-      "Förmåga 3": [
-        "Fri"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Aktiv"
+        ],
+        "Förmåga 2": [
+          "Fri"
+        ],
+        "Förmåga 3": [
+          "Fri"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "Formförändring: Artefakten kan omforma sig i enlighet med mästarens vilja, till någon av typerna Korta vapen, Enhandsvapen, Långa vapen eller Tunga vapen. Förändringen tar en runda i anspråk men håller sedan i sig tills mästaren vill något annat. Handling: Aktiv Korruption: 1",
+      "Förmåga 2": "Blodets rening: Med ett lätt jack eller stick på en egen, blottad kroppsdel kan artefaktens mästare låta Spinneldräpa komma i kontakt med dennes blod och därigenom mildra effekten av gifter – fungerar som ett medelstarkt motgift. Handling: Fri Korruption: 1t4",
+      "Förmåga 3": "Spindelbane: Om artefaktens mästare behärskar förmågan Monsterlärd till gesällnivå (specialisering: bestar) och lyckas med ett slag mot Listig gör Spinneldräpa +1T8 i skada mot varelser av familjen Spindlar. Effekten varar hela scenen ut. Handling: Fri Korruption: 1t6"
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 1
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
   },
-  "nivåer": {
-    "Förmåga 1": "Formförändring: Artefakten kan omforma sig i\nenlighet med mästarens vilja, till någon av typerna\nKorta vapen, Enhandsvapen, Långa vapen eller\nTunga vapen. Förändringen tar en runda i anspråk\nmen håller sedan i sig tills mästaren vill något annat.\nHandling: Aktiv\nKorruption: 1",
-    "Förmåga 2": "Blodets rening: Med ett lätt jack eller stick på\nen egen, blottad kroppsdel kan artefaktens mästare\nlåta Spinneldräpa komma i kontakt med dennes\nblod och därigenom mildra effekten av gifter –\nfungerar som ett medelstarkt motgift.\nHandling: Fri\nKorruption: 1t4",
-    "Förmåga 3": "Spindelbane: Om artefaktens mästare behärs-\nkar förmågan Monsterlärd till gesällnivå (speciali-\nsering: bestar) och lyckas med ett slag mot Listig gör\nSpinneldräpa +1T8 i skada mot varelser av familjen\nSpindlar. Effekten varar hela scenen ut.\nHandling: Fri\nKorruption: 1t6"
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 1
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  }
-},
-{
-  "id": "ar17",
-  "namn": "Natanas Urna",
-  "beskrivning": "Natanas Urna\nDenna underarmslånga urna av matt keramik är inte en prydnad eller ett kärl i vanlig mening. Den fungerar snarare som ett förvaringskärl för en bundet väsen, vars kroppslösa gestalt vilar instängd i dess mörka inre.\n\nNär urnan öppnas frigörs varelsen i form av en slingrande, kvinnoliknande skepnad av svart rök. För den som redan har bundit sig till urnan genom ett medvetet åtagande blir denna gestalt synlig och tillgänglig som en tjänare. Hon tar då kontakt via viskande telepati och erbjuder sina förmågor som spanare och rådgivare.\n\nVarelsen saknar möjlighet att angripa eller fysiskt skada andra levande varelser. Hennes styrka ligger istället i sin förmåga att obemärkt röra sig, betrakta och återge vad hon iakttagit. Hon förstår inga dödliga tungomål men försöker ändå återge sin tolkning av händelser och skeenden.\n\nNär hon vistas utanför urnan påverkas omgivningen på ett olycksbådande sätt. Alla inom en förflyttningshandling från hennes gestalt utsätts för en korrumperande strålning och erhåller 1T4 temporär korruption per scen eller timme. Denna försvinner med tiden som annan kortvarig korruption, men kan hinna sätta djupa spår i sinnet.",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {}
-  },
-  "nivåer": {},
-  "stat": {
-    "skada": "",
-    "vikt": 1.5
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
-  },
-  "korruption": "Speciell"
-},{
-  "id": "ar18",
-  "namn": "Järnpaktens ring",
-  "beskrivning": "Artefakt: Järnpaktens ring\njärnpaktEns ringar smiddEs av alver i drakar-\nnas eld på trollens städ, som ett vapen mot den\ntilltagande korruptionen i Symbaroum. I ringarna\nband de gamla släktena de sista resterna av den\nrena magin, innan den slutligt korrumperades.\nRingarna bars av Järnpaktens härförare i slut-\nstriden mot Symbaroums mörker. Det är i alla fall\nalvernas legender om ringarna, så som de berättas\nför Järnpaktens fåtaliga mänskliga allierade.\nNu har drakarna försvunnit, trollen brutali-\nserats, och inte ens alverna sluter mangrant upp\nbakom den forna alliansen. Ringarna var aldrig\nmånga och nu är de ännu färre. De få kvarvarande\nringarnas makt är dock uppenbar för dem som svär\nJärnpaktens ed och underkastar sig ringarnas lag.\nJärnpaktens ring går endast att binda till sig med\nerfarenhet, inte genom accepterande av korruption.\nDen hindrar inte heller rollpersonen från att få\nmer korruption av fri vilja, men straffar det (se\nkraften Ringens lag).",
-  "kvalitet": [],
-  "taggar": {
-    "typ": [
-      "Artefakt"
-    ],
-    "handling": {
-      "Förmåga 1": [
-        "Fri"
+  {
+    "id": "ar17",
+    "namn": "Natanas Urna",
+    "beskrivning": "Natanas Urna Denna underarmslånga urna av matt keramik är inte en prydnad eller ett kärl i vanlig mening. Den fungerar snarare som ett förvaringskärl för en bundet väsen, vars kroppslösa gestalt vilar instängd i dess mörka inre. När urnan öppnas frigörs varelsen i form av en slingrande, kvinnoliknande skepnad av svart rök. För den som redan har bundit sig till urnan genom ett medvetet åtagande blir denna gestalt synlig och tillgänglig som en tjänare. Hon tar då kontakt via viskande telepati och erbjuder sina förmågor som spanare och rådgivare. Varelsen saknar möjlighet att angripa eller fysiskt skada andra levande varelser. Hennes styrka ligger istället i sin förmåga att obemärkt röra sig, betrakta och återge vad hon iakttagit. Hon förstår inga dödliga tungomål men försöker ändå återge sin tolkning av händelser och skeenden. När hon vistas utanför urnan påverkas omgivningen på ett olycksbådande sätt. Alla inom en förflyttningshandling från hennes gestalt utsätts för en korrumperande strålning och erhåller 1T4 temporär korruption per scen eller timme. Denna försvinner med tiden som annan kortvarig korruption, men kan hinna sätta djupa spår i sinnet.",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 2": [
-        "Aktiv"
+      "handling": {}
+    },
+    "nivåer": {},
+    "stat": {
+      "skada": "",
+      "vikt": 1.5
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
+    },
+    "korruption": "Speciell"
+  },
+  {
+    "id": "ar18",
+    "namn": "Järnpaktens ring",
+    "beskrivning": "Artefakt: Järnpaktens ring järnpaktEns ringar smiddEs av alver i drakarnas eld på trollens städ, som ett vapen mot den tilltagande korruptionen i Symbaroum. I ringarna band de gamla släktena de sista resterna av den rena magin, innan den slutligt korrumperades. Ringarna bars av Järnpaktens härförare i slutstriden mot Symbaroums mörker. Det är i alla fall alvernas legender om ringarna, så som de berättas för Järnpaktens fåtaliga mänskliga allierade. Nu har drakarna försvunnit, trollen brutaliserats, och inte ens alverna sluter mangrant upp bakom den forna alliansen. Ringarna var aldrig många och nu är de ännu färre. De få kvarvarande ringarnas makt är dock uppenbar för dem som svär Järnpaktens ed och underkastar sig ringarnas lag. Järnpaktens ring går endast att binda till sig med erfarenhet, inte genom accepterande av korruption. Den hindrar inte heller rollpersonen från att få mer korruption av fri vilja, men straffar det (se kraften Ringens lag).",
+    "kvalitet": [],
+    "taggar": {
+      "typ": [
+        "Artefakt"
       ],
-      "Förmåga 3": [
-        "Automatisk"
-      ]
+      "handling": {
+        "Förmåga 1": [
+          "Fri"
+        ],
+        "Förmåga 2": [
+          "Aktiv"
+        ],
+        "Förmåga 3": [
+          "Automatisk"
+        ]
+      }
+    },
+    "nivåer": {
+      "Förmåga 1": "BalansEns sköld Ringen skyddar bäraren mot korruption utifrån, så som smittan i Davokars mörka delar eller den giftiga ondska som följer med vissa styggelsers bett och klor (det monstruösa särdraget Korrumperande attack). Ringen har ingen effekt på korruption som bäraren frivilligt accepterar som del av användande av artefakter eller mystiska krafter: tvärtom straffar ringen sådant (se kraften Ringens lag). Handling: Fri Korruption: Ingen",
+      "Förmåga 2": "drömsändning En gång under varje nattsömn kan den som bundit sig till ringen sända ett drömbudskap till en annan paktringsbärare. De två måste inte ha mötts men sändaren måste känna till mottagarens existens. Budskapet blir i form av ett bildspel i drömmen, iga ord kan kommunicerats. Tolkningen sker av mottagaren. Handling: Aktiv Korruption: Ingen",
+      "Förmåga 3": "ringEns lag Ringen slår hårt mot edsbrytare. Den som underkastat sig Järnpaktens lag drabbas av fysisk skada av all korruption som bäraren frivilligt drar på sig: varje poäng temporär korruption ger 1t4 i skada på bäraren."
+    },
+    "stat": {
+      "skada": "",
+      "vikt": 0.02
+    },
+    "grundpris": {
+      "daler": 0,
+      "skilling": 0,
+      "örtegar": 0
     }
-  },
-  "nivåer": {
-    "Förmåga 1": "BalansEns sköld\nRingen skyddar bäraren mot korruption utifrån,\nså som smittan i Davokars mörka delar eller den\ngiftiga ondska som följer med vissa styggelsers bett\noch klor (det monstruösa särdraget Korrumperande\nattack). Ringen har ingen effekt på korruption som\nbäraren frivilligt accepterar som del av användande\nav artefakter eller mystiska krafter: tvärtom straf-\nfar ringen sådant (se kraften Ringens lag).\nHandling: Fri\nKorruption: Ingen",
-    "Förmåga 2": "drömsändning\nEn gång under varje nattsömn kan den som bundit\nsig till ringen sända ett drömbudskap till en annan\npaktringsbärare. De två måste inte ha mötts men\nsändaren måste känna till mottagarens existens.\nBudskapet blir i form av ett bildspel i drömmen,\niga ord kan kommunicerats. Tolkningen sker av\nmottagaren.\nHandling: Aktiv\nKorruption: Ingen",
-    "Förmåga 3": "ringEns lag\nRingen slår hårt mot edsbrytare. Den som under-\nkastat sig Järnpaktens lag drabbas av fysisk skada\nav all korruption som bäraren frivilligt drar på sig:\nvarje poäng temporär korruption ger 1t4 i skada\npå bäraren."
-  },
-  "stat": {
-    "skada": "",
-    "vikt": 0.02
-  },
-  "grundpris": {
-    "daler": 0,
-    "skilling": 0,
-    "örtegar": 0
   }
-}
-
-
 ]


### PR DESCRIPTION
## Summary
- remove extraneous line breaks from artifact descriptions and ability texts to improve readability
- keep artifact abilities listed as "Förmåga 1", "Förmåga 2", etc., formatted like standard ability levels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adb6dc58308323b7dd621d9ae97654