### PR TITLE
Display artifact abilities

### DIFF
--- a/js/text-format.js
+++ b/js/text-format.js
@@ -18,14 +18,27 @@
     if(!p.nivåer) return base;
     const lvls = [];
     const levels = (window.LVL || ['Novis','Ges\u00e4ll','M\u00e4stare']);
-    const idx = maxLevel ? levels.indexOf(maxLevel) : -1;
-    const use = idx >= 0 ? levels.slice(0, idx+1) : levels;
-    use.forEach(l => {
-      if(p.nivåer[l]){
-        lvls.push(`<dt>${l}</dt><dd>${formatText(p.nivåer[l])}</dd>`);
-      }
-    });
-    const lvlHtml = `<dl class="levels">${lvls.join('')}</dl>`;
+
+    // Determine if the object uses the standard Novis/Gesäll/Mästare levels
+    const keys = Object.keys(p.nivåer);
+    const usesStandard = keys.some(k => levels.includes(k));
+
+    if (usesStandard) {
+      const idx = maxLevel ? levels.indexOf(maxLevel) : -1;
+      const use = idx >= 0 ? levels.slice(0, idx + 1) : levels;
+      use.forEach(l => {
+        if (p.nivåer[l]) {
+          lvls.push(`<dt>${l}</dt><dd>${formatText(p.nivåer[l])}</dd>`);
+        }
+      });
+    } else {
+      // Generic handling for entries like artefacts with Förmåga 1/2/... keys
+      keys.forEach(k => {
+        lvls.push(`<dt>${k}</dt><dd>${formatText(p.nivåer[k])}</dd>`);
+      });
+    }
+
+    const lvlHtml = lvls.length ? `<dl class="levels">${lvls.join('')}</dl>` : '';
     return base ? `${base}${lvlHtml}` : lvlHtml;
   }
   window.formatText = formatText;


### PR DESCRIPTION
## Summary
- Show abilities for artifacts by handling non-standard level keys in `abilityHtml`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adbc333144832394063c4c4541469e