### PR TITLE
Reveal artifacts owned by characters

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -558,6 +558,7 @@ function initIndex() {
               }
               if (window.updateXP) updateXP();
               if (window.renderTraits) renderTraits();
+              storeHelper.addRevealedArtifact(store, p.namn);
             }
             renderList(filtered());
             const li = dom.invList?.querySelector(`li[data-name="${CSS.escape(p.namn)}"][data-idx="${flashIdx}"]`);
@@ -817,6 +818,7 @@ function initIndex() {
             storeHelper.setCurrentList(store, list);
             if (window.updateXP) updateXP();
             if (window.renderTraits) renderTraits();
+            storeHelper.removeRevealedArtifact(store, p.namn);
           }
         }
         renderList(filtered());

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1517,6 +1517,7 @@ ${moneyRow}
                 storeHelper.setCurrentList(store, list);
                 if (window.updateXP) updateXP();
                 if (window.renderTraits) renderTraits();
+                storeHelper.removeRevealedArtifact(store, row.name);
               }
             }
           }
@@ -1591,6 +1592,7 @@ ${moneyRow}
                 }
                 if (window.updateXP) updateXP();
                 if (window.renderTraits) renderTraits();
+                storeHelper.addRevealedArtifact(store, entry.namn);
               }
               const selector = !Number.isNaN(parentIdx)
                 ? `li[data-name="${CSS.escape(entry.namn)}"][data-parent="${parentIdx}"][data-child="${flashIdx}"]`
@@ -1641,6 +1643,7 @@ ${moneyRow}
               storeHelper.setCurrentList(store, list);
               if (window.updateXP) updateXP();
               if (window.renderTraits) renderTraits();
+              storeHelper.removeRevealedArtifact(store, row.name);
             }
           }
           const selector = !Number.isNaN(parentIdx)

--- a/js/store.js
+++ b/js/store.js
@@ -599,6 +599,14 @@
     save(store);
   }
 
+  function removeRevealedArtifact(store, name) {
+    if (!store.current) return;
+    store.data[store.current] = store.data[store.current] || {};
+    const list = store.data[store.current].revealedArtifacts || [];
+    store.data[store.current].revealedArtifacts = list.filter(n => n !== name);
+    save(store);
+  }
+
   function clearRevealedArtifacts(store) {
     if (!store.current) return;
     store.data[store.current] = store.data[store.current] || {};
@@ -1126,6 +1134,7 @@ function defaultTraits() {
     setOnlySelected,
     getRevealedArtifacts,
     addRevealedArtifact,
+    removeRevealedArtifact,
     clearRevealedArtifacts,
     getNilasPopupSeen,
     setNilasPopupSeen,


### PR DESCRIPTION
## Summary
- Track and remove revealed artifacts in store
- Ensure adding artifacts reveals them in index and inventory views
- Hide artifacts again when removed from inventory

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adce34bc0c83239e6168ed475f1b11