### PR TITLE
Add explicit artifact cost options

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -528,8 +528,19 @@ function initIndex() {
           const rowBase = { name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
           const tagTyp = p.taggar?.typ || [];
           if (tagTyp.includes('Artefakt')) {
-            const payXP = await confirmPopup('Betala 1 XP? (Avbryt = +1 permanent korruption)');
-            rowBase.artifactEffect = payXP ? 'xp' : 'corruption';
+            const choice = await openDialog('Betala 1 XP eller ta +1 permanent korruption?', {
+              cancel: true,
+              cancelText: 'Avbryt',
+              okText: '-1 erf',
+              extraText: '+1 korruption'
+            });
+            if (choice === true) {
+              rowBase.artifactEffect = 'xp';
+            } else if (choice === 'extra') {
+              rowBase.artifactEffect = 'corruption';
+            } else {
+              return;
+            }
           } else if (p.artifactEffect) {
             rowBase.artifactEffect = p.artifactEffect;
           }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1560,8 +1560,19 @@ ${moneyRow}
             const tagTyp = entry.taggar?.typ || [];
             let artifactEffect = '';
             if (tagTyp.includes('Artefakt')) {
-              const payXP = await confirmPopup('Betala 1 XP? (Avbryt = +1 permanent korruption)');
-              artifactEffect = payXP ? 'xp' : 'corruption';
+              const choice = await openDialog('Betala 1 XP eller ta +1 permanent korruption?', {
+                cancel: true,
+                cancelText: 'Avbryt',
+                okText: '-1 erf',
+                extraText: '+1 korruption'
+              });
+              if (choice === true) {
+                artifactEffect = 'xp';
+              } else if (choice === 'extra') {
+                artifactEffect = 'corruption';
+              } else {
+                return;
+              }
             }
             const addRow = trait => {
               const obj = { name: entry.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -28,7 +28,8 @@ class SharedToolbar extends HTMLElement {
     document.getElementById = id =>
       nativeGetElementById(id) || this.shadowRoot.getElementById(id);
 
-    window.alertPopup = msg => this.openDialog(msg);
+    window.openDialog  = (msg, opts) => this.openDialog(msg, opts);
+    window.alertPopup  = msg => this.openDialog(msg);
     window.confirmPopup = msg => this.openDialog(msg, { cancel: true });
 
     /* ----- Lås bakgrunds-scroll när panel eller popup är öppen ----- */
@@ -505,6 +506,7 @@ class SharedToolbar extends HTMLElement {
           <div class="confirm-row">
             <button id="dialogCancel" class="char-btn danger">Avbryt</button>
             <button id="dialogOk" class="char-btn">OK</button>
+            <button id="dialogExtra" class="char-btn">Extra</button>
           </div>
         </div>
       </div>
@@ -658,32 +660,47 @@ class SharedToolbar extends HTMLElement {
   close(id) { this.panels[id]?.classList.remove('open'); }
 
   openDialog(message, opts = {}) {
-    const { cancel = false, okText = 'OK', cancelText = 'Avbryt' } = opts;
+    const {
+      cancel = false,
+      okText = 'OK',
+      cancelText = 'Avbryt',
+      extraText
+    } = opts;
     return new Promise(resolve => {
-      const pop   = this.shadowRoot.getElementById('dialogPopup');
-      const msgEl = this.shadowRoot.getElementById('dialogMessage');
-      const okBtn = this.shadowRoot.getElementById('dialogOk');
-      const cancelBtn = this.shadowRoot.getElementById('dialogCancel');
+      const pop      = this.shadowRoot.getElementById('dialogPopup');
+      const msgEl    = this.shadowRoot.getElementById('dialogMessage');
+      const okBtn    = this.shadowRoot.getElementById('dialogOk');
+      const cancelBtn= this.shadowRoot.getElementById('dialogCancel');
+      const extraBtn = this.shadowRoot.getElementById('dialogExtra');
       msgEl.textContent = message;
       cancelBtn.style.display = cancel ? '' : 'none';
       okBtn.textContent = okText;
       cancelBtn.textContent = cancelText;
+      if (extraText) {
+        extraBtn.style.display = '';
+        extraBtn.textContent = extraText;
+      } else {
+        extraBtn.style.display = 'none';
+      }
       pop.classList.add('open');
       pop.querySelector('.popup-inner').scrollTop = 0;
       const close = res => {
         pop.classList.remove('open');
         okBtn.removeEventListener('click', onOk);
         cancelBtn.removeEventListener('click', onCancel);
+        extraBtn.removeEventListener('click', onExtra);
         pop.removeEventListener('click', onOutside);
         resolve(res);
       };
       const onOk = () => close(true);
       const onCancel = () => close(false);
+      const onExtra = () => close('extra');
       const onOutside = e => {
         if (!pop.querySelector('.popup-inner').contains(e.target)) close(false);
       };
       okBtn.addEventListener('click', onOk);
       cancelBtn.addEventListener('click', onCancel);
+      extraBtn.addEventListener('click', onExtra);
       pop.addEventListener('click', onOutside);
     });
   }


### PR DESCRIPTION
## Summary
- extend dialog popup with optional third button
- prompt for artifact cost with Cancel, -1 XP or +1 corruption

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68add02365108323ad5a5dd449fec4c9