### PR TITLE
Keep revealed artifacts while equipped and sync removals

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -685,6 +685,19 @@ function initCharacter() {
       invUtil.saveInventory(inv);
       invUtil.renderInventory();
     }
+    if ((p.taggar?.typ || []).includes('Artefakt')) {
+      const inv = storeHelper.getInventory(store);
+      const removeItem = arr => {
+        for (let i = arr.length - 1; i >= 0; i--) {
+          if (arr[i].name === p.namn) arr.splice(i, 1);
+          else if (Array.isArray(arr[i].contains)) removeItem(arr[i].contains);
+        }
+      };
+      removeItem(inv);
+      invUtil.saveInventory(inv);
+      invUtil.renderInventory();
+      storeHelper.removeRevealedArtifact(store, p.namn);
+    }
     renderSkills(filtered());
     updateXP();
     renderTraits();

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -388,7 +388,7 @@ function initIndex() {
         dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
         storeHelper.setOnlySelected(store, false);
         storeHelper.clearRevealedArtifacts(store);
-        revealedArtifacts.clear();
+        revealedArtifacts = new Set(storeHelper.getRevealedArtifacts(store));
         fillDropdowns();
         activeTags(); renderList(filtered());
         window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -901,11 +901,23 @@ function initIndex() {
           }
           invUtil.renderInventory();
         }
-          if (p.namn === 'Välutrustad') {
-            const inv = storeHelper.getInventory(store);
-            invUtil.removeWellEquippedItems(inv);
-            invUtil.saveInventory(inv); invUtil.renderInventory();
-          }
+        if (p.namn === 'Välutrustad') {
+          const inv = storeHelper.getInventory(store);
+          invUtil.removeWellEquippedItems(inv);
+          invUtil.saveInventory(inv); invUtil.renderInventory();
+        }
+        if ((p.taggar?.typ || []).includes('Artefakt')) {
+          const inv = storeHelper.getInventory(store);
+          const removeItem = arr => {
+            for (let i = arr.length - 1; i >= 0; i--) {
+              if (arr[i].name === p.namn) arr.splice(i, 1);
+              else if (Array.isArray(arr[i].contains)) removeItem(arr[i].contains);
+            }
+          };
+          removeItem(inv);
+          invUtil.saveInventory(inv); invUtil.renderInventory();
+          storeHelper.removeRevealedArtifact(store, p.namn);
+        }
       }
     }
     renderList(filtered());

--- a/js/store.js
+++ b/js/store.js
@@ -610,7 +610,27 @@
   function clearRevealedArtifacts(store) {
     if (!store.current) return;
     store.data[store.current] = store.data[store.current] || {};
-    store.data[store.current].revealedArtifacts = [];
+
+    const keep = new Set();
+
+    getCurrentList(store).forEach(it => {
+      const tagTyp = it.taggar?.typ || [];
+      if (tagTyp.includes('Artefakt')) keep.add(it.namn);
+    });
+
+    const collect = arr => {
+      arr.forEach(row => {
+        const entry = (getCustomEntries(store).find(e => e.namn === row.name))
+          || (global.DB || []).find(e => e.namn === row.name) || {};
+        const tagTyp = entry.taggar?.typ || [];
+        if (tagTyp.includes('Artefakt')) keep.add(entry.namn);
+        if (Array.isArray(row.contains)) collect(row.contains);
+      });
+    };
+    collect(getInventory(store));
+
+    const cur = getRevealedArtifacts(store);
+    store.data[store.current].revealedArtifacts = cur.filter(n => keep.has(n));
     save(store);
   }
 


### PR DESCRIPTION
## Summary
- Preserve revealed artifacts that remain on a character even after reset commands
- Remove artifacts from inventory, character and index views in sync
- Reload revealed artifact list in index view when clearing filters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade261a3c483239935904c29fdeba3