### PR TITLE
Normalize mystic archetype tags

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -137,9 +137,15 @@
   }
 
   function explodeTags(arr){
+    const map = {
+      'H\u00e4xa': 'H\u00e4xkonst',
+      'Ordensmagiker': 'Ordensmagi',
+      'Teurg': 'Teurgi'
+    };
     return (arr || [])
       .flatMap(v => v.split(',').map(t => t.trim()))
-      .filter(Boolean);
+      .filter(Boolean)
+      .map(t => map[t] || t);
   }
 
   function splitQuals(val){


### PR DESCRIPTION
## Summary
- Map archetype tags so Häxa, Ordensmagiker, and Teurg are treated as Häxkonst, Ordensmagi, and Teurgi

## Testing
- `node --check js/utils.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b02788074c8323bdc693622fffd9ea