### PR TITLE
Map professions to traditions for lower artifacts

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -531,8 +531,10 @@ function initIndex() {
           if (tagTyp.includes('L\u00e4gre Artefakt')) {
             const reqYrken = explodeTags(p.taggar?.ark_trad);
             if (reqYrken.length) {
-              const hasYrke = reqYrken.some(yrke =>
-                list.some(it => isYrke(it) && it.namn === yrke)
+              const hasYrke = reqYrken.some(req =>
+                list.some(it =>
+                  isYrke(it) && explodeTags([it.namn]).includes(req)
+                )
               );
               if (!hasYrke) {
                 const msg = `Du har inte r\u00e4tt yrke; om du \u00e4nd\u00e5 vill ha ${p.namn} blir det 10x dyrare och traditionens f\u00f6ljare kan komma att ta illa vid sig. L\u00e4gg till \u00e4nd\u00e5?`;

--- a/js/utils.js
+++ b/js/utils.js
@@ -139,8 +139,12 @@
   function explodeTags(arr){
     const map = {
       'H\u00e4xa': 'H\u00e4xkonst',
+      'H\u00e4xkonst': 'H\u00e4xkonst',
+      'H\u00e4xkonster': 'H\u00e4xkonst',
       'Ordensmagiker': 'Ordensmagi',
-      'Teurg': 'Teurgi'
+      'Ordensmagi': 'Ordensmagi',
+      'Teurg': 'Teurgi',
+      'Teurgi': 'Teurgi'
     };
     return (arr || [])
       .flatMap(v => v.split(',').map(t => t.trim()))


### PR DESCRIPTION
## Summary
- Canonicalize tradition tags like "Häxkonster" and map them to related professions
- Compare required traditions against canonicalized profession names when adding lower artifacts

## Testing
- `node --check js/index-view.js js/utils.js`

------
https://chatgpt.com/codex/tasks/task_e_68b029aeacb883239ed101f8daf76d95