### PR TITLE
Shorten compact meta badges for mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -338,7 +338,7 @@ input:focus, select:focus, textarea:focus {
 /* Hide default price line in compact; use badges instead */
 .card.compact .card-price { display: none; }
 
-/* Always-visible compact meta badges (Pris, Nivå, Vikt) */
+/* Always-visible compact meta badges (P, V, level) */
 .meta-badges {
   display: none;
   gap: .35rem;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -308,14 +308,14 @@ function initIndex() {
           .filter(Boolean)
           .join(' ');
         const xpHtml = xpVal != null ? `<span class="xp-cost">Erf: ${xpText}</span>` : '';
-        // Compact meta badges (Pris/Vikt/Nivå for inventory items) with labels for clarity
+        // Compact meta badges (P/V/level) using short labels for mobile space
         const lvlBadgeVal = (availLvls.length > 0) ? curLvl : '';
         const lvlShort = lvlBadgeVal === 'Mästare' ? 'M' : (lvlBadgeVal === 'Gesäll' ? 'G' : (lvlBadgeVal === 'Novis' ? 'N' : ''));
         const priceBadgeLabel = (priceLabel || 'Pris').replace(':','');
         const badgeParts = [];
-        if (priceText) badgeParts.push(`<span class="meta-badge price-badge" title="${priceBadgeLabel}">${priceBadgeLabel}: ${priceText}</span>`);
-        if (weightVal != null) badgeParts.push(`<span class="meta-badge weight-badge" title="Vikt">Vikt: ${weightVal}</span>`);
-        if (isInv(p) && lvlShort) badgeParts.push(`<span class="meta-badge level-badge" title="Nivå: ${lvlBadgeVal}">Nivå: ${lvlShort}</span>`);
+        if (priceText) badgeParts.push(`<span class="meta-badge price-badge" title="${priceBadgeLabel}">P:${priceText}</span>`);
+        if (weightVal != null) badgeParts.push(`<span class="meta-badge weight-badge" title="Vikt">V:${weightVal}</span>`);
+        if (isInv(p) && lvlShort) badgeParts.push(`<span class="meta-badge level-badge" title="${lvlBadgeVal}">${lvlShort}</span>`);
         const metaBadges = compact && badgeParts.length ? `<div class="meta-badges">${badgeParts.join('')}</div>` : '';
         if (infoTagsHtml) {
           infoHtml = `<div class="tags">${infoTagsHtml}</div><br>${infoHtml}`;


### PR DESCRIPTION
## Summary
- Shorten price and weight badges to `P:` and `V:` and display only the level letter to avoid overlap on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b17eed5eb883238297eaacc1a1125c