### PR TITLE
Improve compact badge spacing and price formatting

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -313,8 +313,8 @@ function initIndex() {
         const lvlShort = lvlBadgeVal === 'Mästare' ? 'M' : (lvlBadgeVal === 'Gesäll' ? 'G' : (lvlBadgeVal === 'Novis' ? 'N' : ''));
         const priceBadgeLabel = (priceLabel || 'Pris').replace(':','');
         const badgeParts = [];
-        if (priceText) badgeParts.push(`<span class="meta-badge price-badge" title="${priceBadgeLabel}">P:${priceText}</span>`);
-        if (weightVal != null) badgeParts.push(`<span class="meta-badge weight-badge" title="Vikt">V:${weightVal}</span>`);
+        if (priceText) badgeParts.push(`<span class="meta-badge price-badge" title="${priceBadgeLabel}">P: ${priceText}</span>`);
+        if (weightVal != null) badgeParts.push(`<span class="meta-badge weight-badge" title="Vikt">V: ${weightVal}</span>`);
         if (isInv(p) && lvlShort) badgeParts.push(`<span class="meta-badge level-badge" title="${lvlBadgeVal}">${lvlShort}</span>`);
         const metaBadges = compact && badgeParts.length ? `<div class="meta-badges">${badgeParts.join('')}</div>` : '';
         if (infoTagsHtml) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -163,7 +163,11 @@
     const d = m.d ?? m.daler ?? 0;
     const s = m.s ?? m.skilling ?? 0;
     const o = m.o ?? m['\u00f6rtegar'] ?? 0;
-    return `${d}D ${s}S ${o}\u00d6`;
+    const parts = [];
+    if (d) parts.push(`${d}D`);
+    if (s) parts.push(`${s}S`);
+    if (o) parts.push(`${o}\u00d6`);
+    return parts.join(' ') || '0';
   }
 
   // Returnera HTML med skada/skydd-stats för vapen och rustningar


### PR DESCRIPTION
## Summary
- Add spacing inside compact price and weight meta badges
- Show only non-zero currency units when formatting prices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1816e74ac83238b23fef2f39a6c42