### PR TITLE
Use multiplied prices in unused money calculation

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -959,6 +959,8 @@ function openVehiclePopup(preselectId, precheckedPaths) {
       const baseQ = baseQuals.filter(q => !removed.includes(q));
       const allQ = [...baseQ, ...(row.kvaliteter || [])];
       row.gratisKval = allQ.filter(q => !isNegativeQual(q) && !isNeutralQual(q));
+      // remove any price multiplier when everything is made free
+      delete row.priceMult;
     });
 
     saveInventory(allInv);
@@ -1296,6 +1298,9 @@ function openVehiclePopup(preselectId, precheckedPaths) {
           else            price *= myst ? 10 : 5;
         }
       });
+
+      // apply any manually set price multiplier
+      price *= row.priceMult || 1;
 
       const free = Math.min(Number(row.gratis || 0), row.qty);
       const totalO = Math.max(0, price * row.qty - base * free);


### PR DESCRIPTION
## Summary
- Count price multipliers when computing unused money
- Clear price multipliers when marking all inventory as free

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/inventory-utils.js`


------
https://chatgpt.com/codex/tasks/task_e_68b18604de5883239ee92df5a2b5c196