### PR TITLE
Freeze page scroll during search suggestions

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -82,7 +82,13 @@ function initIndex() {
     const sugEl = dom.searchSug || (document.querySelector('shared-toolbar')?.shadowRoot?.getElementById('searchSuggest'));
     if (!sugEl) return;
     const q = (dom.sIn?.value || '').trim();
-    if (q.length < 2) { sugEl.innerHTML = ''; sugEl.hidden = true; sugIdx = -1; return; }
+    if (q.length < 2) {
+      sugEl.innerHTML = '';
+      sugEl.hidden = true;
+      sugIdx = -1;
+      window.updateScrollLock?.();
+      return;
+    }
     const nq = searchNormalize(q.toLowerCase());
     const seen = new Set();
     const MAX = 50;
@@ -97,10 +103,17 @@ function initIndex() {
       items.push(name);
       if (items.length >= MAX) break;
     }
-    if (!items.length) { sugEl.innerHTML = ''; sugEl.hidden = true; sugIdx = -1; return; }
+    if (!items.length) {
+      sugEl.innerHTML = '';
+      sugEl.hidden = true;
+      sugIdx = -1;
+      window.updateScrollLock?.();
+      return;
+    }
     sugEl.innerHTML = items.map((v,i)=>`<div class="item" data-idx="${i}" data-val="${v.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;')}">${v}</div>`).join('');
     sugEl.hidden = false;
     sugIdx = -1;
+    window.updateScrollLock?.();
   };
   updateSearchDatalist();
 

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -34,7 +34,7 @@ class SharedToolbar extends HTMLElement {
 
     /* ----- Lås bakgrunds-scroll när panel eller popup är öppen ----- */
     this.updateScrollLock = () => {
-      const selector = '[id$="Panel"].open, [id$="Popup"].open, .popup.open';
+      const selector = '[id$="Panel"].open, [id$="Popup"].open, .popup.open, #searchSuggest:not([hidden])';
       const docOpen = document.querySelector(selector);
       const shadowOpen = this.shadowRoot.querySelector(selector);
       const anyOpen = docOpen || shadowOpen;
@@ -42,7 +42,7 @@ class SharedToolbar extends HTMLElement {
     };
     window.updateScrollLock = () => this.updateScrollLock();
 
-    const obsCfg = { attributes: true, attributeFilter: ['class'], subtree: true };
+    const obsCfg = { attributes: true, attributeFilter: ['class', 'hidden'], subtree: true };
     this._bodyObserver = new MutationObserver(this.updateScrollLock);
     this._bodyObserver.observe(document.body, obsCfg);
     this._shadowObserver = new MutationObserver(this.updateScrollLock);
@@ -681,6 +681,7 @@ class SharedToolbar extends HTMLElement {
       const insideSearch = path.includes(sugEl) || path.includes(sIn);
       if (!insideSearch) {
         sugEl.hidden = true;
+        this.updateScrollLock();
       }
     }
 


### PR DESCRIPTION
## Summary
- Freeze background scrolling when search suggestions are visible.
- Observe suggestion visibility and update scroll lock accordingly.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b195aa09e48323bae1fa2af5c67f14