### PR TITLE
Fix mobile scroll lock for active search field

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -34,7 +34,7 @@ class SharedToolbar extends HTMLElement {
 
     /* ----- Lås bakgrunds-scroll när panel eller popup är öppen ----- */
     this.updateScrollLock = () => {
-      const selector = '[id$="Panel"].open, [id$="Popup"].open, .popup.open, #searchSuggest:not([hidden])';
+      const selector = '[id$="Panel"].open, [id$="Popup"].open, .popup.open, #searchSuggest:not([hidden]), #searchField:focus';
       const docOpen = document.querySelector(selector);
       const shadowOpen = this.shadowRoot.querySelector(selector);
       const anyOpen = docOpen || shadowOpen;
@@ -47,6 +47,10 @@ class SharedToolbar extends HTMLElement {
     this._bodyObserver.observe(document.body, obsCfg);
     this._shadowObserver = new MutationObserver(this.updateScrollLock);
     this._shadowObserver.observe(this.shadowRoot, obsCfg);
+
+    const sField = this.shadowRoot.getElementById('searchField');
+    sField.addEventListener('focus', this.updateScrollLock);
+    sField.addEventListener('blur', this.updateScrollLock);
 
     this.updateScrollLock();
   }


### PR DESCRIPTION
## Summary
- Lock page scroll when the search field is focused so the toolbar stays visible

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b19b1cf2e483238f195b294907e1ce