### PR TITLE
Blur search field on back or submission

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -499,7 +499,7 @@ function initCharacter() {
         activeTags();
         renderSkills(filtered());
         renderTraits();
-        dom.sIn.focus();
+        dom.sIn.blur();
         window.scrollTo({ top: 0, behavior: 'smooth' });
       });
     }
@@ -521,6 +521,7 @@ function initCharacter() {
     }
     if(e.key==='Enter'){
       e.preventDefault();
+      dom.sIn.blur();
       const term = sTemp.toLowerCase();
       if (items.length && sugIdx >= 0) {
         const chosen = items[sugIdx]?.dataset?.val || '';

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -440,7 +440,7 @@ function initIndex() {
         updateSearchDatalist();
         activeTags();
         renderList(filtered());
-        dom.sIn.focus();
+        dom.sIn.blur();
         window.scrollTo({ top: 0, behavior: 'smooth' });
       });
     }
@@ -462,6 +462,7 @@ function initIndex() {
     }
     if(e.key==='Enter'){
       e.preventDefault();
+      dom.sIn.blur();
       const term = sTemp.toLowerCase();
       if (items.length && sugIdx >= 0) {
         const chosen = items[sugIdx]?.dataset?.val || '';

--- a/js/main.js
+++ b/js/main.js
@@ -128,6 +128,28 @@ const dom  = {
   cName  : document.getElementById('charName')
 };
 
+/* ----- Hantera back-navigering för sökfältet ----- */
+let searchFocus = false;
+if (dom.sIn) {
+  dom.sIn.addEventListener('focus', () => {
+    history.pushState({ search: true }, '');
+    searchFocus = true;
+  });
+  dom.sIn.addEventListener('blur', () => {
+    if (searchFocus) {
+      searchFocus = false;
+      history.back();
+    }
+  });
+}
+
+window.addEventListener('popstate', () => {
+  if (searchFocus && document.activeElement === dom.sIn) {
+    searchFocus = false;
+    dom.sIn.blur();
+  }
+});
+
 /* ---------- Ladda databasen ---------- */
 let DB = [];
 let DBIndex = {};


### PR DESCRIPTION
## Summary
- Blur search field when browser back button is used
- Defocus search after selecting suggestion or pressing Enter

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b19f04a7d08323802279f6d12d510d