### PR TITLE
Stäng sökfält med back, enter eller förslag

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -141,6 +141,12 @@ if (dom.sIn) {
       history.back();
     }
   });
+  dom.sIn.addEventListener('keydown', e => {
+    if (e.key === 'Enter') dom.sIn.blur();
+  });
+  dom.searchSug?.addEventListener('click', e => {
+    if (e.target.closest('.item')) dom.sIn.blur();
+  });
 }
 
 window.addEventListener('popstate', () => {


### PR DESCRIPTION
## Sammanfattning
- Avbryt sökfält med backknapp via history-state
- Stäng sökfältet när enter trycks eller ett sökförslag väljs

## Test
- `npm test` (misslyckas: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b1b2e2599083239cdf65d47622396b