### PR TITLE
Refine scroll locking for search suggestions

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -34,7 +34,7 @@ class SharedToolbar extends HTMLElement {
 
     /* ----- Lås bakgrunds-scroll när panel eller popup är öppen ----- */
     this.updateScrollLock = () => {
-      const selector = '[id$="Panel"].open, [id$="Popup"].open, .popup.open, #searchSuggest:not([hidden]), #searchField:focus';
+      const selector = '[id$="Panel"].open, [id$="Popup"].open, .popup.open, #searchSuggest:not([hidden])';
       const docOpen = document.querySelector(selector);
       const shadowOpen = this.shadowRoot.querySelector(selector);
       const anyOpen = docOpen || shadowOpen;
@@ -51,6 +51,10 @@ class SharedToolbar extends HTMLElement {
     const sField = this.shadowRoot.getElementById('searchField');
     sField.addEventListener('focus', this.updateScrollLock);
     sField.addEventListener('blur', this.updateScrollLock);
+    const sugEl = this.shadowRoot.getElementById('searchSuggest');
+    ['touchmove','wheel'].forEach(ev =>
+      sugEl.addEventListener(ev, e => e.stopPropagation())
+    );
 
     this.updateScrollLock();
   }
@@ -696,6 +700,7 @@ class SharedToolbar extends HTMLElement {
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));
     if (openPanel && !path.includes(openPanel)) {
       openPanel.classList.remove('open');
+      this.updateScrollLock();
     }
   }
 


### PR DESCRIPTION
## Summary
- Limit scroll lock to panels, popups, and visible search suggestions
- Prevent background scrolling when interacting with search suggestions
- Keep scroll lock in sync when closing panels

## Testing
- ❌ `npm test` (package.json missing)

------
https://chatgpt.com/codex/tasks/task_e_68b1b77c5bd08323968a20e171d3d980