### PR TITLE
Lock background scroll and keep toolbar attached to mobile keyboard

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -39,6 +39,7 @@ body {
   margin-bottom: 90px;         /* plats för toolbar */
 }
 
+html.menu-open,
 body.menu-open {
   overflow: hidden;
 }

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -19,10 +19,12 @@ class SharedToolbar extends HTMLElement {
     const toolbar = this.shadowRoot.querySelector('.toolbar');
     if (window.visualViewport) {
       this._vvHandler = () => {
-        const offset = Math.max(0, window.innerHeight - window.visualViewport.height);
+        const vv = window.visualViewport;
+        const offset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
         toolbar.style.bottom = `${offset}px`;
       };
       window.visualViewport.addEventListener('resize', this._vvHandler);
+      window.visualViewport.addEventListener('scroll', this._vvHandler);
       this._vvHandler();
     }
 
@@ -50,6 +52,7 @@ class SharedToolbar extends HTMLElement {
       const shadowOpen = this.shadowRoot.querySelector(selector);
       const anyOpen = docOpen || shadowOpen;
       document.body.classList.toggle('menu-open', anyOpen);
+      document.documentElement.classList.toggle('menu-open', anyOpen);
     };
     window.updateScrollLock = () => this.updateScrollLock();
 
@@ -72,6 +75,7 @@ class SharedToolbar extends HTMLElement {
 
   disconnectedCallback() {
     window.visualViewport?.removeEventListener('resize', this._vvHandler);
+    window.visualViewport?.removeEventListener('scroll', this._vvHandler);
     document.removeEventListener('click', this._outsideHandler);
     this._bodyObserver?.disconnect();
     this._shadowObserver?.disconnect();


### PR DESCRIPTION
## Summary
- Prevent background scrolling when panels or search suggestions are open by toggling a `menu-open` class on both `html` and `body`.
- Use `visualViewport` scroll and `offsetTop` to keep the toolbar aligned with the mobile keyboard.
- Update CSS to support global scroll locking.

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check js/shared-toolbar.js`
- `npx stylelint css/style.css` *(no config, command terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b1baea718c8323859470230736d343