### PR TITLE
fix: lock toolbar above keyboard

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -20,14 +20,13 @@ class SharedToolbar extends HTMLElement {
     if (window.visualViewport) {
       this._vvHandler = () => {
         /*
-          Placera verktygsraden så långt ned som möjligt. Tidigare
-          justerades bottenpositionen efter tangentbordets höjd vilket
-          gav en extra offset även när tangentbordet inte var öppet.
-          För att alltid hålla verktygsraden dikt an mot skärmens
-          botten sätter vi botten till 0 och låter tangentbordet, om det
-          täcker verktygsraden, ligga ovanpå.
+          Lås verktygsraden precis ovanför tangentbordet. När tangent-
+          bordet inte är öppet blir offset noll och raden placeras mot
+          skärmens nederkant.
         */
-        toolbar.style.bottom = '0px';
+        const vv = window.visualViewport;
+        const offset = Math.max(0, window.innerHeight - (vv.height + vv.offsetTop));
+        toolbar.style.bottom = offset + 'px';
       };
       window.visualViewport.addEventListener('resize', this._vvHandler);
       window.visualViewport.addEventListener('scroll', this._vvHandler);


### PR DESCRIPTION
## Summary
- position toolbar just above on-screen keyboard using visualViewport offset
- retain background scroll lock when search suggestions are visible

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_68b1c0456e5883238b2a4695d0351d59