### PR TITLE
Allow scrolling within open panels

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -51,7 +51,11 @@ class SharedToolbar extends HTMLElement {
     window.confirmPopup = msg => this.openDialog(msg, { cancel: true });
 
     /* ----- Lås bakgrunds-scroll när panel eller popup är öppen ----- */
-    this._preventScroll = e => e.preventDefault();
+    this._preventScroll = e => {
+      if (!e.target.closest('[id$="Panel"].open, [id$="Popup"].open, .popup.open')) {
+        e.preventDefault();
+      }
+    };
     this.updateScrollLock = () => {
       const selector = '[id$="Panel"].open, [id$="Popup"].open, .popup.open, #searchSuggest:not([hidden])';
       const docOpen = document.querySelector(selector);


### PR DESCRIPTION
## Summary
- Prevent global scroll locking on events inside open panels and popups

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c1a8c3208323a397d4c7145e0d54