### PR TITLE
refactor: use template literal for toolbar offset

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -26,7 +26,7 @@ class SharedToolbar extends HTMLElement {
         */
         const vv = window.visualViewport;
         const offset = Math.max(0, window.innerHeight - (vv.height + vv.offsetTop));
-        toolbar.style.bottom = offset + 'px';
+        toolbar.style.bottom = `${offset}px`;
       };
       window.visualViewport.addEventListener('resize', this._vvHandler);
       window.visualViewport.addEventListener('scroll', this._vvHandler);


### PR DESCRIPTION
## Summary
- use template string when setting toolbar bottom position

## Testing
- `node --check js/shared-toolbar.js`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c374086c8323a46df7aa7f7eadf9