### PR TITLE
Remove scroll locking for search overlays

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -39,10 +39,6 @@ body {
   margin-bottom: 90px;         /* plats för toolbar */
 }
 
-html.menu-open,
-body.menu-open {
-  overflow: hidden;
-}
 shared-toolbar {
   display: block;
 }


### PR DESCRIPTION
## Summary
- Drop menu-open class and event handling that prevented body scrolling
- Allow search suggestions to scroll without locking the page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b1fea33c408323b1a1208c421abf71