### PR TITLE
Remove bottom gap beneath toolbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,7 +36,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-bottom: 90px;         /* plats för toolbar */
+  padding-bottom: 90px;        /* plats för toolbar */
 }
 
 shared-toolbar {


### PR DESCRIPTION
## Summary
- prevent extra space under fixed toolbar by replacing body margin with equivalent padding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2015407a08323bd7ef7c2fc031b3d