### PR TITLE
Ensure toolbar stays fixed to bottom

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -411,6 +411,7 @@ input:focus, select:focus, textarea:focus {
   position: fixed;
   bottom: 0;
   left: 0;
+  right: 0;
   width: 100%;
   z-index: 900;
   background: var(--panel);

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -73,6 +73,7 @@ class SharedToolbar extends HTMLElement {
           position: fixed;
           bottom: 0;
           left: 0;
+          right: 0;
           width: 100%;
           z-index: 900;
           background: var(--panel);


### PR DESCRIPTION
## Summary
- Explicitly set the toolbar's right edge in shared toolbar component and global stylesheet to keep it anchored at the screen's bottom.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b202ab72a0832384aa83dac24d80c1