### PR TITLE
Clamp tiny visual viewport offset

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -25,7 +25,8 @@ class SharedToolbar extends HTMLElement {
           skärmens nederkant.
         */
         const vv = window.visualViewport;
-        const offset = Math.max(0, window.innerHeight - (vv.height + vv.offsetTop));
+        let offset = Math.max(0, window.innerHeight - (vv.height + vv.offsetTop));
+        if (offset < 1) offset = 0;
         toolbar.style.bottom = `${offset}px`;
       };
       window.visualViewport.addEventListener('resize', this._vvHandler);


### PR DESCRIPTION
## Summary
- Avoid sub-pixel gaps when visual viewport height is near full screen by clamping very small toolbar offsets to 0.

## Testing
- ⚠️ `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b2046713a88323853c56fcc6878694