### PR TITLE
Lock background scrolling when menus open

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -39,6 +39,12 @@ body {
   padding-bottom: 90px;        /* plats för toolbar */
 }
 
+body.no-scroll {
+  position: fixed;
+  overflow: hidden;
+  width: 100%;
+}
+
 shared-toolbar {
   display: block;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -15,6 +15,25 @@
   // events arrive after fast clicks.
   let manualCloseCount = 0;
 
+  let scrollLocked = false;
+  let scrollY = 0;
+
+  function lockScroll() {
+    if (scrollLocked) return;
+    scrollY = window.scrollY || window.pageYOffset;
+    document.body.style.top = `-${scrollY}px`;
+    document.body.classList.add('no-scroll');
+    scrollLocked = true;
+  }
+
+  function unlockScroll() {
+    if (!scrollLocked) return;
+    document.body.classList.remove('no-scroll');
+    document.body.style.top = '';
+    window.scrollTo(0, scrollY);
+    scrollLocked = false;
+  }
+
   function isOverlay(el) {
     if (!(el instanceof HTMLElement)) return false;
     if (el.classList.contains('popup') || el.classList.contains('offcanvas')) return true;
@@ -41,6 +60,11 @@
             history.back();
           }
         }
+      }
+      if (overlayStack.length > 0) {
+        lockScroll();
+      } else {
+        unlockScroll();
       }
     });
     obs.observe(root, { attributes: true, attributeFilter: ['class'], subtree: true });


### PR DESCRIPTION
## Summary
- prevent page from scrolling when any popup or panel menu is open
- add CSS helper class for locking body scroll

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `apt-get update` *(fails: gpgv, gpgv2 or gpgv1 required)*

------
https://chatgpt.com/codex/tasks/task_e_68b205bfd8408323925173c0379b7858