### PR TITLE
feat: close menus with escape on desktop

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -92,6 +92,17 @@
       setTimeout(() => { isPop = false; });
     }
   });
+
+  // Close open menus/panels with Escape on desktop devices
+  window.addEventListener('keydown', e => {
+    if (e.key !== 'Escape') return;
+    // Detect desktop by fine pointer (e.g. mouse)
+    if (!window.matchMedia('(pointer: fine)').matches) return;
+    if (overlayStack.length > 0) {
+      e.preventDefault();
+      history.back();
+    }
+  });
 })();
 
 /* ---------- Grunddata & konstanter ---------- */


### PR DESCRIPTION
## Summary
- close open menus/panels on desktop when Escape key is pressed

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2083562288323a6f5267e4bbe55fe