### PR TITLE
Always display entry badges

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -341,16 +341,15 @@ input:focus, select:focus, textarea:focus {
 /* Hide default price line in compact; use badges instead */
 .card.compact .card-price { display: none; }
 
-/* Always-visible compact meta badges (P, V, level) */
+/* Meta badges (P, V, level) */
 .meta-badges {
-  display: none;
+  display: inline-flex;
   gap: .35rem;
   align-items: center;
   margin-right: auto; /* push buttons to the right */
   flex: 1 1 auto;
   min-width: 0;
 }
-.card.compact .meta-badges { display: inline-flex; }
 .meta-badge {
   background: var(--border);
   color: var(--txt);

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -333,7 +333,7 @@ function initIndex() {
         if (priceText) badgeParts.push(`<span class="meta-badge price-badge" title="${priceBadgeLabel}">${priceBadgeText}: ${priceText}</span>`);
         if (weightVal != null) badgeParts.push(`<span class="meta-badge weight-badge" title="Vikt">V: ${weightVal}</span>`);
         if (isInv(p) && lvlShort) badgeParts.push(`<span class="meta-badge level-badge" title="${lvlBadgeVal}">${lvlShort}</span>`);
-        const metaBadges = compact && badgeParts.length ? `<div class="meta-badges">${badgeParts.join('')}</div>` : '';
+        const metaBadges = badgeParts.length ? `<div class="meta-badges">${badgeParts.join('')}</div>` : '';
         if (infoTagsHtml) {
           infoHtml = `<div class="tags">${infoTagsHtml}</div><br>${infoHtml}`;
         }


### PR DESCRIPTION
## Summary
- Show P/V/level badges in all entry views, not just compact
- Simplify meta badge styling to always display

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b20b1b972883238d490667d244d386