### PR TITLE
Remove legacy price line from item cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -331,15 +331,6 @@ input:focus, select:focus, textarea:focus {
 #valda .card.compact .inv-controls {
   display: flex;
 }
-.card-price {
-  position: absolute;
-  bottom: 0.6rem;
-  left: 1.3rem;
-  font-size: .9rem;
-  color: var(--subtxt);
-}
-/* Hide default price line in compact; use badges instead */
-.card.compact .card-price { display: none; }
 
 /* Meta badges (P, V, level) */
 .meta-badges {

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -388,13 +388,11 @@ function initIndex() {
           : '';
         const levelHtml = hideDetails ? '' : lvlSel;
         const descHtml = (!compact && !hideDetails) ? `<div class="card-desc">${desc}</div>` : '';
-        const priceHtml = (!compact && priceText) ? `<div class="card-price">${priceLabel} ${priceText}</div>` : '';
         li.innerHTML = `
           <div class="card-title"><span>${p.namn}${badge}</span>${xpHtml}</div>
           ${tagsDiv}
           ${levelHtml}
           ${descHtml}
-          ${priceHtml}
           ${btn}`;
         listEl.appendChild(li);
       });


### PR DESCRIPTION
## Summary
- remove old gray price line from item cards
- clean up styling related to card-price

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b20c9d9edc8323bcb9d72c4bb16c86