### PR TITLE
Ignore small visual viewport offsets for toolbar positioning

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -26,8 +26,11 @@ class SharedToolbar extends HTMLElement {
         */
         const vv = window.visualViewport;
         let offset = Math.max(0, window.innerHeight - (vv.height + vv.offsetTop));
-        if (offset < 1) offset = 0;
-        toolbar.style.bottom = `${offset}px`;
+        if (offset < 50) {
+          toolbar.style.bottom = 'env(safe-area-inset-bottom)';
+        } else {
+          toolbar.style.bottom = `calc(env(safe-area-inset-bottom) + ${offset}px)`;
+        }
       };
       window.visualViewport.addEventListener('resize', this._vvHandler);
       window.visualViewport.addEventListener('scroll', this._vvHandler);


### PR DESCRIPTION
## Summary
- Clamp small visual viewport offsets to zero and align toolbar to `env(safe-area-inset-bottom)` for better iOS behavior

## Testing
- ⚠️ `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b20f363b048323bc42267e288a3a56