### PR TITLE
Fix toolbar position after search field blur

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -35,6 +35,14 @@ class SharedToolbar extends HTMLElement {
       window.visualViewport.addEventListener('resize', this._vvHandler);
       window.visualViewport.addEventListener('scroll', this._vvHandler);
       this._vvHandler();
+
+      // Recalculate toolbar position after the search field loses focus.
+      // iOS sometimes keeps an extra offset after the keyboard closes,
+      // so run the handler again once the viewport has settled.
+      const searchIn = this.shadowRoot.getElementById('searchField');
+      searchIn?.addEventListener('blur', () =>
+        setTimeout(this._vvHandler, 100)
+      );
     }
 
     this.cache();


### PR DESCRIPTION
## Summary
- Recalculate toolbar offset when the search field loses focus to prevent the bar from floating above the bottom on iOS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b213ee886883239cd37882fb736449