### PR TITLE
Fix search suggestion filtering

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -186,7 +186,10 @@ if (dom.sIn) {
     }
   });
   dom.searchSug?.addEventListener('click', e => {
-    if (e.target.closest('.item')) dom.sIn.blur();
+    if (e.target.closest('.item')) {
+      // Delay blur so suggestion handlers can run first
+      setTimeout(() => dom.sIn.blur(), 0);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Delay search field blur when clicking a suggestion so it can add the filter first

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2168881848323b556805c0c37712f