### PR TITLE
Replace elite ability text with emoji

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -596,10 +596,6 @@ select.level {
     padding: .3rem .5rem;
     font-size: .9rem;
   }
-  .inv-controls .char-btn[data-elite-req] {
-    padding: .15rem .25rem;
-    font-size: .45rem;
-  }
   .inv-buttons { gap: .3rem; flex-wrap: wrap; }
   .inv-buttons .char-btn {
     padding: .35rem .6rem;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -354,7 +354,7 @@ function initIndex() {
         const badge = multi && count>0 ? ` <span class="count-badge">×${count}</span>` : '';
         const showInfo = compact || hideDetails;
         const eliteBtn = isElityrke(p)
-          ? `<button class="char-btn" data-elite-req="${p.namn}">Lägg till med förmågor</button>`
+          ? `<button class="char-btn" data-elite-req="${p.namn}">🏋🏻‍♂️</button>`
           : '';
         const allowAdd = !(isService(p) || isEmployment(p));
         let btn = '';


### PR DESCRIPTION
## Summary
- Replace "Lägg till med förmågor" text with 🏋🏻‍♂️ emoji for elite ability button
- Remove mobile CSS rule that shrank elite ability button so it matches other controls

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b217bfc1f48323ad47122a0584c455