### PR TITLE
Handle search suggestions before blur hides them

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -485,9 +485,10 @@ function initCharacter() {
   {
     const sugEl = document.querySelector('shared-toolbar')?.shadowRoot?.getElementById('searchSuggest');
     if (sugEl) {
-      sugEl.addEventListener('click', e => {
+      sugEl.addEventListener('mousedown', e => {
         const it = e.target.closest('.item');
         if (!it) return;
+        e.preventDefault();
         const val = (it.dataset.val || '').trim();
         if (val && !F.search.includes(val)) F.search.push(val);
         if (val && window.storeHelper?.addRecentSearch) {

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -425,9 +425,10 @@ function initIndex() {
   {
     const sugEl = document.querySelector('shared-toolbar')?.shadowRoot?.getElementById('searchSuggest');
     if (sugEl) {
-      sugEl.addEventListener('click', e => {
+      sugEl.addEventListener('mousedown', e => {
         const it = e.target.closest('.item');
         if (!it) return;
+        e.preventDefault();
         const val = (it.dataset.val || '').trim();
         if (val && !F.search.includes(val)) F.search.push(val);
         if (val && window.storeHelper?.addRecentSearch) {

--- a/js/main.js
+++ b/js/main.js
@@ -171,24 +171,20 @@ if (dom.sIn) {
     searchFocus = true;
   });
   dom.sIn.addEventListener('blur', () => {
-    const sugEl = dom.searchSug || (document.querySelector('shared-toolbar')?.shadowRoot?.getElementById('searchSuggest'));
-    if (sugEl) sugEl.hidden = true;
-    if (searchFocus) {
-      searchFocus = false;
-      history.back();
-    }
+    setTimeout(() => {
+      const sugEl = dom.searchSug || (document.querySelector('shared-toolbar')?.shadowRoot?.getElementById('searchSuggest'));
+      if (sugEl) sugEl.hidden = true;
+      if (searchFocus) {
+        searchFocus = false;
+        history.back();
+      }
+    }, 0);
   });
   dom.sIn.addEventListener('keydown', e => {
     if (e.key === 'Enter') dom.sIn.blur();
     else if (e.key === 'Escape' && window.matchMedia('(pointer: fine)').matches) {
       e.preventDefault();
       dom.sIn.blur();
-    }
-  });
-  dom.searchSug?.addEventListener('click', e => {
-    if (e.target.closest('.item')) {
-      // Delay blur so suggestion handlers can run first
-      setTimeout(() => dom.sIn.blur(), 0);
     }
   });
 }


### PR DESCRIPTION
## Summary
- Delay search-field blur handler so suggestion clicks can process first
- Handle suggestion selection on mousedown with prevented blur in index and character views

## Testing
- `node --check js/main.js`
- `node --check js/index-view.js`
- `node --check js/character-view.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b21948a9508323a13cb8f180997906