### PR TITLE
Use plural category name for Tabell

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -46,7 +46,8 @@
     'Specialverktyg',
     'Diverse',
     'Mat',
-    'Dryck'
+    'Dryck',
+    'Tabell'
   ];
 
   const CAT_DISPLAY = {
@@ -75,7 +76,8 @@
     'Dryck': 'Drycker',
     'Byggnad': 'Byggnader',
     'Förvaring': 'Förvaringsföremål',
-    'Fälla': 'Fällor'
+    'Fälla': 'Fällor',
+    'Tabell': 'Tabeller'
   };
 
   function catName(cat){


### PR DESCRIPTION
## Summary
- Display "Tabell" entries under pluralized category "Tabeller"
- Include Tabell in the category order list

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b6a057cc8323874792e2c6af1822