### PR TITLE
Disable table popup toggles on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1942,6 +1942,9 @@ textarea.auto-resize {
 }
 
 @media (max-width: 600px) {
+  #tabellPopup .popup-header #tabellActions {
+    display: none;
+  }
   #tabellPopup .popup-inner {
     width: 100%;
     height: 100%;

--- a/js/tabell-popup.js
+++ b/js/tabell-popup.js
@@ -18,18 +18,26 @@
     `;
     document.body.appendChild(wrap);
     wrap.querySelector('#tabellClose').addEventListener('click', close);
-    wrap.querySelector('#tabellWidth').addEventListener('click', (e) => {
-      const inner = wrap.querySelector('.popup-inner');
-      inner.classList.toggle('wide');
-      // Red when OFF
-      e.currentTarget.classList.toggle('danger', !inner.classList.contains('wide'));
-    });
-    wrap.querySelector('#tabellNoWrap').addEventListener('click', (e) => {
-      const inner = wrap.querySelector('.popup-inner');
-      inner.classList.toggle('nowrap');
-      // Red when OFF
-      e.currentTarget.classList.toggle('danger', !inner.classList.contains('nowrap'));
-    });
+
+    const actions = wrap.querySelector('#tabellActions');
+    const isMobile = window.matchMedia('(max-width: 600px)').matches;
+
+    if (isMobile) {
+      actions.remove();
+    } else {
+      wrap.querySelector('#tabellWidth').addEventListener('click', (e) => {
+        const inner = wrap.querySelector('.popup-inner');
+        inner.classList.toggle('wide');
+        // Red when OFF
+        e.currentTarget.classList.toggle('danger', !inner.classList.contains('wide'));
+      });
+      wrap.querySelector('#tabellNoWrap').addEventListener('click', (e) => {
+        const inner = wrap.querySelector('.popup-inner');
+        inner.classList.toggle('nowrap');
+        // Red when OFF
+        e.currentTarget.classList.toggle('danger', !inner.classList.contains('nowrap'));
+      });
+    }
     wrap.addEventListener('click', e => {
       if (e.target === wrap) close();
     });


### PR DESCRIPTION
## Summary
- Remove table popup header actions on small screens so users can't toggle wrapping or width
- Hide table popup action buttons with mobile-specific CSS

## Testing
- `node --check js/tabell-popup.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cde6489c8323bf71577b3d589303