### PR TITLE
Search matches ability level text

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -371,7 +371,8 @@ function initCharacter() {
     return base
       .filter(p => !isInv(p))
       .filter(p => {
-        const text = searchNormalize(`${p.namn} ${(p.beskrivning || '')}`.toLowerCase());
+        const levelText = Object.values(p.nivåer || {}).join(' ');
+        const text = searchNormalize(`${p.namn} ${(p.beskrivning || '')} ${levelText}`.toLowerCase());
         const hasTerms = terms.length > 0;
         const txt = hasTerms && terms.every(q => text.includes(q));
         const tags = p.taggar || {};

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -280,7 +280,8 @@ function initIndex() {
       }
     }
     return baseEntries.filter(p=>{
-      const text = searchNormalize(`${p.namn} ${(p.beskrivning||'')}`.toLowerCase());
+      const levelText = Object.values(p.nivåer || {}).join(' ');
+      const text = searchNormalize(`${p.namn} ${(p.beskrivning||'')} ${levelText}`.toLowerCase());
       const hasTerms = terms.length > 0;
       const txt = hasTerms && terms.every(q => text.includes(q));
       const tags = p.taggar || {};


### PR DESCRIPTION
## Summary
- Extend search filtering to include text from ability levels

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check js/index-view.js`
- `node --check js/character-view.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5def9e5948323a39fa06e7768c783