### PR TITLE
Add active character requirement popup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1617,7 +1617,13 @@ select.level {
   gap: .8rem;
 }
 #charPopup.open .popup-inner { transform: scale(1); }
-#charPopup .popup-inner button { width: 100%; }
+#charPopup .button-row {
+  display: flex;
+  gap: .6rem;
+}
+#charPopup .button-row button {
+  flex: 1;
+}
 #charPopupContent {
   display: flex;
   flex-direction: column;

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -28,7 +28,7 @@ function initCharacter() {
   const clearBtn = document.getElementById('clearNonInv');
   if (clearBtn) {
     clearBtn.addEventListener('click', async () => {
-      if (!store.current) { await alertPopup('Ingen rollperson vald.'); return; }
+      if (!store.current && !(await requireCharacter())) return;
       const ok = await confirmPopup('Detta tar bort Ras, Yrken, Elityrken, Förmågor, Mystisk kraft, Ritualer, Fördelar, Nackdelar, Särdrag och Monstruösa särdrag från karaktären. Inventariet lämnas orört. Vill du fortsätta?');
       if (!ok) return;
       const before = storeHelper.getCurrentList(store);

--- a/js/elite-add.js
+++ b/js/elite-add.js
@@ -284,7 +284,7 @@ div.innerHTML=`<div class="popup-inner"><h3 id="masterTitle">L\u00e4gg till elit
   }
 
   async function addReq(entry, levels){
-    if(!store.current){ await alertPopup('Ingen rollperson vald.'); return; }
+    if(!store.current && !(await requireCharacter())) return;
     const names=parseNames(entry.krav_formagor||'');
     const listNames = new Set(names);
     if(levels && typeof levels==='object'){
@@ -307,7 +307,7 @@ div.innerHTML=`<div class="popup-inner"><h3 id="masterTitle">L\u00e4gg till elit
   }
 
   async function addElite(entry, opts = {}){
-    if(!store.current){ await alertPopup('Ingen rollperson vald.'); return; }
+    if(!store.current && !(await requireCharacter())) return;
     const list = storeHelper.getCurrentList(store);
     if(list.some(x=>x.namn===entry.namn)) return;
     const skipDup = !!opts.skipDuplicateConfirm;
@@ -332,7 +332,7 @@ div.innerHTML=`<div class="popup-inner"><h3 id="masterTitle">L\u00e4gg till elit
     const name=btn.dataset.eliteReq;
     const entry=DB.find(x=>x.namn===name);
     if(!entry) return;
-    if(!store.current){ await alertPopup('Ingen rollperson vald.'); return; }
+    if(!store.current && !(await requireCharacter())) return;
     const listPre = storeHelper.getCurrentList(store);
     if(listPre.some(x=>x.namn===entry.namn)) return;
     if(listPre.some(isElityrke)){

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -903,10 +903,7 @@ function initIndex() {
     }
     const btn=e.target.closest('button[data-act]');
     if (!btn) return;
-    if (!store.current) {
-      await alertPopup('Ingen rollperson vald.');
-      return;
-    }
+    if (!store.current && !(await requireCharacter())) return;
     const name = btn.dataset.name;
     const tr = btn.closest('li').dataset.trait || null;
     const p  = getEntries().find(x=>x.namn===name);


### PR DESCRIPTION
## Summary
- Replace startup blocker with on-demand popup asking for an active character
- Allow selecting or creating a character from the popup
- Apply consistent styling and update actions to invoke the new popup

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68babe0b06848323ae703d16cb481855