### PR TITLE
Allow dismissing character requirement popup

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1300,7 +1300,15 @@ async function requireCharacter() {
       btnNew.removeEventListener('click', onNew);
       btnCancel.removeEventListener('click', onCancel);
       select.removeEventListener('change', onSelect);
+      pop.removeEventListener('click', onClickOut);
+      document.removeEventListener('keydown', onKey);
       resolve(res);
+    }
+    function onClickOut(e) {
+      if (e.target === pop) close(false);
+    }
+    function onKey(e) {
+      if (e.key === 'Escape') close(false);
     }
     function onChoose() {
       wrap.style.display = '';
@@ -1341,6 +1349,8 @@ async function requireCharacter() {
     btnNew.addEventListener('click', onNew);
     btnCancel.addEventListener('click', onCancel);
     select.addEventListener('change', onSelect);
+    pop.addEventListener('click', onClickOut);
+    document.addEventListener('keydown', onKey);
   });
 }
 


### PR DESCRIPTION
## Summary
- allow closing the character requirement popup by clicking outside
- support dismissing the popup with the Escape key

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bac096f4188323b21fb1a972821ef2