### PR TITLE
Remove 'Flytta till mapp' button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1630,33 +1630,6 @@ select.level {
   gap: .8rem;
 }
 
-/* ---------- Popup för Flytta till mapp ---------- */
-#moveFolderPopup {
-  position: fixed;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0,0,0,.6);
-  z-index: 3000;
-}
-#moveFolderPopup.open { display: flex; }
-#moveFolderPopup .popup-inner {
-  background: var(--panel);
-  border: 1.5px solid var(--border);
-  border-radius: 1.2rem;
-  box-shadow: var(--shadow);
-  padding: 1.5rem 1.4rem 2rem;
-  max-width: 420px;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: .8rem;
-}
-#moveFolderPopup .popup-inner button { width: 100%; }
-
 /* ---------- Popup för Mapphanterare ---------- */
 #folderManagerPopup {
   position: fixed;

--- a/js/main.js
+++ b/js/main.js
@@ -488,13 +488,6 @@ function bindToolbar() {
       });
     }
 
-    /* Flytta till mapp ------------------------------------ */
-    if (id === 'moveToFolder') {
-      if (!store.current && !(await requireCharacter())) return;
-      // Öppna Mappar-UI och använd inbyggda flytta-sektionen för enhetligt UI
-      openFolderManagerPopup();
-    }
-
     /* Mapphanterare --------------------------------------- */
     if (id === 'manageFolders') {
       openFolderManagerPopup();
@@ -672,44 +665,6 @@ function bindToolbar() {
       if (window.indexViewUpdate) window.indexViewUpdate();
     });
   }
-}
-
-// ---------- Popup: Flytta rollperson till mapp ----------
-function openMoveToFolderPopup(cb) {
-  const pop  = bar.shadowRoot.getElementById('moveFolderPopup');
-  const sel  = bar.shadowRoot.getElementById('moveFolderSelect');
-  const ok   = bar.shadowRoot.getElementById('moveFolderApply');
-  const cls  = bar.shadowRoot.getElementById('moveFolderCancel');
-  // fyll val
-  const folders = (storeHelper.getFolders(store) || []).slice()
-    .sort((a,b)=> (a.order ?? 0) - (b.order ?? 0) || String(a.name||'').localeCompare(String(b.name||''), 'sv'));
-  const currentId = store.current;
-  const curFolder = currentId ? storeHelper.getCharacterFolder(store, currentId) : '';
-  sel.innerHTML = folders.map(f=>`<option value="${f.id}"${f.id===curFolder?' selected':''}>${f.name}</option>`).join('');
-
-  pop.classList.add('open');
-  pop.querySelector('.popup-inner').scrollTop = 0;
-  function close() {
-    pop.classList.remove('open');
-    ok.removeEventListener('click', onOk);
-    cls.removeEventListener('click', onCancel);
-    pop.removeEventListener('click', onOutside);
-  }
-  function onOk() {
-    const val = sel.value || '';
-    close();
-    cb(val);
-  }
-  function onCancel() { close(); cb(null); }
-  function onOutside(e) {
-    if(!pop.querySelector('.popup-inner').contains(e.target)){
-      close();
-      cb(null);
-    }
-  }
-  ok.addEventListener('click', onOk);
-  cls.addEventListener('click', onCancel);
-  pop.addEventListener('click', onOutside);
 }
 
 // ---------- Popup: Mapphanterare ----------

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -266,8 +266,8 @@ class SharedToolbar extends HTMLElement {
         </div>
 
         <div class="char-btn-row three-col">
-          <button id="moveToFolder" class="char-btn">Flytta till mapp</button>
           <button id="manageFolders" class="char-btn">Mappar …</button>
+          <button class="char-btn" disabled style="visibility:hidden"></button>
           <button class="char-btn" disabled style="visibility:hidden"></button>
         </div>
 
@@ -567,19 +567,6 @@ class SharedToolbar extends HTMLElement {
           </div>
         </div>
       </div>
-
-      <!-- ---------- Popup Flytta till mapp ---------- -->
-      <div id="moveFolderPopup" class="popup popup-bottom">
-        <div class="popup-inner">
-          <h3>Flytta till mapp</h3>
-          <select id="moveFolderSelect"></select>
-          <div class="button-row" style="margin-top:.6rem;">
-            <button id="moveFolderApply" class="char-btn">Verkställ</button>
-            <button id="moveFolderCancel" class="char-btn danger">Avbryt</button>
-          </div>
-        </div>
-      </div>
-
       <!-- ---------- Popup Mapphanterare ---------- -->
       <div id="folderManagerPopup" class="popup popup-bottom">
         <div class="popup-inner folder-ui">
@@ -803,7 +790,7 @@ class SharedToolbar extends HTMLElement {
     }
 
     // ignore clicks inside popups so panels stay open
-      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','pricePopup','rowPricePopup','vehiclePopup','vehicleRemovePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup','dialogPopup','moveFolderPopup','folderManagerPopup'];
+      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','pricePopup','rowPricePopup','vehiclePopup','vehicleRemovePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup','dialogPopup','folderManagerPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));


### PR DESCRIPTION
## Summary
- remove the unused "Flytta till mapp" button
- delete move-folder popup and related styles
- rely on folder manager popup for moving characters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bac0d2ce448323a34ab00d791af4cc