### PR TITLE
Revise filter toolbar button layout and labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sidan fungerar helt offline och sparar all data i din webbläsares lagring.
 
 ## Export och import av rollpersoner
 
-Use the **Exportera** button in the filter panel to open a menu where you can either download a specific character as a JSON file, or download all saved characters together as a single JSON file. "Alla rollpersoner" ligger alltid överst och den aktiva rollpersonen visas näst högst upp. When supported by your browser a “Save As” dialog allows you to pick both filename and location; otherwise the files are downloaded normally. The **Importera** button lets you select one or more such files — including a single file containing multiple characters — to recreate characters (requires that the database is loaded). Anteckningar följer med vid export så länge något fält är ifyllt.
+Use the **Export** button in the filter panel to open a menu where you can either download a specific character as a JSON file, or download all saved characters together as a single JSON file. "Alla rollpersoner" ligger alltid överst och den aktiva rollpersonen visas näst högst upp. When supported by your browser a “Save As” dialog allows you to pick both filename and location; otherwise the files are downloaded normally. The **Import** button lets you select one or more such files — including a single file containing multiple characters — to recreate characters (requires that the database is loaded). Anteckningar följer med vid export så länge något fält är ifyllt.
 
 ## Anteckningssidan
 
@@ -63,8 +63,8 @@ Verktygsraden innehåller:
 I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 - **Ny rollperson** skapar en tom karaktär och gör den aktiv.
 - **Ta bort rollperson** raderar den aktuella karaktären.
-- **Exportera** öppnar en meny där du kan ladda ner alla rollpersoner eller välja en specifik att exportera som JSON-fil.
-- **Importera** återställer en eller flera karaktärer från sparade filer.
+- **Export** öppnar en meny där du kan ladda ner alla rollpersoner eller välja en specifik att exportera som JSON-fil.
+- **Import** återställer en eller flera karaktärer från sparade filer.
 - **⚒️**, **⚗️** och **🏺** anger nivå på smed, alkemist och artefaktmakare i ditt sällskap. Dessa nivåer används för att räkna ut rabatter på priser.
 - **🔭** gör att flera filter kombineras med OR i stället för AND, vilket ger en bredare sökning.
 - **🤏** växlar mellan vanlig och kompakt listvy.
@@ -100,7 +100,7 @@ Både i index-vyn och i din karaktär visas poster som kort.
 - Monstruösa särdrag kan inte staplas.
 
 ### 9. Export och import
-Se avsnittet ovan. Exportera öppnar en meny där du kan spara alla karaktärer som en samlad JSON-fil, eller välja en enskild karaktär som JSON-fil. Importera läser in sparade filer (även en fil med flera karaktärer) och återställer karaktärer. Anteckningar följer med så länge minst ett fält innehåller text. All data sparas i webblagring så inget backend behövs.
+Se avsnittet ovan. Export öppnar en meny där du kan spara alla karaktärer som en samlad JSON-fil, eller välja en enskild karaktär som JSON-fil. Import läser in sparade filer (även en fil med flera karaktärer) och återställer karaktärer. Anteckningar följer med så länge minst ett fält innehåller text. All data sparas i webblagring så inget backend behövs.
 
 ### 10. Tips och tricks
 - Alla dina val sparas automatiskt i webblagringen på datorn.

--- a/css/style.css
+++ b/css/style.css
@@ -146,6 +146,9 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 .char-btn-row.three-col {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
+.char-btn-row.four-col {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
 .char-btn-row.three-col + .char-btn-row.three-col {
   margin-top: 0;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -472,7 +472,7 @@ function bindToolbar() {
       if (dom.cName) dom.cName.textContent = newName;
     }
 
-    /* Exportera rollperson --------------------------------- */
+    /* Export rollperson --------------------------------- */
     if (id === 'exportChar') {
       if (!store.characters.length) { await alertPopup('Inga rollpersoner att exportera.'); return; }
       openExportPopup(async choice => {
@@ -493,7 +493,7 @@ function bindToolbar() {
       openFolderManagerPopup();
     }
 
-    /* Importera rollperson -------------------------------- */
+    /* Import rollperson -------------------------------- */
     if (id === 'importChar') {
       (async () => {
         try {

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -259,16 +259,11 @@ class SharedToolbar extends HTMLElement {
           <button id="renameChar" class="char-btn">Byt namn</button>
           <button id="newCharBtn" class="char-btn">Ny rollperson</button>
         </div>
-        <div class="char-btn-row three-col">
+        <div class="char-btn-row four-col">
           <button id="deleteChar" class="char-btn danger">Ta bort rollperson</button>
-          <button id="importChar" class="char-btn">Importera</button>
-          <button id="exportChar" class="char-btn">Exportera</button>
-        </div>
-
-        <div class="char-btn-row three-col">
-          <button id="manageFolders" class="char-btn">Mappar …</button>
-          <button class="char-btn" disabled style="visibility:hidden"></button>
-          <button class="char-btn" disabled style="visibility:hidden"></button>
+          <button id="manageFolders" class="char-btn">Folders …</button>
+          <button id="importChar" class="char-btn">Import</button>
+          <button id="exportChar" class="char-btn">Export</button>
         </div>
 
         <div class="filter-group">
@@ -549,7 +544,7 @@ class SharedToolbar extends HTMLElement {
       <!-- ---------- Popup Export ---------- -->
       <div id="exportPopup" class="popup">
         <div class="popup-inner">
-          <h3>Exportera</h3>
+          <h3>Export</h3>
           <div id="exportOptions"></div>
           <button id="exportCancel" class="char-btn danger">Avbryt</button>
         </div>
@@ -663,7 +658,7 @@ class SharedToolbar extends HTMLElement {
             <li>Aktiv mapp: Begränsar listan ”Välj rollperson”. ”Alla” visar alla mappar.</li>
             <li>Typ, Arketyp, Test: Filtrerar listor.</li>
             <li>Ny/Kopiera/Byt namn/Ta bort: Hanterar karaktärer.</li>
-            <li>Exportera/Importera: Säkerhetskopiera eller hämta karaktärer som JSON.</li>
+            <li>Export/Import: Säkerhetskopiera eller hämta karaktärer som JSON.</li>
             <li>⚒️/⚗️/🏺: Välj nivå för smed, alkemist och artefaktmakare (påverkar pris och åtkomst).</li>
             <li>🔭 Utvidga sökning: Växla till OR-filter (matcha någon tag).</li>
             <li>🤏 Kompakt vy: Växla kortare listvy.</li>
@@ -733,7 +728,7 @@ class SharedToolbar extends HTMLElement {
           <h3>Data & lagring</h3>
           <ul>
             <li>Allt sparas lokalt i din webbläsare (localStorage).</li>
-            <li>Använd Exportera/Importera under Filter för säkerhetskopior och flytt mellan enheter.</li>
+            <li>Använd Export/Import under Filter för säkerhetskopior och flytt mellan enheter.</li>
             <li>Rensar du webbläsardata tas lokala rollpersoner bort.</li>
           </ul>
 

--- a/js/store.js
+++ b/js/store.js
@@ -1222,7 +1222,7 @@ function defaultTraits() {
     }
   }
 
-  /* ---------- 7. Exportera ---------- */
+  /* ---------- 7. Export ---------- */
   global.storeHelper = {
     load,
     save,


### PR DESCRIPTION
## Summary
- Rename "Mappar" button to "Folders" and move it next to "Ta bort" within a four-button row.
- Adjust filter toolbar to evenly space four buttons and add CSS for a four-column layout.
- Switch Import/Export labels to English across UI and docs, updating related help text.

## Testing
- ⚠️ `npm test` (package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_68bac302914c8323adabca632906fe57