### PR TITLE
Add folder import and grouped export options

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -1146,7 +1146,7 @@ function defaultTraits() {
   }
 
   /* ---------- 7. Export / Import av karaktärer ---------- */
-  function exportCharacterJSON(store, id) {
+  function exportCharacterJSON(store, id, includeFolder = true) {
     const charId = id || store.current;
     if (!charId) return null;
     const char = store.characters.find(c => c.id === charId);
@@ -1163,7 +1163,7 @@ function defaultTraits() {
     } catch {}
     return {
       name: char.name,
-      ...(folderName ? { folder: folderName } : {}),
+      ...(includeFolder && folderName ? { folder: folderName } : {}),
       data: stripDefaults({
         ...data,
         list: compressList(data.list),


### PR DESCRIPTION
## Summary
- Allow importing character data from selected folders and JSON bundles with folder groups
- Add "Alla (i mappar)" export option to export characters grouped by folder
- Ensure "Exportera alla" single-file and zip exports ignore folder metadata

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bac519b8148323907cb8cb07f8b57d