### PR TITLE
Restrict import to JSON files

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -557,6 +557,7 @@ function bindToolbar() {
           }
           let imported = 0;
           for (const file of files) {
+            if (!file.name.toLowerCase().endsWith('.json')) continue;
             try {
               const text = await file.text();
               const obj = JSON.parse(text);


### PR DESCRIPTION
## Summary
- ensure import routine only processes files ending with `.json`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bacc8d554083238167f169c3fff31f