### PR TITLE
Fix import JSON handling

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -545,7 +545,6 @@ function bindToolbar() {
             inp.type = 'file';
             inp.accept = 'application/json';
             inp.multiple = true;
-            inp.webkitdirectory = true;
             files = await new Promise((resolve, reject) => {
               inp.addEventListener('change', () => {
                 const list = inp.files && inp.files.length ? Array.from(inp.files) : null;


### PR DESCRIPTION
## Summary
- Allow uploading individual JSON files during import

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baceae0b5c83238e521bbc34b8549b