### PR TITLE
Fix styling of force defense button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -204,6 +204,10 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   font-size: 1.2rem;
   cursor: pointer;
   transition: transform .1s ease, opacity .1s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
 }
 .party-toggle:hover  { opacity: .85; }
 .party-toggle:active { transform: scale(.95); opacity: .7; }


### PR DESCRIPTION
## Summary
- ensure party toggles don't shrink or clip by using inline-flex and no shrink

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baf1090cec832397295c5f545e0c12