### PR TITLE
Nollställ fritextsökning vid ny sökning

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -599,9 +599,13 @@ function initCharacter() {
         if (!it) return;
         e.preventDefault();
         const val = (it.dataset.val || '').trim();
-        if (val && !F.search.includes(val)) F.search.push(val);
-        if (val && window.storeHelper?.addRecentSearch) {
-          storeHelper.addRecentSearch(store, val);
+        if (val) {
+          F.search = [val];
+          if (window.storeHelper?.addRecentSearch) {
+            storeHelper.addRecentSearch(store, val);
+          }
+        } else {
+          F.search = [];
         }
         dom.sIn.value = '';
         sTemp = '';
@@ -671,7 +675,7 @@ function initCharacter() {
         updateSearchDatalist();
         return;
       }
-      if(sTemp && !F.search.includes(sTemp)) F.search.push(sTemp);
+      F.search = sTemp ? [sTemp] : [];
       dom.sIn.value=''; sTemp='';
       activeTags(); renderSkills(filtered()); renderTraits(); updateSearchDatalist();
     }

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -636,7 +636,11 @@ function initIndex() {
           return;
         } else {
           const val = (it.dataset.val || '').trim();
-          if (val && !F.search.includes(val)) F.search.push(val);
+          if (val) {
+            F.search = [val];
+          } else {
+            F.search = [];
+          }
           // If exact name match, open that category once
           if (val) {
             const nval = searchNormalize(val.toLowerCase());
@@ -803,16 +807,16 @@ function initIndex() {
         dom.sIn.value=''; sTemp='';
         return;
       }
-      if(sTemp && !F.search.includes(sTemp)) F.search.push(sTemp);
-      // If exact name match, open that category once
       if (sTemp) {
+        F.search = [sTemp];
+        // If exact name match, open that category once
         const nval = searchNormalize(sTemp.toLowerCase());
         const match = getEntries().find(p => searchNormalize(String(p.namn || '').toLowerCase()) === nval);
         const cat = match?.taggar?.typ?.[0];
         if (cat) openCatsOnce.add(cat);
-      }
-      if (sTemp) {
         if (window.storeHelper?.addRecentSearch) storeHelper.addRecentSearch(store, sTemp);
+      } else {
+        F.search = [];
       }
       dom.sIn.value=''; sTemp='';
       activeTags(); renderList(filtered());


### PR DESCRIPTION
## Sammanfattning
- Ersätter tidigare fritextsökningar med den senaste söktermen i index- och karaktärsvyerna.
- Bibehåller valda filter från drop-down-menyer mellan sökningar.

## Testning
- `npm test` *(misslyckas: kunde inte hitta package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4fcbd9848323a084c49c16343a6c