### PR TITLE
Add artifact payment selector and unbound option

### DIFF
--- a/character.html
+++ b/character.html
@@ -24,6 +24,7 @@
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/djurmask.js" defer></script>
   <script src="js/beastform.js" defer></script>
+  <script src="js/artifact-payment.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
   <script src="js/monsterlard.js" defer></script>
   <script src="js/pwa.js" defer></script>

--- a/css/style.css
+++ b/css/style.css
@@ -2335,3 +2335,25 @@ textarea.auto-resize {
 #onlineModal input {
   width: 100%;
 }
+#artifactPaymentPopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.4rem 2rem;
+  width: 90%;
+  max-width: 420px;
+  text-align: left;
+  transform: scale(.8);
+  transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: .8rem;
+}
+#artifactPaymentPopup.open .popup-inner { transform: scale(1); }
+#artifactPaymentPopup .popup-inner button { width: 100%; }
+#artifactPaymentPopup .popup-inner .radio-row {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+}

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/djurmask.js" defer></script>
   <script src="js/beastform.js" defer></script>
+  <script src="js/artifact-payment.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
   <script src="js/monsterlard.js" defer></script>
   <script src="js/elite-add.js"    defer></script>

--- a/js/artifact-payment.js
+++ b/js/artifact-payment.js
@@ -1,0 +1,42 @@
+(function(window){
+  function createPopup(){
+    if(document.getElementById('artifactPaymentPopup')) return;
+    const div=document.createElement('div');
+    div.id='artifactPaymentPopup';
+    div.innerHTML=`<div class="popup-inner"><h3>V\u00e4lj betalning</h3><div id="artifactPaymentOpts" class="radio-list"><label class="radio-row"><input type="radio" name="artifactPay" value="xp">\u20131 erf</label><label class="radio-row"><input type="radio" name="artifactPay" value="corruption">+1 permanent korruption</label><label class="radio-row"><input type="radio" name="artifactPay" value="">Obunden</label></div><button id="artifactPaymentCancel" class="char-btn danger">Avbryt</button></div>`;
+    document.body.appendChild(div);
+  }
+
+  function openPopup(current){
+    return new Promise(resolve=>{
+      createPopup();
+      const pop=document.getElementById('artifactPaymentPopup');
+      const box=pop.querySelector('#artifactPaymentOpts');
+      const cancel=pop.querySelector('#artifactPaymentCancel');
+      const radios=[...box.querySelectorAll('input[name="artifactPay"]')];
+      const init=current||'';
+      radios.forEach(r=>{ r.checked=r.value===init; });
+      pop.classList.add('open');
+      pop.querySelector('.popup-inner').scrollTop = 0;
+      function close(){
+        pop.classList.remove('open');
+        box.removeEventListener('change',onChange);
+        cancel.removeEventListener('click',onCancel);
+        pop.removeEventListener('click',onOutside);
+      }
+      function onChange(e){
+        const inp=e.target.closest('input[name="artifactPay"]');
+        if(!inp) return;
+        close();
+        resolve(inp.value);
+      }
+      function onCancel(){ close(); resolve(null); }
+      function onOutside(e){ if(!pop.querySelector('.popup-inner').contains(e.target)){ close(); resolve(null); } }
+      box.addEventListener('change',onChange);
+      cancel.addEventListener('click',onCancel);
+      pop.addEventListener('click',onOutside);
+    });
+  }
+
+  window.selectArtifactPayment=openPopup;
+})(window);

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -173,7 +173,7 @@
       const entry = getEntry(row.name);
       const tagTyp = entry.taggar?.typ || [];
       if (!tagTyp.includes('Artefakt')) return acc;
-      const eff = row.artifactEffect || entry.artifactEffect;
+      const eff = row.artifactEffect;
       if (eff === 'corruption') acc.corruption += 1;
       else if (eff === 'xp') acc.xp += 1;
       return acc;
@@ -1165,7 +1165,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     }
 
     const isArtifact = tagTyp.includes('Artefakt');
-    const effectVal = row.artifactEffect || entry.artifactEffect || '';
+    const effectVal = row.artifactEffect ?? entry.artifactEffect ?? '';
     if (isArtifact && effectVal) {
       const txt = effectVal === 'corruption'
         ? '+1 permanent korruption'
@@ -1927,8 +1927,9 @@ ${moneyRow}
 
       // "toggleEffect" växlar artefaktens effekt
       if (act === 'toggleEffect') {
-        const eff = row.artifactEffect || entry.artifactEffect || 'corruption';
-        row.artifactEffect = eff === 'corruption' ? 'xp' : 'corruption';
+        const val = await selectArtifactPayment(row.artifactEffect);
+        if (val === null) return;
+        row.artifactEffect = val;
         saveInventory(inv);
         renderInventory();
         return;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -401,6 +401,7 @@ class SharedToolbar extends HTMLElement {
           <div id="customArtifactEffect" class="filter-group" style="display:none">
             <label for="artifactEffect">Effekt</label>
             <select id="artifactEffect">
+              <option value="">Obunden</option>
               <option value="corruption">+1 permanent korruption</option>
               <option value="xp">\u20131 erfarenhet</option>
             </select>

--- a/js/store.js
+++ b/js/store.js
@@ -1105,7 +1105,7 @@ function defaultTraits() {
       if (row.kvaliteter && row.kvaliteter.length) res.k = row.kvaliteter;
       if (row.gratisKval && row.gratisKval.length) res.gk = row.gratisKval;
       if (row.removedKval && row.removedKval.length) res.rk = row.removedKval;
-      if (row.artifactEffect) res.e = row.artifactEffect;
+      if (row.artifactEffect === 'xp' || row.artifactEffect === 'corruption') res.e = row.artifactEffect;
       if (row.nivå) res.l = row.nivå;
       if (row.trait) res.t = row.trait;
       return res;
@@ -1123,7 +1123,7 @@ function defaultTraits() {
           kvaliteter: row.k || [],
           gratisKval: row.gk || [],
           removedKval: row.rk || [],
-          artifactEffect: row.e || '',
+          artifactEffect: row.e === 'xp' || row.e === 'corruption' ? row.e : '',
           nivå: row.l,
           trait: row.t
         };
@@ -1136,7 +1136,7 @@ function defaultTraits() {
           kvaliteter: row.k || [],
           gratisKval: row.gk || [],
           removedKval: row.rk || [],
-          artifactEffect: row.e || '',
+          artifactEffect: row.e === 'xp' || row.e === 'corruption' ? row.e : '',
           nivå: row.l,
           trait: row.t
         };

--- a/notes.html
+++ b/notes.html
@@ -24,6 +24,7 @@
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/djurmask.js" defer></script>
   <script src="js/beastform.js" defer></script>
+  <script src="js/artifact-payment.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
   <script src="js/monsterlard.js" defer></script>
   <script src="js/elite-add.js"    defer></script>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'symbaroum-pwa-v6';
+const CACHE_NAME = 'symbaroum-pwa-v7';
 const URLS_TO_CACHE = [
   // Core pages and styles
   'index.html',
@@ -11,6 +11,7 @@ const URLS_TO_CACHE = [
   'icons/icon_DA',
   // JavaScript
   'js/auto-resize.js',
+  'js/artifact-payment.js',
   'js/beastform.js',
   'js/bloodbond.js',
   'js/character-view.js',


### PR DESCRIPTION
## Summary
- Add `selectArtifactPayment` popup with options for –1 erf, +1 permanent korruption or Obunden
- Replace artifact effect toggle with popup selection and ignore missing effects in totals
- Allow custom items to be marked Obunden and persist only xp/corruption effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb51d656648323bb170f9d522c6021