### PR TITLE
Add unbound option to artifact payment popup

### DIFF
--- a/js/artifact-payment.js
+++ b/js/artifact-payment.js
@@ -3,7 +3,7 @@
     if(document.getElementById('artifactPaymentPopup')) return;
     const div=document.createElement('div');
     div.id='artifactPaymentPopup';
-    div.innerHTML=`<div class="popup-inner"><h3>V\u00e4lj betalning</h3><div id="artifactPaymentOpts" class="radio-list"><label class="radio-row"><input type="radio" name="artifactPay" value="xp">\u20131 erf</label><label class="radio-row"><input type="radio" name="artifactPay" value="corruption">+1 permanent korruption</label><label class="radio-row"><input type="radio" name="artifactPay" value="">Obunden</label></div><button id="artifactPaymentCancel" class="char-btn danger">Avbryt</button></div>`;
+    div.innerHTML=`<div class="popup-inner"><h3>V\u00e4lj betalning</h3><div id="artifactPaymentOpts" class="radio-list"><label class="radio-row"><input type="radio" name="artifactPay" value="cancel">Avbryt</label><label class="radio-row"><input type="radio" name="artifactPay" value="">Obunden</label><label class="radio-row"><input type="radio" name="artifactPay" value="xp">\u20131 erf</label><label class="radio-row"><input type="radio" name="artifactPay" value="corruption">+1 permanent korruption</label></div></div>`;
     document.body.appendChild(div);
   }
 
@@ -12,7 +12,6 @@
       createPopup();
       const pop=document.getElementById('artifactPaymentPopup');
       const box=pop.querySelector('#artifactPaymentOpts');
-      const cancel=pop.querySelector('#artifactPaymentCancel');
       const radios=[...box.querySelectorAll('input[name="artifactPay"]')];
       const init=current||'';
       radios.forEach(r=>{ r.checked=r.value===init; });
@@ -21,19 +20,16 @@
       function close(){
         pop.classList.remove('open');
         box.removeEventListener('change',onChange);
-        cancel.removeEventListener('click',onCancel);
         pop.removeEventListener('click',onOutside);
       }
       function onChange(e){
         const inp=e.target.closest('input[name="artifactPay"]');
         if(!inp) return;
         close();
-        resolve(inp.value);
+        resolve(inp.value==='cancel'?null:inp.value);
       }
-      function onCancel(){ close(); resolve(null); }
       function onOutside(e){ if(!pop.querySelector('.popup-inner').contains(e.target)){ close(); resolve(null); } }
       box.addEventListener('change',onChange);
-      cancel.addEventListener('click',onCancel);
       pop.addEventListener('click',onOutside);
     });
   }

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1002,19 +1002,9 @@ function initIndex() {
             }
           }
           if (tagTyp.includes('Artefakt')) {
-            const choice = await openDialog('Betala 1 XP eller ta +1 permanent korruption?', {
-              cancel: true,
-              cancelText: 'Avbryt',
-              okText: '-1 erf',
-              extraText: '+1 korruption'
-            });
-            if (choice === true) {
-              rowBase.artifactEffect = 'xp';
-            } else if (choice === 'extra') {
-              rowBase.artifactEffect = 'corruption';
-            } else {
-              return;
-            }
+            const val = await selectArtifactPayment();
+            if (val === null) return;
+            if (val) rowBase.artifactEffect = val;
           } else if (p.artifactEffect) {
             rowBase.artifactEffect = p.artifactEffect;
           }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1769,19 +1769,9 @@ ${moneyRow}
             const tagTyp = entry.taggar?.typ || [];
             let artifactEffect = '';
             if (tagTyp.includes('Artefakt')) {
-              const choice = await openDialog('Betala 1 XP eller ta +1 permanent korruption?', {
-                cancel: true,
-                cancelText: 'Avbryt',
-                okText: '-1 erf',
-                extraText: '+1 korruption'
-              });
-              if (choice === true) {
-                artifactEffect = 'xp';
-              } else if (choice === 'extra') {
-                artifactEffect = 'corruption';
-              } else {
-                return;
-              }
+              const val = await selectArtifactPayment();
+              if (val === null) return;
+              artifactEffect = val;
             }
             const addRow = trait => {
               const obj = { name: entry.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -402,8 +402,8 @@ class SharedToolbar extends HTMLElement {
             <label for="artifactEffect">Effekt</label>
             <select id="artifactEffect">
               <option value="">Obunden</option>
-              <option value="corruption">+1 permanent korruption</option>
               <option value="xp">\u20131 erfarenhet</option>
+              <option value="corruption">+1 permanent korruption</option>
             </select>
           </div>
           <div class="money-row">


### PR DESCRIPTION
## Summary
- Add "Avbryt" and "Obunden" options to artifact payment popup and return `null` when cancelling
- Use the payment popup when adding artifacts and when reopening the toggle button
- Reorder custom item artifact effect options

## Testing
- `node --check js/artifact-payment.js`
- `node --check js/inventory-utils.js`
- `node --check js/index-view.js`
- `node --check js/shared-toolbar.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb570fefa8832395d0b6455590ad3f