### PR TITLE
Fix artifact payment popup positioning

### DIFF
--- a/js/artifact-payment.js
+++ b/js/artifact-payment.js
@@ -3,6 +3,7 @@
     if(document.getElementById('artifactPaymentPopup')) return;
     const div=document.createElement('div');
     div.id='artifactPaymentPopup';
+    div.className='popup';
     div.innerHTML=`<div class="popup-inner"><h3>V\u00e4lj betalning</h3><div id="artifactPaymentOpts" class="radio-list"><label class="radio-row"><input type="radio" name="artifactPay" value="cancel">Avbryt</label><label class="radio-row"><input type="radio" name="artifactPay" value="">Obunden</label><label class="radio-row"><input type="radio" name="artifactPay" value="xp">\u20131 erf</label><label class="radio-row"><input type="radio" name="artifactPay" value="corruption">+1 permanent korruption</label></div></div>`;
     document.body.appendChild(div);
   }


### PR DESCRIPTION
## Summary
- ensure artifact payment popup uses standard popup overlay
- enables click-out closing like other popups

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5a3eb5948323b6a4aff61e726e00