### PR TITLE
Allow unbound artifact selection without payment

### DIFF
--- a/js/artifact-payment.js
+++ b/js/artifact-payment.js
@@ -20,17 +20,17 @@
       pop.querySelector('.popup-inner').scrollTop = 0;
       function close(){
         pop.classList.remove('open');
-        box.removeEventListener('change',onChange);
+        box.removeEventListener('click',onSelect);
         pop.removeEventListener('click',onOutside);
       }
-      function onChange(e){
+      function onSelect(e){
         const inp=e.target.closest('input[name="artifactPay"]');
         if(!inp) return;
         close();
         resolve(inp.value==='cancel'?null:inp.value);
       }
       function onOutside(e){ if(!pop.querySelector('.popup-inner').contains(e.target)){ close(); resolve(null); } }
-      box.addEventListener('change',onChange);
+      box.addEventListener('click',onSelect);
       pop.addEventListener('click',onOutside);
     });
   }


### PR DESCRIPTION
## Summary
- Fix artifact payment popup to handle the "Obunden" option via click events
- Selecting "Obunden" now adds an artifact without XP or corruption cost

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5d9231d88323a55789963f375a01