### PR TITLE
Handle unbound artifact payment and popup behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -88,6 +88,7 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 .tag.mystic    { border: 1.5px solid var(--mystic); }
 .tag.neutral   { border: 1.5px solid var(--neutral); }
 .tag.negative  { border: 1.5px solid var(--negative); }
+.tag.unbound   { border: 1.5px solid #e68181; }
 
 .char-btn,
 .toolbar button,

--- a/js/artifact-payment.js
+++ b/js/artifact-payment.js
@@ -4,7 +4,7 @@
     const div=document.createElement('div');
     div.id='artifactPaymentPopup';
     div.className='popup';
-    div.innerHTML=`<div class="popup-inner"><p>V\u00e4lj betalning</p><div id="artifactPaymentOpts" class="button-list"><button data-val="" class="char-btn">Obunden</button><button data-val="xp" class="char-btn">\u20131 erf</button><button data-val="corruption" class="char-btn">+1 permanent korruption</button><button data-val="cancel" class="char-btn danger">Avbryt</button></div></div>`;
+    div.innerHTML=`<div class="popup-inner"><p>V\u00e4lj betalning</p><div id="artifactPaymentOpts" class="button-list"><button data-val="" class="char-btn">Obunden</button><button data-val="corruption" class="char-btn">+1 Permanent korruption</button><button data-val="xp" class="char-btn">\u20131 Erfarenhetspo\u00e4ng</button><button data-val="cancel" class="char-btn danger">Avbryt</button></div></div>`;
     document.body.appendChild(div);
   }
 

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1166,11 +1166,17 @@ function openVehiclePopup(preselectId, precheckedPaths) {
 
     const isArtifact = tagTyp.includes('Artefakt');
     const effectVal = row.artifactEffect ?? entry.artifactEffect ?? '';
-    if (isArtifact && effectVal) {
-      const txt = effectVal === 'corruption'
-        ? '+1 permanent korruption'
-        : '\u20131 erfarenhet';
-      desc += `<br><span class="tag">${txt}</span>`;
+    if (isArtifact) {
+      let txt, cls = 'tag';
+      if (effectVal === 'corruption') {
+        txt = '+1 Permanent korruption';
+      } else if (effectVal === 'xp') {
+        txt = '\u20131 Erfarenhetspo\u00e4ng';
+      } else {
+        txt = 'Obunden';
+        cls += ' unbound';
+      }
+      desc += `<br><span class="${cls}">${txt}</span>`;
     }
     return { desc, rowLevel, freeCnt };
   }

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -902,7 +902,7 @@ class SharedToolbar extends HTMLElement {
     }
 
     // ignore clicks inside popups so panels stay open
-      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','pricePopup','rowPricePopup','vehiclePopup','vehicleRemovePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup','dialogPopup','folderManagerPopup','newCharPopup','dupCharPopup','renameCharPopup'];
+      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','pricePopup','rowPricePopup','vehiclePopup','vehicleRemovePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup','dialogPopup','folderManagerPopup','newCharPopup','dupCharPopup','renameCharPopup','artifactPaymentPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));


### PR DESCRIPTION
## Summary
- Keep inventory panel open when artifact payment popup is used
- Reorder and rename artifact payment options
- Highlight unbound artifacts with a red-bordered tag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5fd9c4cc832389a1155454647077