### PR TITLE
Persist collapse state for filter and inventory cards

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -7,6 +7,8 @@
   // Bring shared currency bases into local scope
   const SBASE = window.SBASE;
   const OBASE = window.OBASE;
+  const INV_TOOLS_KEY = 'invToolsOpen';
+  const INV_INFO_KEY  = 'invInfoOpen';
   // Local helper to safely access the toolbar shadow root without relying on main.js scope
   const getToolbarRoot = () => {
     const el = document.querySelector('shared-toolbar');
@@ -1360,6 +1362,10 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     /* ---------- kort för formaliteter (uppdelat: verktyg & information) ---------- */
     const toolsKey = '__tools__';
     const infoKey  = '__info__';
+    const toolsLS = localStorage.getItem(INV_TOOLS_KEY) === '1';
+    const infoLS  = localStorage.getItem(INV_INFO_KEY) === '1';
+    if (toolsLS) openKeys.add(toolsKey); else openKeys.delete(toolsKey);
+    if (infoLS)  openKeys.add(infoKey);  else openKeys.delete(infoKey);
     const vehicleBtns = vehicles
       .map(v => `<button id="vehicleBtn-${v.entry.id}" class="char-btn">Lasta i ${v.entry.namn}</button>`)
       .join('');
@@ -1519,7 +1525,11 @@ ${moneyRow}
     : '<li class="card">Inga föremål.</li>';
 
     /* ---------- skriv ut ---------- */
-    if (dom.invFormal) dom.invFormal.innerHTML = toolsCard + infoCard;
+    if (dom.invFormal) {
+      dom.invFormal.innerHTML = toolsCard + infoCard;
+      localStorage.setItem(INV_TOOLS_KEY, openKeys.has(toolsKey) ? '1' : '0');
+      localStorage.setItem(INV_INFO_KEY,  openKeys.has(infoKey) ? '1' : '0');
+    }
     dom.invList.innerHTML       = itemCards;
     if (dom.wtOut) dom.wtOut.textContent = formatWeight(usedWeight);
     if (dom.slOut) dom.slOut.textContent = formatWeight(maxCapacity);
@@ -1965,8 +1975,12 @@ ${moneyRow}
         const cardTitle = e.target.closest('.card-title');
         if (cardTitle) {
           const li = cardTitle.closest('li.card');
-          li.classList.toggle('compact');
-          updateCollapseBtnState();
+          if (li) {
+            const isCompact = li.classList.toggle('compact');
+            updateCollapseBtnState();
+            const key = li.dataset.special === '__tools__' ? INV_TOOLS_KEY : INV_INFO_KEY;
+            localStorage.setItem(key, isCompact ? '0' : '1');
+          }
           return;
         }
 

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -5,12 +5,14 @@
      • Off-canvas-paneler: Inventarie, Egenskaper, Filter
      • Popup för kvaliteter
    =========================================================== */
+const FILTER_TOOLS_KEY = 'filterToolsOpen';
+const FILTER_SETTINGS_KEY = 'filterSettingsOpen';
 
 class SharedToolbar extends HTMLElement {
   constructor() {
     super();
     this.attachShadow({ mode: 'open' });
-    // One-time flag: ensure Formaliteter in Filter is collapsed on first open after refresh
+    // One-time flag: ensure filter cards restore state on first open
     this._filterFirstOpenHandled = false;
   }
 
@@ -860,6 +862,19 @@ class SharedToolbar extends HTMLElement {
     this.entryViewToggle = $('entryViewToggle');
   }
 
+  restoreFilterCollapse() {
+    const toolsCard = this.shadowRoot.getElementById('filterFormalCard');
+    const settingsCard = this.shadowRoot.getElementById('filterSettingsCard');
+    const toolsVal = localStorage.getItem(FILTER_TOOLS_KEY);
+    const settingsVal = localStorage.getItem(FILTER_SETTINGS_KEY);
+    const toolsOpen = toolsVal === '1';
+    const settingsOpen = settingsVal === '1';
+    if (toolsCard) toolsCard.classList.toggle('compact', !toolsOpen);
+    if (settingsCard) settingsCard.classList.toggle('compact', !settingsOpen);
+    if (toolsVal === null) localStorage.setItem(FILTER_TOOLS_KEY, toolsOpen ? '1' : '0');
+    if (settingsVal === null) localStorage.setItem(FILTER_SETTINGS_KEY, settingsOpen ? '1' : '0');
+  }
+
   /* ------------------------------------------------------- */
   handleClick(e) {
     const btn = e.target.closest('button, a');
@@ -868,7 +883,11 @@ class SharedToolbar extends HTMLElement {
       const title = e.target.closest('#filterFormalCard .card-title, #filterSettingsCard .card-title');
       if (title) {
         const card = title.closest('.card');
-        card?.classList.toggle('compact');
+        if (card) {
+          const isCompact = card.classList.toggle('compact');
+          const key = card.id === 'filterFormalCard' ? FILTER_TOOLS_KEY : FILTER_SETTINGS_KEY;
+          localStorage.setItem(key, isCompact ? '0' : '1');
+        }
       }
       return;
     }
@@ -884,7 +903,11 @@ class SharedToolbar extends HTMLElement {
     // Collapse/expand specialkorten i filterpanelen
     if (btn.classList.contains('collapse-btn')) {
       const card = btn.closest('#filterFormalCard, #filterSettingsCard');
-      card?.classList.toggle('compact');
+      if (card) {
+        const isCompact = card.classList.toggle('compact');
+        const key = card.id === 'filterFormalCard' ? FILTER_TOOLS_KEY : FILTER_SETTINGS_KEY;
+        localStorage.setItem(key, isCompact ? '0' : '1');
+      }
     }
   }
 
@@ -919,12 +942,8 @@ class SharedToolbar extends HTMLElement {
     const isOpen = panel.classList.contains('open');
     Object.values(this.panels).forEach(p=>p.classList.remove('open'));
     if (!isOpen) {
-      // On first open of Filter panel after refresh, collapse "Formaliteter"
       if (id === 'filterPanel' && !this._filterFirstOpenHandled) {
-        const toolsCard = this.shadowRoot.getElementById('filterFormalCard');
-        if (toolsCard && !toolsCard.classList.contains('compact')) toolsCard.classList.add('compact');
-        const settingsCard = this.shadowRoot.getElementById('filterSettingsCard');
-        if (settingsCard && !settingsCard.classList.contains('compact')) settingsCard.classList.add('compact');
+        this.restoreFilterCollapse();
         this._filterFirstOpenHandled = true;
       }
       panel.classList.add('open');
@@ -935,12 +954,8 @@ class SharedToolbar extends HTMLElement {
     Object.values(this.panels).forEach(p=>p.classList.remove('open'));
     const panel = this.panels[id];
     if (panel) {
-      // On first open of Filter panel after refresh, collapse "Formaliteter"
       if (id === 'filterPanel' && !this._filterFirstOpenHandled) {
-        const toolsCard = this.shadowRoot.getElementById('filterFormalCard');
-        if (toolsCard && !toolsCard.classList.contains('compact')) toolsCard.classList.add('compact');
-        const settingsCard = this.shadowRoot.getElementById('filterSettingsCard');
-        if (settingsCard && !settingsCard.classList.contains('compact')) settingsCard.classList.add('compact');
+        this.restoreFilterCollapse();
         this._filterFirstOpenHandled = true;
       }
       panel.classList.add('open');


### PR DESCRIPTION
## Summary
- store open/closed state for Verktyg 🧰 and Inställningar 💡 in filter panel
- remember Verktyg 🧰 and Information 🔎 sections in inventory panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfd0aeac48323b34b87deec80361e