### PR TITLE
Persist filter and category state across views

### DIFF
--- a/js/notes-view.js
+++ b/js/notes-view.js
@@ -3,6 +3,22 @@
   let form, editBtn, clearBtn, charLink, isEditing=false;
   let catsMinimized = false;
 
+  const charId = store.current || 'default';
+  const STATE_KEY = `notesViewState:${charId}`;
+  let catState = {};
+  const loadState = () => {
+    try { return JSON.parse(localStorage.getItem(STATE_KEY)) || {}; }
+    catch { return {}; }
+  };
+  const saveState = () => {
+    try { localStorage.setItem(STATE_KEY, JSON.stringify({ cats: catState })); }
+    catch {}
+  };
+  {
+    const saved = loadState();
+    catState = saved.cats || {};
+  }
+
   function showView(){
     const notes = storeHelper.getNotes(store);
     fields.forEach(id=>{
@@ -77,10 +93,17 @@
       }
     };
 
-    updateCatToggle();
-    document.querySelectorAll('.note-field').forEach(d => {
-      d.addEventListener('toggle', updateCatToggle);
+    const detailEls = document.querySelectorAll('.note-field');
+    detailEls.forEach(d => {
+      const key = d.querySelector('textarea')?.id || '';
+      if (key && catState[key] === false) d.open = false;
+      d.addEventListener('toggle', () => {
+        if (key) catState[key] = d.open;
+        saveState();
+        updateCatToggle();
+      });
     });
+    updateCatToggle();
 
     if (dom.catToggle) dom.catToggle.addEventListener('click', () => {
       const details = document.querySelectorAll('.note-field');


### PR DESCRIPTION
## Summary
- store filter selections and category open state for index view
- persist character-specific filters and open categories on character pages
- remember collapsed state of note sections per character

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd38d8f2f0832398aa2e5ca2685f0a