### PR TITLE
Ensure defense value has minimum of one

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -113,6 +113,9 @@
       }
     }
 
+    res.forEach(r => { r.value = Math.max(1, r.value); });
+    hamRes.forEach(r => { r.value = Math.max(1, r.value); });
+
     return res.concat(hamRes);
   }
 


### PR DESCRIPTION
## Summary
- Clamp defense calculation so resulting value is never below 1 regardless of trait

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be85fef3cc8323abeecb3fd72a8c02