### PR TITLE
fix: retain filters when modifying entries

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1005,7 +1005,6 @@ function initIndex() {
         const qn = p.namn;
         if (!elig[iIdx].kvaliteter.includes(qn)) elig[iIdx].kvaliteter.push(qn);
         invUtil.saveInventory(inv); invUtil.renderInventory();
-        clearFilters();
         activeTags();
         renderList(filtered());
       });
@@ -1472,7 +1471,6 @@ function initIndex() {
         }
       }
     }
-    clearFilters();
     activeTags();
     renderList(filtered());
     renderTraits();


### PR DESCRIPTION
## Summary
- Avoid resetting filters when adding qualities
- Preserve active filters after manipulating list entries

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beca1d0cf48323aed506e4652816ba