### PR TITLE
Visuell bekräftelse vid import och radering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1913,6 +1913,24 @@ select.level {
 }
 .popup-bottom.open .popup-inner { transform: scale(1) !important; }
 
+/* Toast notification */
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--panel);
+  color: var(--txt);
+  padding: .6rem 1.2rem;
+  border-radius: .6rem;
+  box-shadow: 0 4px 10px rgba(0,0,0,.3);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .3s ease;
+  z-index: 4000;
+}
+.toast.show { opacity: 1; }
+
 /* Clickable price text in inventory */
 .price-click { cursor: pointer; }
 

--- a/js/main.js
+++ b/js/main.js
@@ -677,24 +677,45 @@ function bindToolbar() {
               const obj = JSON.parse(text);
               if (Array.isArray(obj)) {
                 for (const item of obj) {
-                  try { if (storeHelper.importCharacterJSON(store, item)) imported++; } catch {}
+                  try {
+                    const id = storeHelper.importCharacterJSON(store, item);
+                    if (id) {
+                      imported++;
+                      toast(`${item.name || 'Ny rollperson'} är importerad`);
+                    }
+                  } catch {}
                 }
               } else if (obj && Array.isArray(obj.folders)) {
                 for (const folder of obj.folders) {
                   const fname = folder.folder || folder.name || '';
                   if (Array.isArray(folder.characters)) {
                     for (const item of folder.characters) {
-                      try { if (storeHelper.importCharacterJSON(store, { ...item, folder: fname })) imported++; } catch {}
+                      try {
+                        const id = storeHelper.importCharacterJSON(store, { ...item, folder: fname });
+                        if (id) {
+                          imported++;
+                          toast(`${item.name || 'Ny rollperson'} är importerad`);
+                        }
+                      } catch {}
                     }
                   }
                 }
               } else if (obj && Array.isArray(obj.characters)) {
                 for (const item of obj.characters) {
-                  try { if (storeHelper.importCharacterJSON(store, item)) imported++; } catch {}
+                  try {
+                    const id = storeHelper.importCharacterJSON(store, item);
+                    if (id) {
+                      imported++;
+                      toast(`${item.name || 'Ny rollperson'} är importerad`);
+                    }
+                  } catch {}
                 }
               } else {
                 const res = storeHelper.importCharacterJSON(store, obj);
-                if (res) imported++;
+                if (res) {
+                  imported++;
+                  toast(`${obj.name || 'Ny rollperson'} är importerad`);
+                }
               }
             } catch {
               // ignore and continue to next file
@@ -720,8 +741,10 @@ function bindToolbar() {
       if (!(await confirmPopup(`Ta bort “${char.name}”?`))) return;
 
       const idToDel = store.current;
+      const deletedName = char.name;
       storeHelper.deleteCharacter(store, idToDel);
       // Pick a sensible next current character (first in active folder), or none
+      let newActiveName = '';
       try {
         const active = storeHelper.getActiveFolder(store);
         const remaining = (store.characters || [])
@@ -729,8 +752,10 @@ function bindToolbar() {
           .slice()
           .sort((a,b)=> String(a.name||'').localeCompare(String(b.name||''), 'sv'));
         store.current = remaining[0]?.id || '';
+        newActiveName = remaining[0]?.name || '';
         storeHelper.save(store);
       } catch {}
+      toast(newActiveName ? `${deletedName} är raderad. ${newActiveName} är aktiv` : `${deletedName} är raderad`);
       applyCharacterChange();
     }
 

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -57,6 +57,20 @@ class SharedToolbar extends HTMLElement {
     window.openDialog  = (msg, opts) => this.openDialog(msg, opts);
     window.alertPopup  = msg => this.openDialog(msg);
     window.confirmPopup = msg => this.openDialog(msg, { cancel: true });
+    let toastTimer;
+    window.toast = msg => {
+      let el = document.getElementById('toast');
+      if (!el) {
+        el = document.createElement('div');
+        el.id = 'toast';
+        el.className = 'toast';
+        document.body.appendChild(el);
+      }
+      el.textContent = msg;
+      el.classList.add('show');
+      clearTimeout(toastTimer);
+      toastTimer = setTimeout(() => el.classList.remove('show'), 3000);
+    };
 
     // Allow search suggestions to scroll without affecting the page
     const sugEl = this.shadowRoot.getElementById('searchSuggest');


### PR DESCRIPTION
## Summary
- Lägg till global `toast`-funktion med stil.
- Visa toast med karaktärsnamn när rollpersoner importeras.
- Visa toast när en rollperson raderas och vilken karaktär som nu är aktiv.

## Testing
- `npm test` *(missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bececcf0988323b60f059ab9415d53