### PR TITLE
Preserve non-search filters on new text search

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -41,14 +41,6 @@ function initIndex() {
     catState = saved.cats || {};
   }
 
-  const clearFilters = () => {
-    F.search = [];
-    F.typ = [];
-    F.ark = [];
-    F.test = [];
-    saveState();
-  };
-
   const getEntries = () => {
     const base = DB
       .concat(window.TABELLER || [])
@@ -655,14 +647,8 @@ function initIndex() {
   window.indexViewRefreshFilters = () => { fillDropdowns(); updateSearchDatalist(); };
 
   /* -------- events -------- */
-  dom.sIn.addEventListener('input',()=>{
-    const prev = sTemp;
+  dom.sIn.addEventListener('input', () => {
     sTemp = dom.sIn.value.trim();
-    if (!prev && sTemp) {
-      clearFilters();
-      activeTags();
-      renderList(filtered());
-    }
     updateSearchDatalist();
   });
   {


### PR DESCRIPTION
## Summary
- Avoid clearing selected filters when typing in the text search field
- Remove obsolete clearFilters helper since filters are no longer reset

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bed2698b1883238ee5e4f2aa30b551