### PR TITLE
Display level descriptions for inventory items

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1126,8 +1126,8 @@ function openVehiclePopup(preselectId, precheckedPaths) {
         : null
     );
     let desc = '';
-    if (entry.beskrivning && (!isArtifact || isLArtifact)) {
-      desc += formatText(entry.beskrivning);
+    if (!isArtifact || isLArtifact) {
+      desc += abilityHtml(entry, rowLevel);
     }
     const tagList = (tagger.typ || [])
       .concat(explodeTags(tagger.ark_trad), tagger.test || [])


### PR DESCRIPTION
## Summary
- show item descriptions with level details in inventory view
- skip description for full artifacts but allow lower artifacts and elixirs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bedcc54c3c83239f5b2d54d62e75ac