### PR TITLE
Visa kvalitetstyp och sortera kvaliteter

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -53,6 +53,14 @@ function initIndex() {
 
   const FALT_BUNDLE = ['Flinta och stål','Kokkärl','Rep, 10 meter','Sovfäll','Tändved','Vattenskinn'];
 
+  const QUAL_TYPE_MAP = {
+    'Vapenkvalitet': 'Vapen',
+    'Rustningskvalitet': 'Rustning',
+    'Sköldkvalitet': 'Sköld',
+    'Allmän kvalitet': 'Allmänt'
+  };
+  const QUAL_TYPE_KEYS = Object.keys(QUAL_TYPE_MAP);
+
   const flashAdded = (name, trait) => {
     const selector = `li[data-name="${CSS.escape(name)}"]${trait ? `[data-trait="${CSS.escape(trait)}"]` : ''}`;
     const root = dom.lista || document;
@@ -507,14 +515,15 @@ function initIndex() {
         let xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
         if (isElityrke(p)) xpText = `Minst ${eliteReq.minXP ? eliteReq.minXP(p, charList) : 50}`;
         const xpTag = (xpVal != null || isElityrke(p)) ? `<span class="tag xp-cost">Erf: ${xpText}</span>` : '';
+        const typeTags = (p.taggar?.typ || []).map(t => `<span class="tag">${QUAL_TYPE_MAP[t] || t}</span>`);
         const infoTagsHtml = [xpTag]
-          .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(typeTags)
           .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
           .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
           .filter(Boolean)
           .join(' ');
         const tagsHtml = []
-          .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(typeTags)
           .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
           .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
           .filter(Boolean)
@@ -529,6 +538,12 @@ function initIndex() {
         const priceBadgeLabel = (priceLabel || 'Pris').replace(':','');
         const priceBadgeText = priceLabel === 'Dagslön:' ? 'Dagslön' : 'P';
         const badgeParts = [];
+        if (isQual(p)) {
+          (p.taggar?.typ || [])
+            .filter(t => QUAL_TYPE_KEYS.includes(t))
+            .map(t => QUAL_TYPE_MAP[t])
+            .forEach(lbl => badgeParts.push(`<span class="meta-badge">${lbl}</span>`));
+        }
         if (priceText) badgeParts.push(`<span class="meta-badge price-badge" title="${priceBadgeLabel}">${priceBadgeText}: ${priceText}</span>`);
         if (capacityVal != null) badgeParts.push(`<span class="meta-badge capacity-badge" title="Bärkapacitet">BK: ${capacityVal}</span>`);
         if (weightVal != null) badgeParts.push(`<span class="meta-badge weight-badge" title="Vikt">V: ${weightVal}</span>`);

--- a/js/utils.js
+++ b/js/utils.js
@@ -173,6 +173,16 @@
       const bi = LVL.indexOf(bLvl);
       if(ai !== bi) return ai - bi;
     }
+    if (['Kvalitet','Mystisk kvalitet'].includes(ta) && ['Kvalitet','Mystisk kvalitet'].includes(tb)) {
+      const order = ['Allm\u00e4n kvalitet','Vapenkvalitet','Rustningskvalitet','Sk\u00f6ldkvalitet'];
+      const aSub = taList[taList.indexOf(ta)+1];
+      const bSub = tbList[tbList.indexOf(tb)+1];
+      const ai = order.indexOf(aSub);
+      const bi = order.indexOf(bSub);
+      const ia = ai === -1 ? 0 : ai;
+      const ib = bi === -1 ? 0 : bi;
+      if (ia !== ib) return ia - ib;
+    }
     const at = taList.join(',');
     const bt = tbList.join(',');
     if(at < bt) return -1;


### PR DESCRIPTION
## Sammanfattning
- Lägg till taggar för kvaliteters måltyp och visa dem i listan.
- Ersätt tekniska taggar som `Vapenkvalitet` med läsbara etiketter.
- Sortera kvaliteter efter vilken typ de gäller: Allmänt → Vapen → Rustning → Sköld.

## Test
- `npm test` *(misslyckades: package.json saknas)*

------
https://chatgpt.com/codex/tasks/task_e_68bfed84bdf083239f47650569823af5