### PR TITLE
Fix overload indicator threshold

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1270,7 +1270,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     const capClassOf = (used, max) => {
       if (!max || max <= 0) return '';
       const ratio = used / max;
-      if (ratio >= 1.0) return 'cap-neg';   // överlast
+      if (ratio > 1.0) return 'cap-neg';    // överlast: över maxkapacitet
       if (ratio >= 0.95) return 'cap-crit'; // nära max
       if (ratio >= 0.80) return 'cap-warn'; // närmar sig
       return '';


### PR DESCRIPTION
## Summary
- show red capacity indicator only when weight exceeds capacity

## Testing
- `node - <<'NODE'
const fs = require('fs');
const text = fs.readFileSync('js/inventory-utils.js','utf8');
let snippet = text.slice(text.indexOf('const capClassOf'), text.indexOf('};', text.indexOf('const capClassOf'))+2);
snippet = snippet.replace('const capClassOf', 'capClassOf');
eval('var capClassOf;' + snippet);
console.log('ratio 1.0 =>', capClassOf(100,100));
console.log('ratio 1.01 =>', capClassOf(101,100));
NODE`
- `curl -I http://localhost:8000/`

------
https://chatgpt.com/codex/tasks/task_e_68bff1e6cae48323a9a8b99527e9b6e3