### PR TITLE
Uppdatera Mörkt förflutet

### DIFF
--- a/data/nackdel.json
+++ b/data/nackdel.json
@@ -333,7 +333,7 @@
   {
     "id": "na28",
     "namn": "Mörkt förflutet",
-    "beskrivning": "Genom tidigare äventyrs bistra konsekvenser har karaktären fått känna på vad för mörker som ligger runt davokars djup. Karaktären börjar sitt äventyr med en tredjedel av sin korruptionströskel fylld med permanent korruption avrundat uppåt. Så en karaktär med 14 i viljestark har tre korruption, medans en karaktär med 5 viljestark har 1 korruption. Detta gäller även karaktärer som höjt sin korruptionströskel med förmågor och fördelar.",
+    "beskrivning": "Genom tidigare äventyrs bistra konsekvenser har karaktären fått känna på vad för mörker som ligger runt davokars djup. När nackdelen tas drabbas karaktären av temporär korruption motsvarande en fjärdedel av sin korruptionströskel, avrundat uppåt. En karaktär med tröskel 14 får alltså 4 korruption. Har karaktären även särdraget Jordnära minskar smärtgränsen med en fjärdedel istället för en sjättedel. Detta gäller även karaktärer som höjt sin korruptionströskel med förmågor och fördelar.",
     "kan_införskaffas_flera_gånger": false,
     "taggar": {
       "typ": [

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -251,7 +251,6 @@ function initCharacter() {
     const hasSjalastark = list.some(p=>p.namn==='Själastark');
     const resistCount = list.filter(p=>p.namn==='Motståndskraft').length;
     const sensCount = list.filter(p=>p.namn==='Korruptionskänslig').length;
-    const hasDarkPast = list.some(p=>p.namn==='Mörkt förflutet');
     const permBase = storeHelper.calcPermanentCorruption(list, effects);
     const hasEarth = list.some(p=>p.namn==='Jordnära');
     const baseMax = strongGift ? valWill * 2 : valWill;
@@ -259,7 +258,7 @@ function initCharacter() {
     const maxCor = baseMax + (hasSjalastark ? 1 : 0);
     let thresh = threshBase + resistCount - sensCount;
     let perm = hasEarth ? (permBase % 2) : permBase;
-    if(hasDarkPast) perm += Math.ceil(thresh / 3);
+    const temp = storeHelper.calcDarkPastTemporaryCorruption(list, thresh);
 
     const defTrait = getDefenseTraitName(list);
     const kvickForDef = vals[defTrait];
@@ -338,6 +337,7 @@ function initCharacter() {
         <ul>
           <li>Maximal korruption: ${maxCor}</li>
           <li>Permanent korruption: ${perm}</li>
+          <li>Temporär korruption: ${temp}</li>
           <li>Korruptionströskel: ${thresh}</li>
         </ul>
       </section>

--- a/js/store.js
+++ b/js/store.js
@@ -905,6 +905,12 @@ function defaultTraits() {
     return cor;
   }
 
+  function calcDarkPastTemporaryCorruption(list, thresh) {
+    if (!Array.isArray(list)) return 0;
+    if (!list.some(e => e.namn === 'Mörkt förflutet')) return 0;
+    return Math.ceil((Number(thresh) || 0) / 4);
+  }
+
   function calcUsedXP(list, extra) {
     let xp = 0;
 
@@ -1009,9 +1015,9 @@ function defaultTraits() {
     if (list.some(e => e.namn === 'Jordnära')) {
       pain -= Math.floor(perm / 2);
     }
-    // Ny regel: Jordnära + Mörkt förflutet ger ytterligare - (smärtgräns / 6)
+    // Ny regel: Jordnära + Mörkt förflutet ger ytterligare - (smärtgräns / 4)
     if (list.some(e => e.namn === 'Jordnära') && list.some(e => e.namn === 'Mörkt förflutet')) {
-      const extraPenalty = Math.floor(pain / 6);
+      const extraPenalty = Math.floor(pain / 4);
       pain -= extraPenalty;
     }
     return pain;
@@ -1396,6 +1402,7 @@ function defaultTraits() {
     calcTotalXP,
     countDisadvantages,
     calcPermanentCorruption,
+    calcDarkPastTemporaryCorruption,
     calcCarryCapacity,
     calcPainThreshold,
     abilityLevel,

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -171,7 +171,6 @@
 
     const resistCount = list.filter(p => p.namn === 'Motståndskraft').length;
     const sensCount   = list.filter(p => p.namn === 'Korruptionskänslig').length;
-    const hasDarkPast = list.some(p => p.namn === 'Mörkt förflutet');
 
     const defTrait = getDefenseTraitName(list);
     const defs = calcDefense(vals[defTrait]);
@@ -198,8 +197,8 @@
         const maxCor = baseMax + (hasSjalastark ? 1 : 0);
         let   thresh = threshBase + resistCount - sensCount;
         let perm = hasEarth ? (permBase % 2) : permBase;
-        if (hasDarkPast) perm += Math.ceil(thresh / 3);
-        extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` + `<div class="trait-extra">Maximal korruption: ${maxCor} • Korruptionströskel: ${thresh}</div>`;
+        const temp = storeHelper.calcDarkPastTemporaryCorruption(list, thresh);
+        extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` + `<div class="trait-extra">Temporär korruption: ${temp}</div>` + `<div class="trait-extra">Maximal korruption: ${maxCor} • Korruptionströskel: ${thresh}</div>`;
       }
       if (k === 'Diskret') {
         if (storeHelper.abilityLevel(list, 'Fint') >= 1) {


### PR DESCRIPTION
## Sammanfattning
- Justerar nackdelen **Mörkt förflutet** så att den ger temporär korruption motsvarande 1/4 av korruptionströskeln och beskriver effekten i texten.
- Lägger till funktion för att beräkna temporär korruption och uppdaterar visning i karaktärs- och egenskapsvyer.
- Ändrar jordnära-kombinationen så att smärtgränsen minskar med 1/4 istället för 1/6.

## Testning
- `npm test` *(misslyckades: Could not read package.json)*
- `node --check js/store.js js/character-view.js js/traits-utils.js`


------
https://chatgpt.com/codex/tasks/task_e_68bff32571108323a80672f08db1311f