### PR TITLE
Handle Dark Past as permanent corruption

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -237,14 +237,7 @@ function initCharacter() {
     const vals = {};
     KEYS.forEach(k=>{ vals[k] = (traits[k]||0) + (bonus[k]||0) + (maskBonus[k]||0); });
 
-    const hasHardnackad = list.some(p=>p.namn==='Hårdnackad');
-    const hasKraftprov = list.some(p=>p.namn==='Kraftprov');
     const valStark = vals['Stark'];
-    const capacity = storeHelper.calcCarryCapacity(valStark, list);
-    const hardy = hasHardnackad ? 1 : 0;
-    const talBase = hasKraftprov ? valStark + 5 : Math.max(10, valStark);
-    const tal = talBase + hardy;
-    const pain = storeHelper.calcPainThreshold(valStark, list, effects);
 
     const valWill = vals['Viljestark'];
     const strongGift = list.some(p=>p.namn==='Stark gåva' && ['Gesäll','Mästare'].includes(p.nivå||''));
@@ -257,8 +250,18 @@ function initCharacter() {
     const threshBase = strongGift ? valWill : Math.ceil(valWill / 2);
     const maxCor = baseMax + (hasSjalastark ? 1 : 0);
     let thresh = threshBase + resistCount - sensCount;
+    const darkPerm = storeHelper.calcDarkPastPermanentCorruption(list, thresh);
     let perm = hasEarth ? (permBase % 2) : permBase;
-    const temp = storeHelper.calcDarkPastTemporaryCorruption(list, thresh);
+    perm += darkPerm;
+    const effectsWithDark = { ...effects, corruption: (effects.corruption || 0) + darkPerm };
+
+    const hasHardnackad = list.some(p=>p.namn==='Hårdnackad');
+    const hasKraftprov = list.some(p=>p.namn==='Kraftprov');
+    const capacity = storeHelper.calcCarryCapacity(valStark, list);
+    const hardy = hasHardnackad ? 1 : 0;
+    const talBase = hasKraftprov ? valStark + 5 : Math.max(10, valStark);
+    const tal = talBase + hardy;
+    const pain = storeHelper.calcPainThreshold(valStark, list, effectsWithDark);
 
     const defTrait = getDefenseTraitName(list);
     const kvickForDef = vals[defTrait];
@@ -337,7 +340,6 @@ function initCharacter() {
         <ul>
           <li>Maximal korruption: ${maxCor}</li>
           <li>Permanent korruption: ${perm}</li>
-          <li>Temporär korruption: ${temp}</li>
           <li>Korruptionströskel: ${thresh}</li>
         </ul>
       </section>

--- a/js/store.js
+++ b/js/store.js
@@ -905,7 +905,7 @@ function defaultTraits() {
     return cor;
   }
 
-  function calcDarkPastTemporaryCorruption(list, thresh) {
+  function calcDarkPastPermanentCorruption(list, thresh) {
     if (!Array.isArray(list)) return 0;
     if (!list.some(e => e.namn === 'Mörkt förflutet')) return 0;
     return Math.ceil((Number(thresh) || 0) / 4);
@@ -1402,7 +1402,7 @@ function defaultTraits() {
     calcTotalXP,
     countDisadvantages,
     calcPermanentCorruption,
-    calcDarkPastTemporaryCorruption,
+    calcDarkPastPermanentCorruption,
     calcCarryCapacity,
     calcPainThreshold,
     abilityLevel,

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -172,6 +172,14 @@
     const resistCount = list.filter(p => p.namn === 'Motståndskraft').length;
     const sensCount   = list.filter(p => p.namn === 'Korruptionskänslig').length;
 
+    const valWill = vals['Viljestark'];
+    const baseMax   = strongGift ? valWill * 2 : valWill;
+    const threshBase = strongGift ? valWill : Math.ceil(valWill / 2);
+    const maxCor = baseMax + (hasSjalastark ? 1 : 0);
+    let   thresh = threshBase + resistCount - sensCount;
+    const darkPerm = storeHelper.calcDarkPastPermanentCorruption(list, thresh);
+    const effectsWithDark = { ...effects, corruption: (effects.corruption || 0) + darkPerm };
+
     const defTrait = getDefenseTraitName(list);
     const defs = calcDefense(vals[defTrait]);
 
@@ -187,18 +195,14 @@
       if (k === 'Stark') {
         const base = storeHelper.calcCarryCapacity(val, list);
         tal  += hardy;
-        pain = storeHelper.calcPainThreshold(val, list, effects);
+        pain = storeHelper.calcPainThreshold(val, list, effectsWithDark);
         beforeExtra = `<button class="trait-count" data-trait="${k}">Förmågor: ${counts[k]}</button>` + `<div class="trait-extra">Bärkapacitet: ${formatWeight(base)}</div>`;
         afterExtra = '';
         extra = `<div class="trait-extra">Tålighet: ${tal} • Smärtgräns: ${pain}</div>`;
       } else if (k === 'Viljestark') {
-        const baseMax   = strongGift ? val * 2 : val;
-        const threshBase = strongGift ? val : Math.ceil(val / 2);
-        const maxCor = baseMax + (hasSjalastark ? 1 : 0);
-        let   thresh = threshBase + resistCount - sensCount;
         let perm = hasEarth ? (permBase % 2) : permBase;
-        const temp = storeHelper.calcDarkPastTemporaryCorruption(list, thresh);
-        extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` + `<div class="trait-extra">Temporär korruption: ${temp}</div>` + `<div class="trait-extra">Maximal korruption: ${maxCor} • Korruptionströskel: ${thresh}</div>`;
+        perm += darkPerm;
+        extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` + `<div class="trait-extra">Maximal korruption: ${maxCor} • Korruptionströskel: ${thresh}</div>`;
       }
       if (k === 'Diskret') {
         if (storeHelper.abilityLevel(list, 'Fint') >= 1) {


### PR DESCRIPTION
## Summary
- calculate permanent corruption from Mörkt förflutet based on a quarter of the threshold
- drop temporary corruption counter under Viljestark and include Dark Past in corruption totals

## Testing
- `node --check js/store.js`
- `node --check js/character-view.js`
- `node --check js/traits-utils.js`
- `npm test` *(fails: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68bff6a7d1548323a36d5d3a437a6248