### PR TITLE
Color-code qualities and group selection popup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,7 +15,8 @@
   --subtxt:      #a0a0a0;
   --accent:      #3d7cff;
   --mystic:      #a64cff;
-  --neutral:     #5e9cff;
+  --quality:     #5e9cff;
+  --neutral:     #6ac28c;
   --negative:    #8b4513;
   --danger:      #e74c3c;
   --danger-bg:   #3c1a1a;
@@ -85,6 +86,7 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 .tag.removable { cursor: pointer; }
 .tag.free,
 .tag.price-mult { background: var(--accent); color:#fff; }
+.tag.quality   { border: 1.5px solid var(--quality); }
 .tag.mystic    { border: 1.5px solid var(--mystic); }
 .tag.neutral   { border: 1.5px solid var(--neutral); }
 .tag.negative  { border: 1.5px solid var(--negative); }
@@ -761,6 +763,22 @@ select.level {
 }
 #qualPopup .popup-inner button {
   width: 100%;
+}
+#qualPopup #qualOptions .char-btn.quality {
+  background: var(--quality);
+  border: 1.5px solid var(--quality);
+}
+#qualPopup #qualOptions .char-btn.neutral {
+  background: var(--neutral);
+  border: 1.5px solid var(--neutral);
+}
+#qualPopup #qualOptions .char-btn.negative {
+  background: var(--negative);
+  border: 1.5px solid var(--negative);
+}
+#qualPopup #qualOptions .char-btn.mystic {
+  background: var(--mystic);
+  border: 1.5px solid var(--mystic);
 }
 /* ---------- Popup för mästarnivå ---------- */
 #masterPopup {


### PR DESCRIPTION
## Summary
- color-code quality selection buttons and group qualities by type
- add blue borders for regular qualities and soft green for neutral ones
- sort qualities by positive, neutral and negative

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c035b3d2e08323b7dfbdfae7b882a2