### PR TITLE
Beräkna priser via örtegar-bas

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -7,6 +7,8 @@
   // Bring shared currency bases into local scope
   const SBASE = window.SBASE;
   const OBASE = window.OBASE;
+  const moneyToO = window.moneyToO;
+  const oToMoney = window.oToMoney;
   const INV_TOOLS_KEY = 'invToolsOpen';
   const INV_INFO_KEY  = 'invInfoOpen';
   // Local helper to safely access the toolbar shadow root without relying on main.js scope
@@ -32,16 +34,9 @@
     'Galär': '⛵',
     'Flodbåt': '🛥️'
   };
-  const moneyToO = m => (m.daler||0)*SBASE*OBASE + (m.skilling||0)*OBASE + (m['örtegar']||0);
   let dragIdx = null;
   let dragEl = null;
   let dragEnabled = false;
-
-  const oToMoney = o => {
-    const d = Math.floor(o / (SBASE * OBASE)); o %= SBASE * OBASE;
-    const s = Math.floor(o / OBASE);           const ø = o % OBASE;
-    return { d, s, o: ø };              // <–– returnera d/s/o
-  };
 
   const dividePrice = (amt, divisor) => {
     const o = typeof amt === 'number' ? amt : moneyToO(amt || {});

--- a/js/store.js
+++ b/js/store.js
@@ -20,6 +20,9 @@
 
   const DARK_BLOOD_TRAITS = ['Naturligt vapen', 'Pansar', 'Robust', 'Regeneration', 'Vingar'];
 
+  const moneyToO = global.moneyToO;
+  const oToMoney = global.oToMoney;
+
   /* ---------- 1. Grund­struktur ---------- */
   function emptyStore() {
     return {
@@ -755,11 +758,7 @@
 
   function normalizeMoney(m) {
     const res = { ...defaultMoney(), ...(m || {}) };
-    res.skilling += Math.floor(res["örtegar"] / 10);
-    res["örtegar"] %= 10;
-    res.daler += Math.floor(res.skilling / 10);
-    res.skilling %= 10;
-    return res;
+    return oToMoney(moneyToO(res));
   }
 
   /* ---------- 6a. Karaktärsdrag ---------- */

--- a/js/utils.js
+++ b/js/utils.js
@@ -24,6 +24,24 @@
   ];
   const SBASE = 10, OBASE = 10;
 
+  // Konvertera ett penningobjekt till totalt antal örtegar
+  function moneyToO(m) {
+    m = m || {};
+    return (m.daler || m.d || 0) * SBASE * OBASE +
+           (m.skilling || m.s || 0) * OBASE +
+           (m['örtegar'] || m.o || 0);
+  }
+
+  // Konvertera örtegar till ett objekt med daler/skilling/örtegar
+  function oToMoney(o) {
+    let rem = Math.max(0, Math.floor(o));
+    const d = Math.floor(rem / (SBASE * OBASE));
+    rem %= SBASE * OBASE;
+    const s = Math.floor(rem / OBASE);
+    const ø = rem % OBASE;
+    return { daler: d, skilling: s, 'örtegar': ø, d, s, o: ø };
+  }
+
   const TYPE_PRIORITIES = { Ras: 0, Yrke: 1, Elityrke: 2 };
 
   const CAT_ORDER = [
@@ -318,6 +336,8 @@
   window.EQUIP = EQUIP;
   window.SBASE = SBASE;
   window.OBASE = OBASE;
+  window.moneyToO = moneyToO;
+  window.oToMoney = oToMoney;
   window.isInv = isInv;
   window.isQual = isQual;
   window.canApplyQuality = canApplyQuality;


### PR DESCRIPTION
## Sammanfattning
- Lägg till hjälpfunktioner för att räkna och konvertera valuta i örtegar, skilling och daler.
- Använd de nya funktionerna för prisuträkningar i inventarie‑hantering och lagring.
- Normalisera pengar konsekvent utan hårdkodade konverteringar.

## Testning
- `node --check js/utils.js && node --check js/inventory-utils.js && node --check js/store.js`
- `node - <<'NODE' ... örtegar-test ... NODE`
- `node - <<'NODE' ... normalizeMoney-test ... NODE`
- `npm test` *(fail: missing package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68c036cfae708323b7d02294ec99af6a