### PR TITLE
Ensure money conversion helpers load correctly

### DIFF
--- a/character.html
+++ b/character.html
@@ -10,8 +10,8 @@
 
   <link rel="stylesheet" href="css/style.css">
   <script src="js/text-format.js" defer></script>
-  <script src="js/store.js"          defer></script>
   <script src="js/utils.js"          defer></script>
+  <script src="js/store.js"          defer></script>
   <script src="js/inventory-utils.js" defer></script>
   <script src="js/traits-utils.js" defer></script>
   <script src="js/shared-toolbar.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
 
   <link rel="stylesheet" href="css/style.css">
   <script src="js/text-format.js" defer></script>
-  <script src="js/store.js"        defer></script>
   <script src="js/utils.js"        defer></script>
+  <script src="js/store.js"        defer></script>
   <script src="js/inventory-utils.js" defer></script>
   <script src="js/traits-utils.js" defer></script>
   <script src="js/shared-toolbar.js" defer></script>

--- a/js/store.js
+++ b/js/store.js
@@ -20,8 +20,21 @@
 
   const DARK_BLOOD_TRAITS = ['Naturligt vapen', 'Pansar', 'Robust', 'Regeneration', 'Vingar'];
 
-  const moneyToO = global.moneyToO;
-  const oToMoney = global.oToMoney;
+  function moneyToO(...args) {
+    const fn = global.moneyToO;
+    if (typeof fn !== 'function') {
+      throw new Error('moneyToO is not available');
+    }
+    return fn(...args);
+  }
+
+  function oToMoney(...args) {
+    const fn = global.oToMoney;
+    if (typeof fn !== 'function') {
+      throw new Error('oToMoney is not available');
+    }
+    return fn(...args);
+  }
 
   /* ---------- 1. Grund­struktur ---------- */
   function emptyStore() {

--- a/notes.html
+++ b/notes.html
@@ -10,8 +10,8 @@
 
   <link rel="stylesheet" href="css/style.css">
   <script src="js/text-format.js" defer></script>
-  <script src="js/store.js"          defer></script>
   <script src="js/utils.js"          defer></script>
+  <script src="js/store.js"          defer></script>
   <script src="js/inventory-utils.js" defer></script>
   <script src="js/traits-utils.js" defer></script>
   <script src="js/shared-toolbar.js" defer></script>


### PR DESCRIPTION
## Summary
- Load `js/utils.js` before `js/store.js` in top-level HTML files so global money conversion helpers are defined
- Resolve `moneyToO`/`oToMoney` lazily inside `store.js` with defensive checks

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0392b0234832385cc01efb0f560f3