### PR TITLE
Group qualities in add-quality popup

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -236,7 +236,11 @@
       if (obj.item) return getName(obj.item);
       return obj;
     };
-    const rank = n => isNegativeQual(n) ? 2 : isNeutralQual(n) ? 1 : 0;
+    const rank = n =>
+      isNegativeQual(n) ? 3 :
+      isMysticQual(n)   ? 2 :
+      isNeutralQual(n)  ? 1 :
+      0;
     arr.sort((a, b) => {
       const na = getName(a);
       const nb = getName(b);


### PR DESCRIPTION
## Summary
- Order qualities by type in the "Add quality" popup, placing normal qualities first, then neutral, mystic, and negative ones last

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0497f58fc8323a63035d1f2593972