### PR TITLE
Expand PDF bank with offline caching

### DIFF
--- a/data/pdf-list.json
+++ b/data/pdf-list.json
@@ -1,4 +1,70 @@
 [
-  {"title": "Spelarens Grundbok", "file": "data/Spelarens Grundbok.pdf"},
-  {"title": "Regelalternativ",   "file": "data/Regelalternativ.pdf"}
+  {
+    "title": "Allianser inom Kampanjen",
+    "file": "data/Allianser inom Kampanjen.pdf"
+  },
+  {
+    "title": "Davokar",
+    "file": "data/Davokar.pdf"
+  },
+  {
+    "title": "Fraktioner",
+    "file": "data/Fraktioner.pdf"
+  },
+  {
+    "title": "Karvosti, Grund",
+    "file": "data/Karvosti, Grund.pdf"
+  },
+  {
+    "title": "Karvosti",
+    "file": "data/Karvosti.pdf"
+  },
+  {
+    "title": "Litet rollformulär",
+    "file": "data/Litet rollformulär.pdf"
+  },
+  {
+    "title": "Mystiska Traditioner",
+    "file": "data/Mystiska Traditioner.pdf"
+  },
+  {
+    "title": "Regelalternativ",
+    "file": "data/Regelalternativ.pdf"
+  },
+  {
+    "title": "SL regler",
+    "file": "data/SL regler.pdf"
+  },
+  {
+    "title": "Spelarens Grundbok",
+    "file": "data/Spelarens Grundbok.pdf"
+  },
+  {
+    "title": "Spelarregler",
+    "file": "data/Spelarregler.pdf"
+  },
+  {
+    "title": "Spelvärld",
+    "file": "data/Spelvärld.pdf"
+  },
+  {
+    "title": "Stort rollformulär",
+    "file": "data/Stort rollformulär.pdf"
+  },
+  {
+    "title": "Tistla Fäste, grund",
+    "file": "data/Tistla Fäste, grund.pdf"
+  },
+  {
+    "title": "Tistla Fäste",
+    "file": "data/Tistla Fäste.pdf"
+  },
+  {
+    "title": "Yndaros, Grund",
+    "file": "data/Yndaros, Grund.pdf"
+  },
+  {
+    "title": "Yndaros",
+    "file": "data/Yndaros.pdf"
+  }
 ]

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1442,7 +1442,6 @@ function openVehiclePopup(preselectId, precheckedPaths) {
             ${vehicleBtns}
             <button id="dragToggle" class="char-btn">Dra & Släpp</button>
             <button id="saveFreeBtn" class="char-btn">Spara & gratismarkera</button>
-            <button id="pdfLibraryBtn" class="char-btn">PDF-bank</button>
             <button id="clearInvBtn" class="char-btn danger">Rensa inventarie</button>
           </div>
         </div>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'symbaroum-pwa-v7';
+const CACHE_NAME = 'symbaroum-pwa-v8';
 const URLS_TO_CACHE = [
   // Core pages and styles
   'index.html',
@@ -75,9 +75,15 @@ const URLS_TO_CACHE = [
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches
-      .open(CACHE_NAME)
-      .then(cache => cache.addAll(URLS_TO_CACHE))
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      await cache.addAll(URLS_TO_CACHE);
+      const response = await cache.match('data/pdf-list.json');
+      if (response) {
+        const pdfs = await response.json();
+        await cache.addAll(pdfs.map(p => p.file));
+      }
+    })()
   );
 });
 


### PR DESCRIPTION
## Summary
- Remove PDF-bank button from inventory tools menu so it only appears in the filter menu.
- List every PDF in `data` via `pdf-list.json` and show them in the PDF-bank popup.
- Pre-cache all PDFs in the service worker for fast access and offline availability.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c25c20b0848323a3649735219950ec