### PR TITLE
Fix PDF bank popup in shadow DOM

### DIFF
--- a/js/pdf-library.js
+++ b/js/pdf-library.js
@@ -1,11 +1,13 @@
 // PDF Library popup
 
-document.querySelectorAll('#pdfLibraryBtn').forEach(btn => {
-  btn.addEventListener('click', async () => {
-    const pdfs = await fetch('data/pdf-list.json').then(r => r.json());
-    const html = pdfs
-      .map(p => `<div><a href="${encodeURI(p.file)}" target="_blank" rel="noopener">${p.title}</a></div>`)
-      .join('');
-    tabellPopup.open(html, 'PDF-bank');
-  });
+// The PDF button lives inside the shared-toolbar shadow DOM which makes
+// `querySelectorAll` ineffective. `document.getElementById` is patched by
+// the toolbar to also search its shadow root, so use it instead.
+const pdfBtn = document.getElementById('pdfLibraryBtn');
+pdfBtn?.addEventListener('click', async () => {
+  const pdfs = await fetch('data/pdf-list.json').then(r => r.json());
+  const html = pdfs
+    .map(p => `<div><a href="${encodeURI(p.file)}" target="_blank" rel="noopener">${p.title}</a></div>`)
+    .join('');
+  tabellPopup.open(html, 'PDF-bank');
 });


### PR DESCRIPTION
## Summary
- Ensure the PDF-bank button inside the `shared-toolbar` shadow DOM triggers the popup correctly by switching to `getElementById`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c25edf08d88323b8be8d90da96b1bf