### PR TITLE
Style PDF library popup like smithPopup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1532,6 +1532,42 @@ select.level {
 }
 #defensePopup .popup-inner button { width: 100%; }
 
+/* ---------- Popup för PDF-bank ---------- */
+#pdfPopup {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(0,0,0,.6);
+  z-index: 3000;
+}
+#pdfPopup.open { display: flex; }
+#pdfPopup .popup-inner {
+  background: var(--panel);
+  border: 1.5px solid var(--border);
+  border-radius: 1.2rem 1.2rem 0 0;
+  box-shadow: var(--shadow);
+  padding: 1.5rem 1.4rem 2rem;
+  width: 100%;
+  max-width: 420px;
+  text-align: center;
+  transform: translateY(100%);
+  transition: transform .25s ease;
+  display: flex;
+  flex-direction: column;
+  gap: .8rem;
+}
+#pdfPopup.open .popup-inner { transform: translateY(0); }
+#pdfPopup #pdfOptions {
+  display: flex;
+  flex-direction: column;
+  gap: .6rem;
+}
+#pdfPopup .popup-inner button { width: 100%; }
+
 /* ---------- Popup för export ---------- */
 #exportPopup {
   position: fixed;

--- a/js/pdf-library.js
+++ b/js/pdf-library.js
@@ -6,8 +6,33 @@
 const pdfBtn = document.getElementById('pdfLibraryBtn');
 pdfBtn?.addEventListener('click', async () => {
   const pdfs = await fetch('data/pdf-list.json').then(r => r.json());
-  const html = pdfs
-    .map(p => `<div><a href="${encodeURI(p.file)}" target="_blank" rel="noopener">${p.title}</a></div>`)
+  const pop = document.getElementById('pdfPopup');
+  const box = document.getElementById('pdfOptions');
+  const cls = document.getElementById('pdfCancel');
+  box.innerHTML = pdfs
+    .map(p => `<button data-href="${encodeURI(p.file)}" class="char-btn">${p.title}</button>`)
     .join('');
-  tabellPopup.open(html, 'PDF-bank');
+  pop.classList.add('open');
+  pop.querySelector('.popup-inner').scrollTop = 0;
+  function close() {
+    pop.classList.remove('open');
+    box.removeEventListener('click', onBtn);
+    cls.removeEventListener('click', onCancel);
+    pop.removeEventListener('click', onOutside);
+  }
+  function onBtn(e) {
+    const b = e.target.closest('button[data-href]');
+    if (!b) return;
+    window.open(b.dataset.href, '_blank', 'noopener');
+    close();
+  }
+  function onCancel() { close(); }
+  function onOutside(e) {
+    if (!pop.querySelector('.popup-inner').contains(e.target)) {
+      close();
+    }
+  }
+  box.addEventListener('click', onBtn);
+  cls.addEventListener('click', onCancel);
+  pop.addEventListener('click', onOutside);
 });

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -607,6 +607,15 @@ class SharedToolbar extends HTMLElement {
         </div>
       </div>
 
+      <!-- ---------- Popup PDF-bank ---------- -->
+      <div id="pdfPopup" class="popup popup-bottom">
+        <div class="popup-inner">
+          <h3>PDF-bank</h3>
+          <div id="pdfOptions"></div>
+          <button id="pdfCancel" class="char-btn danger">Avbryt</button>
+        </div>
+      </div>
+
       <!-- ---------- Popup Export ---------- -->
       <div id="exportPopup" class="popup">
         <div class="popup-inner">
@@ -976,7 +985,7 @@ class SharedToolbar extends HTMLElement {
     }
 
     // ignore clicks inside popups so panels stay open
-      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','pricePopup','rowPricePopup','vehiclePopup','vehicleRemovePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','nilasPopup','tabellPopup','dialogPopup','folderManagerPopup','newCharPopup','dupCharPopup','renameCharPopup','artifactPaymentPopup'];
+      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','pricePopup','rowPricePopup','vehiclePopup','vehicleRemovePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','pdfPopup','nilasPopup','tabellPopup','dialogPopup','folderManagerPopup','newCharPopup','dupCharPopup','renameCharPopup','artifactPaymentPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));


### PR DESCRIPTION
## Summary
- Add dedicated PDF-bank popup with smith-style full-width buttons
- Update shared toolbar to recognize pdfPopup for outside click handling
- Implement popup logic and styling for PDF library

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c26cb071208323b6123b252fc47f26