### PR TITLE
Organize PDF library into categories

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1568,6 +1568,19 @@ select.level {
 }
 #pdfPopup .popup-inner button { width: 100%; }
 
+#pdfPopup .pdf-category {
+  border: 2px solid var(--card-border);
+  border-radius: .6rem;
+  padding: .4rem .6rem .6rem;
+  display: flex;
+  flex-direction: column;
+  gap: .4rem;
+}
+#pdfPopup .pdf-category h3 {
+  margin: 0 0 .2rem;
+  font-size: 1rem;
+}
+
 /* ---------- Popup för export ---------- */
 #exportPopup {
   position: fixed;

--- a/data/pdf-list.json
+++ b/data/pdf-list.json
@@ -1,70 +1,39 @@
 [
   {
-    "title": "Allianser inom Kampanjen",
-    "file": "data/Allianser inom Kampanjen.pdf"
+    "category": "Regler",
+    "items": [
+      { "title": "Spelarens Grundbok", "file": "data/Spelarens Grundbok.pdf" },
+      { "title": "Spelarregler", "file": "data/Spelarregler.pdf" },
+      { "title": "SL regler", "file": "data/SL regler.pdf" },
+      { "title": "Regelalternativ", "file": "data/Regelalternativ.pdf" },
+      { "title": "Litet rollformul\u00e4r", "file": "data/Litet rollformula\u0308r.pdf" },
+      { "title": "Stort rollformul\u00e4r", "file": "data/Stort rollformula\u0308r.pdf" }
+    ]
   },
   {
-    "title": "Davokar",
-    "file": "data/Davokar.pdf"
+    "category": "V\u00e4rlds\u00f6versikt",
+    "items": [
+      { "title": "Spelv\u00e4rld", "file": "data/Spelva\u0308rld.pdf" },
+      { "title": "Davokar", "file": "data/Davokar.pdf" },
+      { "title": "Mystiska Traditioner", "file": "data/Mystiska Traditioner.pdf" }
+    ]
   },
   {
-    "title": "Fraktioner",
-    "file": "data/Fraktioner.pdf"
+    "category": "Platser",
+    "items": [
+      { "title": "Yndaros, Grund", "file": "data/Yndaros, Grund.pdf" },
+      { "title": "Yndaros, Detalj", "file": "data/Yndaros.pdf" },
+      { "title": "Tistla F\u00e4ste, Grund", "file": "data/Tistla F\u00e4ste, grund.pdf" },
+      { "title": "Tistla F\u00e4ste, Detalj", "file": "data/Tistla F\u00e4ste.pdf" },
+      { "title": "Karvosti, Grund", "file": "data/Karvosti, Grund.pdf" },
+      { "title": "Karvosti, Detalj", "file": "data/Karvosti.pdf" }
+    ]
   },
   {
-    "title": "Karvosti, Grund",
-    "file": "data/Karvosti, Grund.pdf"
-  },
-  {
-    "title": "Karvosti",
-    "file": "data/Karvosti.pdf"
-  },
-  {
-    "title": "Litet rollformulär",
-    "file": "data/Litet rollformulär.pdf"
-  },
-  {
-    "title": "Mystiska Traditioner",
-    "file": "data/Mystiska Traditioner.pdf"
-  },
-  {
-    "title": "Regelalternativ",
-    "file": "data/Regelalternativ.pdf"
-  },
-  {
-    "title": "SL regler",
-    "file": "data/SL regler.pdf"
-  },
-  {
-    "title": "Spelarens Grundbok",
-    "file": "data/Spelarens Grundbok.pdf"
-  },
-  {
-    "title": "Spelarregler",
-    "file": "data/Spelarregler.pdf"
-  },
-  {
-    "title": "Spelvärld",
-    "file": "data/Spelvärld.pdf"
-  },
-  {
-    "title": "Stort rollformulär",
-    "file": "data/Stort rollformulär.pdf"
-  },
-  {
-    "title": "Tistla Fäste, grund",
-    "file": "data/Tistla Fäste, grund.pdf"
-  },
-  {
-    "title": "Tistla Fäste",
-    "file": "data/Tistla Fäste.pdf"
-  },
-  {
-    "title": "Yndaros, Grund",
-    "file": "data/Yndaros, Grund.pdf"
-  },
-  {
-    "title": "Yndaros",
-    "file": "data/Yndaros.pdf"
+    "category": "Akt\u00f6rer och krafter",
+    "items": [
+      { "title": "Fraktioner", "file": "data/Fraktioner.pdf" },
+      { "title": "Allianser inom Kampanjen", "file": "data/Allianser inom Kampanjen.pdf" }
+    ]
   }
 ]

--- a/js/pdf-library.js
+++ b/js/pdf-library.js
@@ -10,7 +10,14 @@ pdfBtn?.addEventListener('click', async () => {
   const box = document.getElementById('pdfOptions');
   const cls = document.getElementById('pdfCancel');
   box.innerHTML = pdfs
-    .map(p => `<button data-href="${encodeURI(p.file)}" class="char-btn">${p.title}</button>`)
+    .map(cat => `
+      <div class="pdf-category">
+        <h3>${cat.category}</h3>
+        ${cat.items
+          .map(p => `<button data-href="${encodeURI(p.file)}" class="char-btn">${p.title}</button>`)
+          .join('')}
+      </div>
+    `)
     .join('');
   pop.classList.add('open');
   pop.querySelector('.popup-inner').scrollTop = 0;

--- a/sw.js
+++ b/sw.js
@@ -81,7 +81,8 @@ self.addEventListener('install', event => {
       const response = await cache.match('data/pdf-list.json');
       if (response) {
         const pdfs = await response.json();
-        await cache.addAll(pdfs.map(p => p.file));
+        const files = pdfs.flatMap(c => c.items.map(p => p.file));
+        await cache.addAll(files);
       }
     })()
   );


### PR DESCRIPTION
## Summary
- Group PDF library entries under new categories and display them as bordered sections in the popup
- Apply matching styles for each category block
- Update service worker caching for the restructured PDF list

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c273b26c008323aaa53928194a7367