### PR TITLE
Valbart kraftval för lägre artefakter

### DIFF
--- a/character.html
+++ b/character.html
@@ -25,6 +25,7 @@
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/djurmask.js" defer></script>
   <script src="js/beastform.js" defer></script>
+  <script src="js/kraftval.js" defer></script>
   <script src="js/artifact-payment.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
   <script src="js/monsterlard.js" defer></script>

--- a/data/lagre-artefakter.json
+++ b/data/lagre-artefakter.json
@@ -11,8 +11,10 @@
       ]
     },
     "nivåer": {
-      "Novis": "Artefaktmakare inom Ordo Magica har bundit en mystisk kraft på novis-, gesäll- eller mästarnivå (beroende på nivå i pergamentet), som sedan kan läsas och aktiveras av någon annan som behärskar Ordensmagi till samma nivå som kraften på pergamentet eller högre, alternativt besitter förmågan Lärd till minst gesällnivå. Den som använder pergamentet drabbas av temporär korruption som vanligt. Pergamentet förbrukas när det används."
+      "Novis": "Artefaktmakare inom Ordo Magica har bundit en mystisk kraft på novisnivå i pergamentet, som sedan kan läsas och aktiveras av någon annan som behärskar Ordensmagi till minst novisnivå eller besitter förmågan Lärd till minst gesällnivå. Den som använder pergamentet drabbas av temporär korruption som vanligt. Pergamentet förbrukas när det används."
     },
+    "bound": "kraft",
+    "boundLabel": "Formel",
     "grundpris": {
       "daler": 2,
       "skilling": 0,
@@ -122,6 +124,8 @@
     "nivåer": {
       "Novis": "En ritual nedtecknas i en kodex på ett sådant sätt att en annan ritualist kan använda den, trots att de inte behärskar ritualen. Kodexen förbrukas när ritualen används."
     },
+    "bound": "ritual",
+    "boundLabel": "Ritual",
     "grundpris": {
       "daler": 4,
       "skilling": 0,
@@ -240,8 +244,10 @@
       ]
     },
     "nivåer": {
-      "Gesäll": "Artefaktmakare inom Ordo Magica har bundit en mystisk kraft på novis-, gesäll- eller mästarnivå (beroende på nivå i pergamentet), som sedan kan läsas och aktiveras av någon annan som behärskar Ordensmagi till samma nivå som kraften på pergamentet eller högre, alternativt besitter förmågan Lärd till minst gesällnivå. Den som använder pergamentet drabbas av temporär korruption som vanligt. Pergamentet förbrukas när det används."
+      "Gesäll": "Artefaktmakare inom Ordo Magica har bundit en mystisk kraft på gesällnivå i pergamentet, som sedan kan läsas och aktiveras av någon annan som behärskar Ordensmagi till minst gesällnivå eller besitter förmågan Lärd till minst gesällnivå. Den som använder pergamentet drabbas av temporär korruption som vanligt. Pergamentet förbrukas när det används."
     },
+    "bound": "kraft",
+    "boundLabel": "Formel",
     "grundpris": {
       "daler": 4,
       "skilling": 0,
@@ -261,8 +267,10 @@
       "ark_trad": []
     },
     "nivåer": {
-      "Gesäll": "Artefaktmakaren har bundit en mystisk kraft på novis-, gesäll- eller mästarnivå i ett sigill, som när det bryts av någon utlöser kraften. Den som bryter sigillet drabbas av temporär korruption som vanligt. Sigillet kan bara brytas en gång, sedan är det förbrukat."
+      "Gesäll": "Artefaktmakaren har bundit en mystisk kraft på gesällnivå i ett sigill, som när det bryts av någon utlöser kraften. Den som bryter sigillet drabbas av temporär korruption som vanligt. Sigillet kan bara brytas en gång, sedan är det förbrukat."
     },
+    "bound": "kraft",
+    "boundLabel": "Formel",
     "grundpris": {
       "daler": 8,
       "skilling": 0,
@@ -282,8 +290,10 @@
       "ark_trad": []
     },
     "nivåer": {
-      "Gesäll": "Artefaktmakaren har bundit en mystisk kraft på novis-, gesäll- eller mästarnivå i ett sigill, som när det bryts av någon utlöser kraften. Den som bryter sigillet drabbas av temporär korruption som vanligt. Sigillet kan bara brytas en gång, sedan är det förbrukat."
+      "Novis": "Artefaktmakaren har bundit en mystisk kraft på novisnivå i ett sigill, som när det bryts av någon utlöser kraften. Den som bryter sigillet drabbas av temporär korruption som vanligt. Sigillet kan bara brytas en gång, sedan är det förbrukat."
     },
+    "bound": "kraft",
+    "boundLabel": "Formel",
     "grundpris": {
       "daler": 8,
       "skilling": 0,
@@ -597,8 +607,10 @@
       ]
     },
     "nivåer": {
-      "Mästare": "Artefaktmakare inom Ordo Magica har bundit en mystisk kraft på novis-, gesäll- eller mästarnivå (beroende på nivå i pergamentet), som sedan kan läsas och aktiveras av någon annan som behärskar Ordensmagi till samma nivå som kraften på pergamentet eller högre, alternativt besitter förmågan Lärd till minst gesällnivå. Den som använder pergamentet drabbas av temporär korruption som vanligt. Pergamentet förbrukas när det används."
+      "Mästare": "Artefaktmakare inom Ordo Magica har bundit en mystisk kraft på mästarnivå i pergamentet, som sedan kan läsas och aktiveras av någon annan som behärskar Ordensmagi till minst mästarnivå eller besitter förmågan Lärd till minst gesällnivå. Den som använder pergamentet drabbas av temporär korruption som vanligt. Pergamentet förbrukas när det används."
     },
+    "bound": "kraft",
+    "boundLabel": "Formel",
     "grundpris": {
       "daler": 6,
       "skilling": 0,
@@ -618,8 +630,10 @@
       "ark_trad": []
     },
     "nivåer": {
-      "Mästare": "Artefaktmakaren har bundit en mystisk kraft på novis-, gesäll- eller mästarnivå i ett sigill, som när det bryts av någon utlöser kraften. Den som bryter sigillet drabbas av temporär korruption som vanligt. Sigillet kan bara brytas en gång, sedan är det förbrukat."
+      "Mästare": "Artefaktmakaren har bundit en mystisk kraft på mästarnivå i ett sigill, som när det bryts av någon utlöser kraften. Den som bryter sigillet drabbas av temporär korruption som vanligt. Sigillet kan bara brytas en gång, sedan är det förbrukat."
     },
+    "bound": "kraft",
+    "boundLabel": "Formel",
     "grundpris": {
       "daler": 12,
       "skilling": 0,
@@ -662,6 +676,8 @@
     "nivåer": {
       "Mästare": "Artefaktmakaren binder en ritual i ett sigill, som när det bryts utlöser ritualens effekt. Skaparen av sigillet måste inte själv behärska ritualen men behöver någon med sig som kan ritualen vid skapandet av sigillet, eller ha tillgång till en ritualkodex med ritualen (kodexen förstörs då när sigillet skapas). Den som bryter sigillet drabbas av temporär korruption som vanligt."
     },
+    "bound": "ritual",
+    "boundLabel": "Ritual",
     "grundpris": {
       "daler": 12,
       "skilling": 0,

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/djurmask.js" defer></script>
   <script src="js/beastform.js" defer></script>
+  <script src="js/kraftval.js" defer></script>
   <script src="js/artifact-payment.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
   <script src="js/monsterlard.js" defer></script>

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1126,6 +1126,20 @@ function initIndex() {
               if (used.includes(trait) && !(await confirmPopup('Samma karakt\u00e4rsdrag finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
               addRow(trait);
             });
+          } else if (p.bound === 'kraft' && window.powerPicker) {
+            const used = inv.filter(it => it.id===p.id).map(it=>it.trait).filter(Boolean);
+            powerPicker.pickKraft(used, async val => {
+              if(!val) return;
+              if (used.includes(val) && !(await confirmPopup('Samma formel finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
+              addRow(val);
+            });
+          } else if (p.bound === 'ritual' && window.powerPicker) {
+            const used = inv.filter(it => it.id===p.id).map(it=>it.trait).filter(Boolean);
+            powerPicker.pickRitual(used, async val => {
+              if(!val) return;
+              if (used.includes(val) && !(await confirmPopup('Samma ritual finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
+              addRow(val);
+            });
           } else {
             addRow();
           }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1251,7 +1251,9 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     }
     desc += itemStatHtml(entry, row);
     if (row.trait && row.id !== 'l9') {
-      desc += `<br><strong>Karakt\u00e4rsdrag:</strong> ${row.trait}`;
+      const ent = getEntry(row.id || row.name);
+      const label = ent.boundLabel || 'Karakt\u00e4rsdrag';
+      desc += `<br><strong>${label}:</strong> ${row.trait}`;
     }
 
     const removedQ = row.removedKval ?? [];
@@ -1930,6 +1932,20 @@ ${moneyRow}
                 if(!trait) return;
                 if (used.includes(trait) && !(await confirmPopup('Samma karakt\u00e4rsdrag finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
                 addRow(trait);
+              });
+            } else if (entry.bound === 'kraft' && window.powerPicker) {
+              const used = inv.filter(it => it.id === entry.id).map(it=>it.trait).filter(Boolean);
+              powerPicker.pickKraft(used, async val => {
+                if(!val) return;
+                if (used.includes(val) && !(await confirmPopup('Samma formel finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
+                addRow(val);
+              });
+            } else if (entry.bound === 'ritual' && window.powerPicker) {
+              const used = inv.filter(it => it.id === entry.id).map(it=>it.trait).filter(Boolean);
+              powerPicker.pickRitual(used, async val => {
+                if(!val) return;
+                if (used.includes(val) && !(await confirmPopup('Samma ritual finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
+                addRow(val);
               });
             } else {
               addRow();

--- a/js/kraftval.js
+++ b/js/kraftval.js
@@ -1,0 +1,61 @@
+(function(window){
+  function createPopup(){
+    if(document.getElementById('powerPopup')) return;
+    const div=document.createElement('div');
+    div.id='powerPopup';
+    div.innerHTML=`<div class="popup-inner"><h3 id="powerTitle"></h3><input id="powerSearch" type="text" placeholder="Sök..."><div id="powerOpts"></div><button id="powerCancel" class="char-btn danger">Avbryt</button></div>`;
+    document.body.appendChild(div);
+  }
+
+  function openPopup(list,title,cb){
+    createPopup();
+    const pop=document.getElementById('powerPopup');
+    const box=pop.querySelector('#powerOpts');
+    const search=pop.querySelector('#powerSearch');
+    const cls=pop.querySelector('#powerCancel');
+    pop.querySelector('#powerTitle').textContent=title;
+    function render(f=''){
+      const fl=f.trim().toLowerCase();
+      box.innerHTML=list.filter(n=>n.toLowerCase().includes(fl)).map((n,i)=>`<button data-i="${i}" class="char-btn">${n}</button>`).join('');
+    }
+    render();
+    pop.classList.add('open');
+    pop.querySelector('.popup-inner').scrollTop=0;
+    function close(){
+      pop.classList.remove('open');
+      box.innerHTML='';
+      search.value='';
+      box.removeEventListener('click',onClick);
+      cls.removeEventListener('click',onCancel);
+      pop.removeEventListener('click',onOutside);
+      search.removeEventListener('input',onSearch);
+    }
+    function onClick(e){
+      const b=e.target.closest('button[data-i]');
+      if(!b) return;
+      const idx=Number(b.dataset.i);
+      close();
+      cb(list[idx]);
+    }
+    function onCancel(){ close(); cb(null); }
+    function onOutside(e){ if(!pop.querySelector('.popup-inner').contains(e.target)){ close(); cb(null); } }
+    function onSearch(){ render(search.value); }
+    box.addEventListener('click',onClick);
+    cls.addEventListener('click',onCancel);
+    pop.addEventListener('click',onOutside);
+    search.addEventListener('input',onSearch);
+    search.focus();
+  }
+
+  function pickKraft(used,cb){
+    const list=(window.DB||[]).filter(ent=> (ent.taggar?.typ||[]).includes('Mystisk kraft')).map(ent=>ent.namn).sort();
+    openPopup(list,'Välj formel',res=>cb(res));
+  }
+
+  function pickRitual(used,cb){
+    const list=(window.DB||[]).filter(ent=> (ent.taggar?.typ||[]).includes('Ritual')).map(ent=>ent.namn).sort();
+    openPopup(list,'Välj ritual',res=>cb(res));
+  }
+
+  window.powerPicker={pickKraft,pickRitual};
+})(window);

--- a/notes.html
+++ b/notes.html
@@ -25,6 +25,7 @@
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/djurmask.js" defer></script>
   <script src="js/beastform.js" defer></script>
+  <script src="js/kraftval.js" defer></script>
   <script src="js/artifact-payment.js" defer></script>
   <script src="js/bloodbond.js" defer></script>
   <script src="js/monsterlard.js" defer></script>


### PR DESCRIPTION
## Sammanfattning
- införde `powerPicker` med sökbar popup för att välja formel eller ritual
- la till val av kraft/ritual när Formelpergament, Formelsigill, Ritualkodex och Ritualsigill läggs till i inventariet
- uppdaterade beskrivningar för Formelpergament och Formelsigill så att nivå framgår

## Testning
- `node --check js/kraftval.js && node --check js/index-view.js && node --check js/inventory-utils.js`
- `npm test` *(misslyckas: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c294e4ac3c8323a73e3d187cf8df21