### PR TITLE
Tillåt stapling av pergament och sigill

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -52,6 +52,7 @@ function initIndex() {
   const isHidden = p => (p.taggar?.typ || []).some(t => ['artefakt','kuriositet','skatt'].includes(String(t).toLowerCase()));
 
   const FALT_BUNDLE = ['di10','di11','di12','di13','di14','di15'];
+  const STACKABLE_IDS = ['l1','l11','l27','l6','l12','l13','l28','l30'];
 
   const QUAL_TYPE_MAP = {
     'Vapenkvalitet': 'Vapen',
@@ -1030,7 +1031,7 @@ function initIndex() {
             const ent = invUtil.getEntry(id);
             if (!ent.namn) return;
             const indivItem = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakt','Färdmedel']
-              .some(t=>ent.taggar.typ.includes(t));
+              .some(t=>ent.taggar.typ.includes(t)) && !STACKABLE_IDS.includes(ent.id);
             const existing = inv.find(r => r.id === ent.id);
             if (indivItem || !existing) {
               inv.push({ id: ent.id, name: ent.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] });
@@ -1050,7 +1051,8 @@ function initIndex() {
             }
           });
         } else {
-          const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakt','Färdmedel'].some(t=>p.taggar.typ.includes(t));
+          const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakt','Färdmedel']
+            .some(t=>p.taggar.typ.includes(t)) && !STACKABLE_IDS.includes(p.id);
           const rowBase = { id:p.id, name:p.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] };
           const tagTyp = p.taggar?.typ || [];
           if (tagTyp.includes('L\u00e4gre Artefakt')) {
@@ -1130,14 +1132,14 @@ function initIndex() {
             const used = inv.filter(it => it.id===p.id).map(it=>it.trait).filter(Boolean);
             powerPicker.pickKraft(used, async val => {
               if(!val) return;
-              if (used.includes(val) && !(await confirmPopup('Samma formel finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
+              if (used.includes(val) && !STACKABLE_IDS.includes(p.id) && !(await confirmPopup('Samma formel finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
               addRow(val);
             });
           } else if (p.bound === 'ritual' && window.powerPicker) {
             const used = inv.filter(it => it.id===p.id).map(it=>it.trait).filter(Boolean);
             powerPicker.pickRitual(used, async val => {
               if(!val) return;
-              if (used.includes(val) && !(await confirmPopup('Samma ritual finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
+              if (used.includes(val) && !STACKABLE_IDS.includes(p.id) && !(await confirmPopup('Samma ritual finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
               addRow(val);
             });
           } else {

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -11,6 +11,7 @@
   const oToMoney = window.oToMoney;
   const INV_TOOLS_KEY = 'invToolsOpen';
   const INV_INFO_KEY  = 'invInfoOpen';
+  const STACKABLE_IDS = ['l1','l11','l27','l6','l12','l13','l28','l30'];
   // Local helper to safely access the toolbar shadow root without relying on main.js scope
   const getToolbarRoot = () => {
     const el = document.querySelector('shared-toolbar');
@@ -578,7 +579,7 @@
       if (!row) return;
       const entry = getEntry(row.id || row.name);
       const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakt','Färdmedel']
-        .some(t => entry.taggar?.typ?.includes(t));
+        .some(t => entry.taggar?.typ?.includes(t)) && !STACKABLE_IDS.includes(entry.id);
 
       if (indiv) {
         for (let i = 0; i < qty; i++) {
@@ -1857,7 +1858,8 @@ ${moneyRow}
             bundle.forEach(id => {
               const ent = getEntry(id);
               if (!ent.namn) return;
-              const indivItem = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakt','Färdmedel'].some(t => ent.taggar.typ.includes(t));
+              const indivItem = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakt','Färdmedel']
+                .some(t => ent.taggar.typ.includes(t)) && !STACKABLE_IDS.includes(ent.id);
               const existing = inv.findIndex(r => r.id === ent.id);
               if (indivItem || existing === -1) {
                 inv.push({ id: ent.id, name: ent.namn, qty:1, gratis:0, gratisKval:[], removedKval:[] });
@@ -1877,7 +1879,8 @@ ${moneyRow}
               }
             });
           } else {
-            const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakt','Färdmedel'].some(t => entry.taggar.typ.includes(t));
+            const indiv = ['Vapen','Sköld','Rustning','L\u00e4gre Artefakt','Artefakt','Färdmedel']
+              .some(t => entry.taggar.typ.includes(t)) && !STACKABLE_IDS.includes(entry.id);
             const tagTyp = entry.taggar?.typ || [];
             let artifactEffect = '';
             if (tagTyp.includes('Artefakt')) {
@@ -1947,14 +1950,14 @@ ${moneyRow}
               const used = inv.filter(it => it.id === entry.id).map(it=>it.trait).filter(Boolean);
               powerPicker.pickKraft(used, async val => {
                 if(!val) return;
-                if (used.includes(val) && !(await confirmPopup('Samma formel finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
+                if (used.includes(val) && !STACKABLE_IDS.includes(entry.id) && !(await confirmPopup('Samma formel finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
                 addRow(val);
               });
             } else if (entry.bound === 'ritual' && window.powerPicker) {
               const used = inv.filter(it => it.id === entry.id).map(it=>it.trait).filter(Boolean);
               powerPicker.pickRitual(used, async val => {
                 if(!val) return;
-                if (used.includes(val) && !(await confirmPopup('Samma ritual finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
+                if (used.includes(val) && !STACKABLE_IDS.includes(entry.id) && !(await confirmPopup('Samma ritual finns redan. L\u00e4gga till \u00e4nd\u00e5?'))) return;
                 addRow(val);
               });
             } else {

--- a/js/kraftval.js
+++ b/js/kraftval.js
@@ -14,9 +14,11 @@
     const search=pop.querySelector('#powerSearch');
     const cls=pop.querySelector('#powerCancel');
     pop.querySelector('#powerTitle').textContent=title;
+    let current=list;
     function render(f=''){
       const fl=f.trim().toLowerCase();
-      box.innerHTML=list.filter(n=>n.toLowerCase().includes(fl)).map((n,i)=>`<button data-i="${i}" class="char-btn">${n}</button>`).join('');
+      current=list.filter(n=>n.toLowerCase().includes(fl));
+      box.innerHTML=current.map((n,i)=>`<button data-i="${i}" class="char-btn">${n}</button>`).join('');
     }
     render();
     pop.classList.add('open');
@@ -35,7 +37,7 @@
       if(!b) return;
       const idx=Number(b.dataset.i);
       close();
-      cb(list[idx]);
+      cb(current[idx]);
     }
     function onCancel(){ close(); cb(null); }
     function onOutside(e){ if(!pop.querySelector('.popup-inner').contains(e.target)){ close(); cb(null); } }


### PR DESCRIPTION
## Sammanfattning
- Låt formelpergament, (ritual)kodex och sigill staplas utan varningsdialog
- Åtgärda buggen där sökfunktionen i kraft-/ritualpopupen alltid valde fel kraft

## Test
- `npm test` *(fail: package.json saknas)*
- `node --check js/kraftval.js js/inventory-utils.js js/index-view.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2badf13908323b8f5e2971725febf