### PR TITLE
Handle Stenpansar armor penalty

### DIFF
--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -64,9 +64,12 @@
         ...(row.kvaliteter || [])
       ];
       let limit = entry.stat?.['begränsning'] || 0;
+      let stonePen = 0;
       if(allQ.includes('Smidig') || allQ.includes('Smidigt')) limit += 2;
       if(allQ.includes('Otymplig') || allQ.includes('Otympligt')) limit -= 1;
+      if(allQ.includes('Stenpansar')) stonePen -= 4;
       if(rustLvl >= 2) limit = 0;
+      limit += stonePen;
       out.push({ name: nameMap.get(row), value: kvick + limit });
       return out;
     }, []);

--- a/js/utils.js
+++ b/js/utils.js
@@ -260,11 +260,14 @@
           ];
           const baseQ = baseQuals.filter(q => !removed.includes(q));
           const allQ = [...baseQ, ...(row.kvaliteter || [])];
+          let stonePen = 0;
           if (allQ.includes('Smidig') || allQ.includes('Smidigt')) limit += 2;
           if (allQ.includes('Otymplig') || allQ.includes('Otympligt')) limit -= 1;
+          if (allQ.includes('Stenpansar')) stonePen -= 4;
           const list = storeHelper.getCurrentList(store);
           const rustLvl = storeHelper.abilityLevel(list, 'Rustmästare');
           if (rustLvl >= 2) limit = 0;
+          limit += stonePen;
         }
         parts.push(`Begr\u00e4nsning: ${limit}`);
       }


### PR DESCRIPTION
## Summary
- ensure Stenpansar quality adds permanent −4 restriction
- Rustmästare ability no longer removes Stenpansar penalty

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c4089a9934832396fc72d848658021