### PR TITLE
Justera smideskonstens prisberäkning

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1078,11 +1078,11 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     if (forgeLvl && forgeable) {
       const posCnt = countPositiveQuals(allQuals);
       const mystCnt = allQuals.filter(q => !isNegativeQual(q) && !isNeutralQual(q) && isMysticQual(q)).length;
-      if (
-        (forgeLvl === 1 && posCnt === 0) ||
-        (forgeLvl === 2 && mystCnt === 0 && posCnt <= 1) ||
-        (forgeLvl >= 3 && posCnt <= 2)
-      ) {
+      const qualifies =
+        (forgeLvl >= 1 && posCnt === 0) ||
+        (forgeLvl >= 2 && posCnt === 1 && mystCnt === 0) ||
+        (forgeLvl >= 3 && posCnt === 2 && mystCnt <= 1);
+      if (qualifies) {
         base = dividePrice(base, 2);
       }
     }


### PR DESCRIPTION
## Sammanfattning
- Uppdatera prislogik för Smideskonst så att halvering bara sker vid exakt rätt antal positiva kvaliteter för varje nivå.

## Testning
- `npm test` *(misslyckas: package.json saknas)*

------
https://chatgpt.com/codex/tasks/task_e_68c40b37de6c8323af4e828a859fbb0b