### PR TITLE
Ensure qualities only apply to matching item types

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1028,14 +1028,19 @@ function initIndex() {
       const inv = storeHelper.getInventory(store);
       if (!inv.length) { await alertPopup('Ingen utrustning i inventariet.'); return; }
       const elig = inv.filter(it => {
-        const tag = (invUtil.getEntry(it.id || it.name)?.taggar?.typ) || [];
-        return ['Vapen','Sköld','Rustning'].some(t => tag.includes(t));
+        const entry = invUtil.getEntry(it.id || it.name);
+        if (window.canApplyQuality) return canApplyQuality(entry, p);
+        const tag = (entry?.taggar?.typ) || [];
+        return ['Vapen','Sköld','Pil/Lod','Rustning','Artefakt','Lägre Artefakt'].some(t => tag.includes(t));
       });
- if (!elig.length) { await alertPopup('Ingen lämplig utrustning att förbättra.'); return; }
- invUtil.openQualPopup(elig, iIdx => {
-        elig[iIdx].kvaliteter = elig[iIdx].kvaliteter||[];
+      if (!elig.length) { await alertPopup('Ingen lämplig utrustning att förbättra.'); return; }
+      invUtil.openQualPopup(elig, iIdx => {
+        const row   = elig[iIdx];
+        const entry = invUtil.getEntry(row.id || row.name);
+        if (window.canApplyQuality && !canApplyQuality(entry, p)) return;
+        row.kvaliteter = row.kvaliteter || [];
         const qn = p.namn;
-        if (!elig[iIdx].kvaliteter.includes(qn)) elig[iIdx].kvaliteter.push(qn);
+        if (!row.kvaliteter.includes(qn)) row.kvaliteter.push(qn);
         invUtil.saveInventory(inv); invUtil.renderInventory();
         activeTags();
         renderList(filtered());

--- a/js/utils.js
+++ b/js/utils.js
@@ -143,13 +143,17 @@
     const toShield  = qTypes.includes('Sköldkvalitet');
     const toArmor   = qTypes.includes('Rustningskvalitet');
 
-    // Allmän kvalitet: inga begränsningar
-    if (isGeneral) return true;
+    const QUAL_ITEM_TYPES = ['Vapen','Sköld','Pil/Lod','Rustning','Artefakt','Lägre Artefakt'];
+
+    // Allmän kvalitet: endast för föremål som kan ha kvaliteter
+    if (isGeneral) {
+      return QUAL_ITEM_TYPES.some(t => itTypes.includes(t));
+    }
 
     // Om inga nya typer finns på kvaliteten: falla tillbaka till gamla beteendet
     // (kvaliteter gällde generellt för vapen/sköld/rustning)
     if (!toWeapon && !toShield && !toArmor) {
-      return ['Vapen','Sköld','Rustning'].some(t => itTypes.includes(t));
+      return QUAL_ITEM_TYPES.some(t => itTypes.includes(t));
     }
 
     if (toWeapon && itTypes.includes('Vapen')) return true;


### PR DESCRIPTION
## Summary
- Restrict "Allmän kvalitet" to items that support qualities, including weapons, shields, armor, ammunition, and artifacts
- Filter inventory items through `canApplyQuality` when adding a quality from index view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c40fd889f48323964167c3aeca7fbe