### PR TITLE
Remove free markers in quality picker and restrict artifact quality types

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -284,8 +284,6 @@
     box.innerHTML = items.map(({item, idx}) => {
       const base  = item.namn || item.name;
       const label = nameMap.get(item) || base;
-      const gCnt  = Number(item.gratis || 0);
-      const mark  = gCnt ? ` 🆓${gCnt>1?`×${gCnt}`:''}` : '';
       let cls = 'char-btn';
       if (qualMode) {
         cls += ' quality';
@@ -293,7 +291,8 @@
         else if (isNeutralQual(base)) cls += ' neutral';
         if (isMysticQual(base)) cls += ' mystic';
       }
-      return `<button data-i="${idx}" class="${cls}">${label}${mark}</button>`;
+      // Don't show free marker in quality selection
+      return `<button data-i="${idx}" class="${cls}">${label}</button>`;
     }).join('');
 
     /* öppna */

--- a/js/utils.js
+++ b/js/utils.js
@@ -145,20 +145,30 @@
 
     const QUAL_ITEM_TYPES = ['Vapen','Sköld','Pil/Lod','Rustning','Artefakt','Lägre Artefakt'];
 
+    const isArtifact = itTypes.includes('Artefakt') || itTypes.includes('Lägre Artefakt');
+    const isWeapon   = itTypes.includes('Vapen');
+    const isShield   = itTypes.includes('Sköld');
+    const isArmor    = itTypes.includes('Rustning');
+    const isAmmo     = itTypes.includes('Pil/Lod');
+    const artifactOnly = isArtifact && !isWeapon && !isShield && !isArmor && !isAmmo;
+
     // Allmän kvalitet: endast för föremål som kan ha kvaliteter
     if (isGeneral) {
       return QUAL_ITEM_TYPES.some(t => itTypes.includes(t));
     }
 
+    // Artefakter utan andra typer får inga andra kvaliteter
+    if (artifactOnly) return false;
+
     // Om inga nya typer finns på kvaliteten: falla tillbaka till gamla beteendet
     // (kvaliteter gällde generellt för vapen/sköld/rustning)
     if (!toWeapon && !toShield && !toArmor) {
-      return QUAL_ITEM_TYPES.some(t => itTypes.includes(t));
+      return isWeapon || isShield || isArmor || isAmmo;
     }
 
-    if (toWeapon && itTypes.includes('Vapen')) return true;
-    if (toShield && itTypes.includes('Sköld')) return true;
-    if (toArmor  && itTypes.includes('Rustning')) return true;
+    if (toWeapon && isWeapon) return true;
+    if (toShield && isShield) return true;
+    if (toArmor  && isArmor) return true;
     return false;
   }
   function isYrke(p){ return (p.taggar?.typ||[]).includes('Yrke'); }


### PR DESCRIPTION
## Summary
- Remove free icon from quality selection popup
- Prevent artifacts from receiving non-applicable quality types

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4134ea9d883239da6f093ac2c1ba8