### PR TITLE
Enable search-triggered toolbar actions

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -627,9 +627,9 @@ function initCharacter() {
     }
     const nq = searchNormalize(q.toLowerCase());
     const esc = v => v.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/"/g,'&quot;');
-    const seen = new Set();
     const MAX = 50;
-    const items = [];
+    const seen = new Set();
+    const entryItems = [];
     for (const p of filtered()) {
       const name = String(p.namn || '').trim();
       if (!name) continue;
@@ -637,19 +637,32 @@ function initCharacter() {
       if (!nname.includes(nq)) continue;
       if (seen.has(name)) continue;
       seen.add(name);
-      items.push(name);
-      if (items.length >= MAX) break;
+      entryItems.push(name);
+      if (entryItems.length >= MAX) break;
     }
-    if (!items.length) {
+    const cmdMatches = (window.SEARCH_ACTIONS || []).filter(cmd =>
+      cmd.terms.some(t => {
+        const nt = searchNormalize(t.toLowerCase());
+        return nt.includes(nq) || nq.includes(nt);
+      })
+    );
+    const allItems = [
+      ...cmdMatches.map(c => ({ type: 'action', id: c.id, label: c.label })),
+      ...entryItems.map(v => ({ type: 'entry', val: v }))
+    ];
+    if (!allItems.length) {
       sugEl.innerHTML = '';
       sugEl.hidden = true;
       sugIdx = -1;
       window.updateScrollLock?.();
       return;
     }
-    sugEl.innerHTML = items.map((v,i)=>{
-      const disp = v.charAt(0).toUpperCase() + v.slice(1);
-      return `<div class="item" data-idx="${i}" data-val="${esc(v)}">${disp}</div>`;
+    sugEl.innerHTML = allItems.map((obj,i)=>{
+      const disp = (obj.label || obj.val).charAt(0).toUpperCase() + (obj.label || obj.val).slice(1);
+      if (obj.type === 'action') {
+        return `<div class=\"item\" data-idx=\"${i}\" data-cmd=\"action\" data-action=\"${esc(obj.id)}\">${disp}</div>`;
+      }
+      return `<div class=\"item\" data-idx=\"${i}\" data-val=\"${esc(obj.val)}\">${disp}</div>`;
     }).join('');
     sugEl.hidden = false;
     sugIdx = -1;
@@ -683,6 +696,12 @@ function initCharacter() {
             const it = e.target.closest('.item');
             if (!it) return;
             e.preventDefault();
+            if (it.dataset.cmd === 'action') {
+              if (window.runSearchCommand) runSearchCommand(it.dataset.action, true);
+              dom.sIn.value=''; sTemp=''; updateSearchDatalist();
+              dom.sIn.blur();
+              return;
+            }
             const val = (it.dataset.val || '').trim();
             if (val) {
               const union = storeHelper.getFilterUnion(store);
@@ -734,6 +753,11 @@ function initCharacter() {
       const term = sTemp.toLowerCase();
         if (items.length && sugIdx >= 0) {
           const it = items[sugIdx];
+          if (it?.dataset?.cmd === 'action') {
+            if (window.runSearchCommand) runSearchCommand(it.dataset.action, true);
+            dom.sIn.value=''; sTemp=''; updateSearchDatalist();
+            return;
+          }
           const chosen = it?.dataset?.val || '';
           if (chosen) {
             dom.sIn.value = chosen; sTemp = chosen.trim();
@@ -767,6 +791,11 @@ function initCharacter() {
         return;
       }
       if (tryNilasPopup(sTemp)) {
+        dom.sIn.value=''; sTemp='';
+        updateSearchDatalist();
+        return;
+      }
+      if (window.runSearchCommand && runSearchCommand(sTemp)) {
         dom.sIn.value=''; sTemp='';
         updateSearchDatalist();
         return;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -8,6 +8,62 @@
 const FILTER_TOOLS_KEY = 'filterToolsOpen';
 const FILTER_SETTINGS_KEY = 'filterSettingsOpen';
 
+// Sökbara kommandon kopplade till knappar i verktygs- och inställningspanelerna
+const SEARCH_ACTIONS = [
+  // Inventarie: Verktyg
+  { id: 'addCustomBtn',   panel: 'invPanel',    label: 'Nytt föremål',          terms: ['nytt föremål','lägg till föremål','skapa föremål'] },
+  { id: 'manageMoneyBtn', panel: 'invPanel',    label: 'Hantera pengar',        terms: ['hantera pengar','pengar','pengahantering'] },
+  { id: 'multiPriceBtn',  panel: 'invPanel',    label: 'Multiplicera pris',     terms: ['multiplicera pris','prisfaktor','prisjustering'] },
+  { id: 'squareBtn',      panel: 'invPanel',    label: 'Lägg till antal',       terms: ['lägg till antal','antal','x²','x2'] },
+  { id: 'dragToggle',     panel: 'invPanel',    label: 'Dra & Släpp',           terms: ['dra & släpp','dra och släpp','drag and drop','dra och slapp'] },
+  { id: 'saveFreeBtn',    panel: 'invPanel',    label: 'Spara & gratismarkera', terms: ['spara & gratismarkera','gratismarkera','spara gratis'] },
+  { id: 'clearInvBtn',    panel: 'invPanel',    label: 'Rensa inventarie',      terms: ['rensa inventarie','töm inventarie','radera inventarie'] },
+
+  // Filterpanel: Verktyg
+  { id: 'newCharBtn',     panel: 'filterPanel', label: 'Ny rollperson',         terms: ['ny rollperson','ny karaktär','skapa rollperson'] },
+  { id: 'duplicateChar',  panel: 'filterPanel', label: 'Kopiera rollperson',    terms: ['kopiera rollperson','kopiera karaktär','duplicera rollperson'] },
+  { id: 'renameChar',     panel: 'filterPanel', label: 'Byt namn',              terms: ['byt namn','byta namn','rename'] },
+  { id: 'manageFolders',  panel: 'filterPanel', label: 'Mapphantering',         terms: ['mapphantering','hantera mappar','mappar'] },
+  { id: 'exportChar',     panel: 'filterPanel', label: 'Exportera',             terms: ['exportera','exportera rollperson','export'] },
+  { id: 'importChar',     panel: 'filterPanel', label: 'Importera',             terms: ['importera','importera rollperson','import'] },
+  { id: 'pdfLibraryBtn',  panel: 'filterPanel', label: 'PDF-bank',              terms: ['pdf-bank','pdf bank','pdf'] },
+  { id: 'deleteChar',     panel: 'filterPanel', label: 'Radera rollperson',     terms: ['radera rollperson','ta bort rollperson','radera karaktär'] },
+
+  // Filterpanel: Inställningar
+  { id: 'partySmith',     panel: 'filterPanel', label: 'Smed i partyt',         terms: ['smed i partyt','smed','party smed'] },
+  { id: 'partyAlchemist', panel: 'filterPanel', label: 'Alkemist i partyt',     terms: ['alkemist i partyt','alkemist','party alkemist'] },
+  { id: 'partyArtefacter',panel: 'filterPanel', label: 'Artefaktmakare i partyt', terms: ['artefaktmakare i partyt','artefaktmakare','party artefakt'] },
+  { id: 'filterUnion',    panel: 'filterPanel', label: 'Utvidgad sökning',      terms: ['utvidgad sökning','utvidgad','or-sökning'] },
+  { id: 'entryViewToggle',panel: 'filterPanel', label: 'Expandera vy',          terms: ['expandera vy','expandera','kompakt vy'] },
+  { id: 'forceDefense',   panel: 'filterPanel', label: 'Tvinga försvar',        terms: ['tvinga försvar','försvar','force defense'] }
+];
+
+window.SEARCH_ACTIONS = SEARCH_ACTIONS;
+window.runSearchCommand = function(termOrId, byId = false) {
+  const toolbar = document.querySelector('shared-toolbar');
+  if (!toolbar) return false;
+  let action = null;
+  if (byId) {
+    action = SEARCH_ACTIONS.find(a => a.id === termOrId);
+  } else {
+    const nterm = searchNormalize(String(termOrId || '').toLowerCase());
+    action = SEARCH_ACTIONS.find(a =>
+      a.terms.some(t => {
+        const nt = searchNormalize(t.toLowerCase());
+        return nt === nterm || nt.startsWith(nterm) || nterm.startsWith(nt);
+      })
+    );
+  }
+  if (!action) return false;
+  if (action.panel) toolbar.open(action.panel);
+  const btn = toolbar.shadowRoot.getElementById(action.id);
+  if (btn) {
+    btn.click();
+    return true;
+  }
+  return false;
+};
+
 class SharedToolbar extends HTMLElement {
   constructor() {
     super();


### PR DESCRIPTION
## Summary
- add global mapping for inventory and filter tool buttons so search can trigger them
- extend search suggestions to include command buttons and run their actions
- support triggering toolbar settings toggles via search or suggestion

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4156c6288832381965950f60300e0