### PR TITLE
Prevent empty search from triggering toolbar actions

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -42,11 +42,14 @@ window.SEARCH_ACTIONS = SEARCH_ACTIONS;
 window.runSearchCommand = function(termOrId, byId = false) {
   const toolbar = document.querySelector('shared-toolbar');
   if (!toolbar) return false;
+
   let action = null;
   if (byId) {
     action = SEARCH_ACTIONS.find(a => a.id === termOrId);
   } else {
-    const nterm = searchNormalize(String(termOrId || '').toLowerCase());
+    const term = String(termOrId || '').trim();
+    if (!term) return false;
+    const nterm = searchNormalize(term.toLowerCase());
     action = SEARCH_ACTIONS.find(a =>
       a.terms.some(t => {
         const nt = searchNormalize(t.toLowerCase());
@@ -55,7 +58,7 @@ window.runSearchCommand = function(termOrId, byId = false) {
     );
   }
   if (!action) return false;
-  if (action.panel) toolbar.open(action.panel);
+  if (action.panel && typeof toolbar.open === 'function') toolbar.open(action.panel);
   const btn = toolbar.shadowRoot.getElementById(action.id);
   if (btn) {
     btn.click();


### PR DESCRIPTION
## Summary
- Guard against empty or whitespace-only search terms when matching toolbar commands
- Safely open panels only when the toolbar is initialized

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4173e28d88323884589f94df1be54