### PR TITLE
Remove free emoji from quality selector

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -284,8 +284,6 @@
     box.innerHTML = items.map(({item, idx}) => {
       const base  = item.namn || item.name;
       const label = nameMap.get(item) || base;
-      const gCnt  = Number(item.gratis || 0);
-      const mark  = gCnt ? ` 🆓${gCnt>1?`×${gCnt}`:''}` : '';
       let cls = 'char-btn';
       if (qualMode) {
         cls += ' quality';
@@ -293,7 +291,7 @@
         else if (isNeutralQual(base)) cls += ' neutral';
         if (isMysticQual(base)) cls += ' mystic';
       }
-      return `<button data-i="${idx}" class="${cls}">${label}${mark}</button>`;
+      return `<button data-i="${idx}" class="${cls}">${label}</button>`;
     }).join('');
 
     /* öppna */


### PR DESCRIPTION
## Summary
- stop showing the 🆓 emoji for gratis-tagged items in the "Välj kvalitet" popup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4214635e88323b8fa9a9c0dd07f8f