### PR TITLE
Enable clickable tags for filtering

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -84,6 +84,7 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
                padding: .15rem .7rem; border-radius: .55rem;
                font-size: .85rem; white-space: nowrap; }
 .tag.removable { cursor: pointer; }
+.filter-tag { cursor: pointer; }
 .tag.free,
 .tag.price-mult { background: var(--accent); color:#fff; }
 .tag.quality   { border: 1.5px solid var(--quality); }

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -539,16 +539,19 @@ function initCharacter() {
         let xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
         if (isElityrke(p)) xpText = `Minst ${eliteReq.minXP ? eliteReq.minXP(p, curList) : 50}`;
         const xpTag = `<span class="tag xp-cost">Erf: ${xpText}</span>`;
+        const typeTags = (p.taggar?.typ || []).map(t => `<span class="tag filter-tag" data-section="typ" data-val="${t}">${t}</span>`);
+        const arkTags = explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag filter-tag" data-section="ark" data-val="${t}">${t}</span>`);
+        const testTags = (p.taggar?.test || []).map(t => `<span class="tag filter-tag" data-section="test" data-val="${t}">${t}</span>`);
         const infoTagsHtml = [xpTag]
-          .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
-          .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
-          .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(typeTags)
+          .concat(arkTags)
+          .concat(testTags)
           .filter(Boolean)
           .join(' ');
         const tagsHtml = []
-          .concat((p.taggar?.typ || []).map(t => `<span class="tag">${t}</span>`))
-          .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
-          .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(typeTags)
+          .concat(arkTags)
+          .concat(testTags)
           .filter(Boolean)
           .join(' ');
         const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
@@ -820,6 +823,15 @@ function initCharacter() {
 
   /* ta bort & nivåbyte */
   dom.valda.addEventListener('click', async e=>{
+    const tag = e.target.closest('.filter-tag');
+    if (tag) {
+      const section = tag.dataset.section;
+      const val = tag.dataset.val;
+      if (!F[section].includes(val)) F[section].push(val);
+      if (section === 'typ') openCatsOnce.add(val);
+      activeTags(); renderSkills(filtered()); renderTraits();
+      return;
+    }
     const conflictBtn = e.target.closest('.conflict-btn');
       if(conflictBtn){
         const currentName = conflictBtn.dataset.name;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -520,17 +520,19 @@ function initIndex() {
         let xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
         if (isElityrke(p)) xpText = `Minst ${eliteReq.minXP ? eliteReq.minXP(p, charList) : 50}`;
         const xpTag = (xpVal != null || isElityrke(p)) ? `<span class="tag xp-cost">Erf: ${xpText}</span>` : '';
-        const typeTags = (p.taggar?.typ || []).map(t => `<span class="tag">${QUAL_TYPE_MAP[t] || t}</span>`);
+        const typeTags = (p.taggar?.typ || []).map(t => `<span class="tag filter-tag" data-section="typ" data-val="${t}">${QUAL_TYPE_MAP[t] || t}</span>`);
+        const arkTags = explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag filter-tag" data-section="ark" data-val="${t}">${t}</span>`);
+        const testTags = (p.taggar?.test || []).map(t => `<span class="tag filter-tag" data-section="test" data-val="${t}">${t}</span>`);
         const infoTagsHtml = [xpTag]
           .concat(typeTags)
-          .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
-          .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(arkTags)
+          .concat(testTags)
           .filter(Boolean)
           .join(' ');
         const tagsHtml = []
           .concat(typeTags)
-          .concat(explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag">${t}</span>`))
-          .concat((p.taggar?.test || []).map(t => `<span class="tag">${t}</span>`))
+          .concat(arkTags)
+          .concat(testTags)
           .filter(Boolean)
           .join(' ');
         const xpHtml = (xpVal != null || isElityrke(p)) ? `<span class="xp-cost">Erf: ${xpText}</span>` : '';
@@ -952,6 +954,15 @@ function initIndex() {
 
   /* lista-knappar */
   dom.lista.addEventListener('click', async e=>{
+    const tag = e.target.closest('.filter-tag');
+    if (tag) {
+      const section = tag.dataset.section;
+      const val = tag.dataset.val;
+      if (!F[section].includes(val)) F[section].push(val);
+      if (section === 'typ') openCatsOnce.add(val);
+      activeTags(); renderList(filtered());
+      return;
+    }
     // Special clear-filters action inside the Hoppsan category
     const clearBtn = e.target.closest('button[data-clear-filters]');
     if (clearBtn) {


### PR DESCRIPTION
## Summary
- Render tag spans with `filter-tag` class and section/value metadata
- Handle `.filter-tag` clicks to update filters in index and character views
- Style `.filter-tag` with pointer cursor for clickability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4216c239c83239e236dd045c41824