### PR TITLE
Handle unknown tag sections for filters

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -825,7 +825,9 @@ function initCharacter() {
   dom.valda.addEventListener('click', async e=>{
     const tag = e.target.closest('.filter-tag');
     if (tag) {
-      const section = tag.dataset.section;
+      const sectionMap = { ark_trad: 'ark', ark: 'ark', typ: 'typ', test: 'test' };
+      const section = sectionMap[tag.dataset.section];
+      if (!section) return;
       const val = tag.dataset.val;
       if (!F[section].includes(val)) F[section].push(val);
       if (section === 'typ') openCatsOnce.add(val);

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -956,7 +956,9 @@ function initIndex() {
   dom.lista.addEventListener('click', async e=>{
     const tag = e.target.closest('.filter-tag');
     if (tag) {
-      const section = tag.dataset.section;
+      const sectionMap = { ark_trad: 'ark', ark: 'ark', typ: 'typ', test: 'test' };
+      const section = sectionMap[tag.dataset.section];
+      if (!section) return;
       const val = tag.dataset.val;
       if (!F[section].includes(val)) F[section].push(val);
       if (section === 'typ') openCatsOnce.add(val);


### PR DESCRIPTION
## Summary
- Map tag section attributes to known filters so ark-trad, typ, and test tags trigger filtering correctly

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4232ea7848323b5b2f4fb88dea944