### PR TITLE
Ensure active filters wrap within container

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -79,7 +79,13 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 }
 
 .tags        { display: flex; flex-wrap: wrap; gap: .4rem; }
-#activeFilters { margin-bottom: 1rem; }
+#activeFilters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem;
+  width: 100%;
+  margin-bottom: 1rem;
+}
 .tag         { background: var(--border); color: var(--subtxt);
                padding: .15rem .7rem; border-radius: .55rem;
                font-size: .85rem; white-space: nowrap; }


### PR DESCRIPTION
## Summary
- Constrain active filter tags to the main view with flex wrapping and full width

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c565cf32b08323b7074e3418894631