### PR TITLE
Align search tags above main panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -84,7 +84,8 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   flex-wrap: wrap;
   gap: .4rem;
   width: 100%;
-  margin-bottom: 1rem;
+  max-width: 520px;
+  margin: 0 auto 1rem;
 }
 .tag         { background: var(--border); color: var(--subtxt);
                padding: .15rem .7rem; border-radius: .55rem;


### PR DESCRIPTION
## Summary
- Center the `activeFilters` tag container and limit its width to match the main panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c569fc7a008323b835b502ae439348