### PR TITLE
Ensure note textareas auto expand on mobile

### DIFF
--- a/js/auto-resize.js
+++ b/js/auto-resize.js
@@ -4,13 +4,11 @@
     el.style.height = 'auto';
     el.style.height = el.scrollHeight + 'px';
   }
-  window.addEventListener('input', e=>{
-    if(e.target.classList && e.target.classList.contains('auto-resize')){
-      autoResize(e.target);
-    }
-  });
   window.addEventListener('DOMContentLoaded', ()=>{
-    document.querySelectorAll('.auto-resize').forEach(autoResize);
+    document.querySelectorAll('.auto-resize').forEach(el => {
+      el.addEventListener('input', () => autoResize(el));
+      autoResize(el);
+    });
   });
   window.autoResize = autoResize;
 })(window);


### PR DESCRIPTION
## Summary
- Fix note field auto-resize to register input handlers directly on textareas so they expand while typing on mobile.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b71aab748323844f59e2c4a4c955