### PR TITLE
Add Traditionslös archetype filter

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -390,7 +390,12 @@ function initCharacter() {
       (p.taggar.typ||[])
         .filter(Boolean)
         .forEach(v=>sets.typ.add(v));
-      explodeTags(p.taggar.ark_trad).forEach(v=>sets.ark.add(v));
+      const arkTags = explodeTags(p.taggar.ark_trad);
+      if (arkTags.length) {
+        arkTags.forEach(v => sets.ark.add(v));
+      } else if (Array.isArray(p.taggar?.ark_trad)) {
+        sets.ark.add('Traditionslös');
+      }
       (p.taggar.test||[])
         .filter(Boolean)
         .forEach(v=>sets.test.add(v));
@@ -433,10 +438,11 @@ function initCharacter() {
         const tags = p.taggar || {};
         const selTags = [...F.typ, ...F.ark, ...F.test];
         const hasTags = selTags.length > 0;
+        const arkTags = explodeTags(tags.ark_trad);
         const itmTags = [
-          ...(tags.typ      ?? []),
-          ...explodeTags(tags.ark_trad),
-          ...(tags.test     ?? [])
+          ...(tags.typ ?? []),
+          ...(arkTags.length ? arkTags : (Array.isArray(tags.ark_trad) ? ['Traditionslös'] : [])),
+          ...(tags.test ?? [])
         ];
         const tagOk = !hasTags || (
           union ? selTags.some(t => itmTags.includes(t))
@@ -540,7 +546,9 @@ function initCharacter() {
         if (isElityrke(p)) xpText = `Minst ${eliteReq.minXP ? eliteReq.minXP(p, curList) : 50}`;
         const xpTag = `<span class="tag xp-cost">Erf: ${xpText}</span>`;
         const typeTags = (p.taggar?.typ || []).map(t => `<span class="tag filter-tag" data-section="typ" data-val="${t}">${t}</span>`);
-        const arkTags = explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag filter-tag" data-section="ark" data-val="${t}">${t}</span>`);
+        const trTags = explodeTags(p.taggar?.ark_trad);
+        const arkTags = (trTags.length ? trTags : (Array.isArray(p.taggar?.ark_trad) ? ['Traditionslös'] : []))
+          .map(t => `<span class="tag filter-tag" data-section="ark" data-val="${t}">${t}</span>`);
         const testTags = (p.taggar?.test || []).map(t => `<span class="tag filter-tag" data-section="test" data-val="${t}">${t}</span>`);
         const infoTagsHtml = [xpTag]
           .concat(typeTags)

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -181,7 +181,12 @@ function initIndex() {
       (p.taggar.typ||[])
         .filter(Boolean)
         .forEach(v=>set.typ.add(v));
-      explodeTags(p.taggar.ark_trad).forEach(v=>set.ark.add(v));
+      const arkTags = explodeTags(p.taggar.ark_trad);
+      if (arkTags.length) {
+        arkTags.forEach(v => set.ark.add(v));
+      } else if (Array.isArray(p.taggar?.ark_trad)) {
+        set.ark.add('Traditionslös');
+      }
       (p.taggar.test||[])
         .filter(Boolean)
         .forEach(v=>set.test.add(v));
@@ -354,10 +359,11 @@ function initIndex() {
       const tags = p.taggar || {};
       const selTags = [...F.typ, ...F.ark, ...F.test];
       const hasTags = selTags.length > 0;
+      const arkTags = explodeTags(tags.ark_trad);
       const itmTags = [
-        ...(tags.typ      ?? []),
-        ...explodeTags(tags.ark_trad),
-        ...(tags.test     ?? [])
+        ...(tags.typ ?? []),
+        ...(arkTags.length ? arkTags : (Array.isArray(tags.ark_trad) ? ['Traditionslös'] : [])),
+        ...(tags.test ?? [])
       ];
       const tagHit = hasTags && (
         union ? selTags.some(t => itmTags.includes(t))
@@ -537,7 +543,9 @@ function initIndex() {
         if (isElityrke(p)) xpText = `Minst ${eliteReq.minXP ? eliteReq.minXP(p, charList) : 50}`;
         const xpTag = (xpVal != null || isElityrke(p)) ? `<span class="tag xp-cost">Erf: ${xpText}</span>` : '';
         const typeTags = (p.taggar?.typ || []).map(t => `<span class="tag filter-tag" data-section="typ" data-val="${t}">${QUAL_TYPE_MAP[t] || t}</span>`);
-        const arkTags = explodeTags(p.taggar?.ark_trad).map(t => `<span class="tag filter-tag" data-section="ark" data-val="${t}">${t}</span>`);
+        const trTags = explodeTags(p.taggar?.ark_trad);
+        const arkTags = (trTags.length ? trTags : (Array.isArray(p.taggar?.ark_trad) ? ['Traditionslös'] : []))
+          .map(t => `<span class="tag filter-tag" data-section="ark" data-val="${t}">${t}</span>`);
         const testTags = (p.taggar?.test || []).map(t => `<span class="tag filter-tag" data-section="test" data-val="${t}">${t}</span>`);
         const infoTagsHtml = [xpTag]
           .concat(typeTags)

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -1246,8 +1246,9 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     if (!isArtifact || isLArtifact) {
       desc += abilityHtml(entry, rowLevel);
     }
+    const arkTags = explodeTags(tagger.ark_trad);
     const tagList = (tagger.typ || [])
-      .concat(explodeTags(tagger.ark_trad), tagger.test || [])
+      .concat(arkTags.length ? arkTags : (Array.isArray(tagger.ark_trad) ? ['Traditionslös'] : []), tagger.test || [])
       .map(t => `<span class="tag">${t}</span>`);
     if (rowLevel) tagList.push(`<span class="tag level">${rowLevel}</span>`);
     if (freeCnt) tagList.push(`<span class="tag free removable" data-free="1">Gratis${freeCnt>1?`×${freeCnt}`:''} ✕</span>`);


### PR DESCRIPTION
## Summary
- handle entries without tradition as `Traditionslös`
- support `Traditionslös` option in archetype filters and tag rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c8275f9ce88323abbf31f3e940c546