### PR TITLE
Fix lower artifact requirement for elite professions

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1104,7 +1104,7 @@ function initIndex() {
               const itemLevel = LEVEL_IDX[lvlName] || 0;
               let hasYrke = reqYrken.some(req =>
                 list.some(it =>
-                  isYrke(it) && explodeTags([it.namn]).includes(req)
+                  (isYrke(it) || isElityrke(it)) && explodeTags([it.namn]).includes(req)
                 )
               );
               if (!hasYrke && artLevel >= itemLevel) {


### PR DESCRIPTION
## Summary
- allow lower artefact access checks to consider both regular and elite professions
- keep the fallback pricing warning when the required archetype or tradition is still missing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c920363e6c8323afff21a83b437ce9