### PR TITLE
Ensure artifacts category includes all tagged items

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -207,7 +207,7 @@ function initCharacter() {
 
     const cats = {};
     list.forEach(p=>{
-      const cat = p.taggar?.typ?.[0] || 'Övrigt';
+      const cat = entryCategory(p);
       (cats[cat] ||= []).push(p);
     });
 
@@ -480,7 +480,7 @@ function initCharacter() {
     const searchActive = terms.length > 0;
     const catNameMatch = {};
     groups.forEach(g=>{
-      const cat = g.entry.taggar?.typ?.[0] || 'Övrigt';
+      const cat = entryCategory(g.entry);
       (cats[cat] ||= []).push(g);
       if (searchActive) {
         const name = searchNormalize((g.entry.namn || '').toLowerCase());
@@ -724,7 +724,7 @@ function initCharacter() {
               }
               const nval = searchNormalize(val.toLowerCase());
               const match = storeHelper.getCurrentList(store).find(p => !isInv(p) && searchNormalize(String(p.namn || '').toLowerCase()) === nval);
-              const cat = match?.taggar?.typ?.[0];
+              const cat = match ? entryCategory(match) : '';
               if (cat) openCatsOnce.add(cat);
               if (window.storeHelper?.addRecentSearch) {
                 storeHelper.addRecentSearch(store, val);
@@ -806,7 +806,7 @@ function initCharacter() {
         }
         const nval = searchNormalize(sTemp.toLowerCase());
         const match = storeHelper.getCurrentList(store).find(p => !isInv(p) && searchNormalize(String(p.namn || '').toLowerCase()) === nval);
-        const cat = match?.taggar?.typ?.[0];
+        const cat = match ? entryCategory(match) : '';
         if (cat) openCatsOnce.add(cat);
       } else {
         F.search = [];

--- a/js/utils.js
+++ b/js/utils.js
@@ -109,6 +109,15 @@
     return CAT_DISPLAY[cat] || cat;
   }
 
+  function entryCategory(entry) {
+    const types = Array.isArray(entry?.taggar?.typ)
+      ? entry.taggar.typ.map(t => String(t).trim()).filter(Boolean)
+      : [];
+    const hasArtefakt = types.some(t => t.toLowerCase() === 'artefakt');
+    if (hasArtefakt) return 'Artefakt';
+    return types[0] || 'Övrigt';
+  }
+
   function catComparator(a, b){
     const ai = CAT_ORDER.indexOf(a);
     const bi = CAT_ORDER.indexOf(b);
@@ -370,4 +379,5 @@
   window.copyToClipboard = copyToClipboard;
   window.catComparator = catComparator;
   window.catName = catName;
+  window.entryCategory = entryCategory;
 })(window);


### PR DESCRIPTION
## Summary
- add a shared `entryCategory` helper that maps any entry tagged with Artefakt to the Artefakt category
- update the character view to use the helper for grouping, conflicts and search so Artefakt-tagged items always appear under Artefakter

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca785593f88323aa2edd289a7a3e98