### PR TITLE
Ensure character view groups artefact-tagged entries

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -200,8 +200,11 @@ function initCharacter() {
   }
 
   const charCategory = (entry, { allowFallback = true } = {}) => {
-    const types = entry?.taggar?.typ || [];
-    if (types.includes('Artefakt')) return 'Artefakt';
+    const types = Array.isArray(entry?.taggar?.typ)
+      ? entry.taggar.typ
+      : [];
+    const hasArtifact = types.some(t => String(t).trim().toLowerCase() === 'artefakt');
+    if (hasArtifact) return 'Artefakt';
     if (types.length) return types[0];
     return allowFallback ? 'Övrigt' : undefined;
   };


### PR DESCRIPTION
## Summary
- ensure the character view categorizes entries with the Artefakt tag under Artefakter even when it is not their primary type
- perform case-insensitive matching so custom entries with trimmed variations still map correctly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca7d2dec0083239a1202f4c50dc0f0