### PR TITLE
Allow scrolling in custom item popup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1184,9 +1184,14 @@ select.level {
   padding: 1.5rem 1.4rem 2rem;
   width: 100%;
   max-width: 420px;
+  max-height: calc(100vh - 2rem);
+  max-height: calc(100dvh - 2rem);
   text-align: center;
   transform: translateY(100%);
   transition: transform .25s ease;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   display: flex;
   flex-direction: column;
   gap: .8rem;


### PR DESCRIPTION
## Summary
- keep the custom item popup within the viewport by capping its height and enabling scrolling
- contain overscroll to the popup for smoother touch behaviour

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ca7e1434fc8323be7a7c0f0ac7beed