### PR TITLE
Fix mobile wrapping for character tags

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -975,6 +975,17 @@ input:focus, select:focus, textarea:focus {
   align-content: flex-start;
 }
 
+#valda .inv-controls-left {
+  flex-direction: column;
+  align-items: flex-start;
+  align-content: flex-start;
+  gap: .3rem;
+}
+#valda .inv-controls-left .entry-tags {
+  align-items: flex-start;
+  align-content: flex-start;
+}
+
 .entry-tags {
   --entry-tag-row: 1.35rem;
   display: flex;


### PR DESCRIPTION
## Summary
- Justerade layouten för `#valda`-kontrollerna så att taggarna radbryts på samma sätt som i rollpersonvyn på mobil.

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd54d674a08323b432f58685ef88ef