### PR TITLE
Replace toolbar emojis with PNG icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sidan fungerar helt offline och sparar all data i din webbläsares lagring.
 ## Funktioner
 - Hantera flera rollpersoner med erfarenhetspoäng, inventarie och specialförmågor.
 - Filtrera listor på taggar och sökord.
-- Paneler för inventarie (`🎒`), egenskaper (`📊`) och anteckningar (`📜`).
+- Paneler för inventarie, egenskaper och anteckningar – öppnas via verktygsradens knappar.
 - Export och import av rollpersoner via JSON-filer.
 - All information lagras i webbläsarens `localStorage`, vilket gör att dina val finns kvar mellan besök.
 
@@ -52,14 +52,14 @@ Både index- och rollpersons-vyn använder samma verktygsrad. Pilen med symbolen
 Verktygsraden innehåller:
 - Ett sökfält. Skriv ett ord och tryck Enter för att lägga till det som filter.
 - `XP:` visar hur mycket erfarenhet du har använt. Detta uppdateras automatiskt.
-- `🎒` öppnar inventariet.
-- `📊` öppnar egenskapspanelen.
+- Inventarieknappen öppnar inventariet.
+- Egenskapsknappen öppnar egenskapspanelen.
 - `📜` öppnar anteckningspanelen.
 - Skriv `lol` i sökfältet och tryck Enter för att rensa alla filter.
-- `⚙️` öppnar filtermenyn där du bland annat skapar och hanterar rollpersoner.
+- Filterknappen öppnar filtermenyn där du bland annat skapar och hanterar rollpersoner.
 
 ### 4. Filtermenyn
-I panelen som öppnas med `⚙️` finns flera viktiga knappar:
+I filterpanelen finns flera viktiga knappar:
 - **Ny rollperson** skapar en tom karaktär och gör den aktiv.
 - **Ta bort rollperson** raderar den aktuella karaktären.
 - **Export** öppnar en meny där du kan ladda ner alla rollpersoner eller välja en specifik att exportera som JSON-fil.
@@ -67,16 +67,16 @@ I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 - **⚒️**, **⚗️** och **🏺** anger nivå på smed, alkemist och artefaktmakare i ditt sällskap. Dessa nivåer används för att räkna ut rabatter på priser.
 - **🔭** gör att flera filter kombineras med OR i stället för AND, vilket ger en bredare sökning.
 - **↕️ Expandera vy** växlar till vanliga vyn.
-- **ℹ️** visar en snabböversikt av alla knappar.
+- **Hjälp** visar en snabböversikt av alla knappar.
 
 ### 5. Inventariepanelen
-Via `🎒` kommer du åt allt du har samlat på dig.
+Via inventarieknappen kommer du åt allt du har samlat på dig.
 - **Kategori** låter dig filtrera inventarielistan på typ av utrustning.
 - Under **Verktyg** hittar du knappar för **🆕**, **💰**, **🧹** och **x²** för att lägga till flera av samma föremål. Om föremålet inte kan staplas skapas nya fält.
 I listan för varje föremål finns knappar för att öka/minska antal, markera som gratis, redigera kvaliteter och mer.
 
 ### 6. Egenskapspanelen
-`📊` visar en summering av karaktärens förmågor och särdrag.
+Egenskapsknappen visar en summering av karaktärens förmågor och särdrag.
 - Här fyller du i totala erfarenhetspoäng.
 - Panelen räknar ut använd XP, kostnader från artefakter samt eventuell korruption.
 - Du kan även se en lista över uppnådda totala poäng i olika kategorier.
@@ -104,7 +104,7 @@ Se avsnittet ovan. Export öppnar en meny där du kan spara alla karaktärer som
 ### 10. Tips och tricks
 - Alla dina val sparas automatiskt i webblagringen på datorn.
 - Klicka på taggar i en lista för att snabbt filtrera på samma typ eller arketyp.
-- Hjälpmenyn (ℹ️) innehåller en sammanfattning av alla knappar om du behöver snabb hjälp.
+- Hjälpmenyn innehåller en sammanfattning av alla knappar om du behöver snabb hjälp.
 
 ## Utveckling och bidrag
 Projektet består av statisk HTML, CSS och JavaScript utan byggsteg. Ändringar i `data/` och `js/` reflekteras direkt i webbläsaren. Förslag, felrapporter och förbättringar tas emot via pull requests.

--- a/css/style.css
+++ b/css/style.css
@@ -143,9 +143,37 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   transition: transform .1s ease, opacity .1s ease;
 }
 .char-btn.danger { background: var(--danger); }
-.char-btn.icon   { font-size: 1.1rem; }
+.char-btn.icon   { font-size: 1.1rem; gap: .35rem; }
 .char-btn:hover  { opacity: .85; }
 .char-btn:active { transform: scale(.95); opacity: .7; }
+
+.btn-icon {
+  width: 1.45rem;
+  height: 1.45rem;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+  display: inline-block;
+  flex-shrink: 0;
+}
+
+.card .inv-controls .char-btn .btn-icon {
+  width: calc(var(--ctrl-btn-size) * .58);
+  height: calc(var(--ctrl-btn-size) * .58);
+}
+
+.char-btn.traits-btn { background: #2a3c36; }
+.char-btn.inv-btn    { background: #2c3028; }
+.char-btn.filter-btn { background: #314438; }
+.char-btn.info-btn,
+.party-toggle.info-btn { background: #2d433b; }
+.char-btn.character-btn { background: #3a4c38; }
+
+.icon-egenskaper { background-image: url('../icons/egenskaper.png'); }
+.icon-inventarie { background-image: url('../icons/inventarie.png'); }
+.icon-filter     { background-image: url('../icons/filter.png'); }
+.icon-info       { background-image: url('../icons/info.png'); }
+.icon-character  { background-image: url('../icons/character.png'); }
 
 /* Kvadratiska kortkontroller (exkl. "Börja om?") */
 .card .inv-controls .char-btn:not([data-clear-filters]) {
@@ -1090,7 +1118,7 @@ input:focus, select:focus, textarea:focus {
 
 /* Badge för inventarie­knapp */
 #invBadge { background: var(--danger); border-radius: 50%;
-            padding: 0 .45rem; font-size: .75rem; margin-left: .25rem; }
+            padding: 0 .45rem; font-size: .75rem; margin-left: 0; }
 
 /* animation when inventory items change */
 .inv-flash { animation: invFlash .6s ease-out; }

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1179,7 +1179,7 @@ function initCharacter() {
           bodyHtml: infoBodyHtml,
           meta: infoMeta
         });
-        const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
+        const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info"><span class="btn-icon icon-info" aria-hidden="true"></span></button>`;
 
         const multi = (p.kan_införskaffas_flera_gånger && typesList.some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
         const total = storeHelper.getCurrentList(store).filter(x=>x.namn===p.namn && !x.trait).length;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -470,7 +470,7 @@ function initIndex() {
       cats[cat].forEach(p=>{
         if (p.kolumner && p.rader) {
           const infoHtml = tabellInfoHtml(p);
-          const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info">ℹ️</button>`;
+          const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info"><span class="btn-icon icon-info" aria-hidden="true"></span></button>`;
           const tagsHtml = (p.taggar?.typ || [])
             .map(t => `<span class="tag">${t}</span>`)
             .join(' ');
@@ -646,7 +646,7 @@ function initIndex() {
           bodyHtml: infoBodyHtml,
           meta: infoMeta
         });
-        const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
+        const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info"><span class="btn-icon icon-info" aria-hidden="true"></span></button>`;
         const multi = isInv(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         let count;
         if (isInv(p)) {

--- a/js/main.js
+++ b/js/main.js
@@ -272,11 +272,11 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
   // Katalog med UI-kommandon: id, visningsnamn, panel och CSS-selector
   const UI_CMDS = [
     // Toppknappar
-    { id: 'open-inventory',  label: 'Inventarie',   sel: '#invToggle',    panel: 'invPanel',    emoji: '🎒',
+    { id: 'open-inventory',  label: 'Inventarie',   sel: '#invToggle',    panel: 'invPanel',    emoji: '',
       syn: ['inventarie','inventory','ryggsäck','ryggsack','rygga','inv'] },
-    { id: 'open-traits',     label: 'Egenskaper',   sel: '#traitsToggle', panel: 'traitsPanel', emoji: '📊',
+    { id: 'open-traits',     label: 'Egenskaper',   sel: '#traitsToggle', panel: 'traitsPanel', emoji: '',
       syn: ['egenskaper','traits','drag','karaktärsdrag','karaktarsdrag'] },
-    { id: 'open-filter',     label: 'Filter',       sel: '#filterToggle', panel: 'filterPanel', emoji: '⚙️',
+    { id: 'open-filter',     label: 'Filter',       sel: '#filterToggle', panel: 'filterPanel', emoji: '',
       syn: ['filter','verktyg'] },
     // Huvudvyns knappar utanför toolbaren (rollpersonssidan)
     { id: 'open-notes',      label: 'Anteckningar', sel: '#notesLink',    panel: null,          emoji: '📜',
@@ -293,7 +293,7 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
     { id: 'settings-union',   label: 'Utvidgad sökning',     sel: '#filterUnion',     panel: 'filterPanel', emoji: '🔭', syn: ['utvidga sökning','or-sökning','union','OR'] },
     { id: 'settings-expand',  label: 'Expandera vy',         sel: '#entryViewToggle', panel: 'filterPanel', emoji: '↕️', syn: ['expandera vy','vy','detaljer','expand'] },
     { id: 'settings-defense', label: 'Tvinga försvar',       sel: '#forceDefense',    panel: 'filterPanel', emoji: '🏃', syn: ['försvar','tvinga försvar','försvarskaraktärsdrag'] },
-    { id: 'settings-help',    label: 'Hjälp',                sel: '#infoToggle',      panel: 'filterPanel', emoji: 'ℹ️',
+    { id: 'settings-help',    label: 'Hjälp',                sel: '#infoToggle',      panel: 'filterPanel', emoji: '',
       syn: ['hjälp','info','information','behöver du hjälp','behover du hjalp'] },
 
     // Inventarie → Verktyg 🧰

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -150,7 +150,7 @@ class SharedToolbar extends HTMLElement {
           border-radius: 50%;
           padding: 0 .45rem;
           font-size: .75rem;
-          margin-left: .25rem;
+          margin-left: 0;
         }
         .toolbar .exp-counter {
           display: flex;
@@ -224,12 +224,17 @@ class SharedToolbar extends HTMLElement {
           <span class="exp-counter">XP: <span id="xpOut">0</span></span>
         </div>
         <div class="button-row">
-          <button  id="traitsToggle" class="char-btn icon" title="Egenskaper">📊</button>
-          <button  id="invToggle"    class="char-btn icon" title="Inventarie">
-            🎒 <span id="invBadge">0</span>
+          <button id="traitsToggle" class="char-btn icon traits-btn" title="Egenskaper" aria-label="Egenskaper">
+            <span class="btn-icon icon-egenskaper" aria-hidden="true"></span>
           </button>
-          <a       id="switchRole" class="char-btn icon" title="Byt vy">🔄</a>
-          <button  id="filterToggle" class="char-btn icon" title="Filter">⚙️</button>
+          <button id="invToggle" class="char-btn icon inv-btn" title="Inventarie" aria-label="Inventarie">
+            <span class="btn-icon icon-inventarie" aria-hidden="true"></span>
+            <span id="invBadge">0</span>
+          </button>
+          <a id="switchRole" class="char-btn icon" title="Byt vy">🔄</a>
+          <button id="filterToggle" class="char-btn icon filter-btn" title="Filter" aria-label="Filter">
+            <span class="btn-icon icon-filter" aria-hidden="true"></span>
+          </button>
         </div>
       </footer>
 
@@ -420,7 +425,9 @@ class SharedToolbar extends HTMLElement {
                   <span class="toggle-desc">
                     <span class="toggle-question">Behöver du hjälp?</span>
                   </span>
-                  <button id="infoToggle" class="party-toggle" title="Visa hjälp">ℹ️</button>
+                  <button id="infoToggle" class="party-toggle info-btn" title="Visa hjälp" aria-label="Visa hjälp">
+                    <span class="btn-icon icon-info" aria-hidden="true"></span>
+                  </button>
                 </li>
               </ul>
             </div>
@@ -920,7 +927,7 @@ class SharedToolbar extends HTMLElement {
             <ul class="summary-list">
               <li>Sök i fältet ovan och tryck Enter för att filtrera.</li>
               <li>Klicka på en post för detaljer. Lägg till med "Lägg till" eller "+".</li>
-              <li>Öppna panelerna längst ned: 📊 Egenskaper, 🎒 Inventarie, ⚙️ Filter.</li>
+              <li>Öppna panelerna längst ned via knapparna för Egenskaper, Inventarie och Filter.</li>
             </ul>
           </section>
 
@@ -930,7 +937,7 @@ class SharedToolbar extends HTMLElement {
               <li>▼: Minimerar/expanderar alla kategorier i listor.</li>
               <li>🧝 / 📇: Växlar mellan rollperson och index (ikonen ändras per sida).</li>
               <li>📜: Öppnar anteckningssidan (i rollpersonens sidhuvud).</li>
-              <li>🎒: Öppnar inventariepanelen. 📊: Öppnar egenskapspanelen. ⚙️: Öppnar filter.</li>
+              <li>Knapparna för Egenskaper, Inventarie och Filter öppnar respektive panel.</li>
               <li>XP: Visar dina totala erfarenhetspoäng.</li>
               <li>Sök: Skriv och tryck Enter för att lägga till ett filter. Klicka på taggarna under sökfältet för att ta bort filter.</li>
               <li>Förslag: Använd ↑/↓ för att bläddra, klicka för att lägga till.</li>
@@ -959,7 +966,7 @@ class SharedToolbar extends HTMLElement {
               <li>🔭 Utvidga sökning: Växla till OR-filter (matcha någon tag).</li>
               <li>↕️ Expandera vy: Visar fler detaljer i kort (alla utom Ras, Yrken och Elityrken).</li>
               <li>🏃 Försvar: Välj försvarskaraktärsdrag manuellt.</li>
-              <li>ℹ️ Hjälp: Visar denna panel.</li>
+              <li>Hjälpknappen visar denna panel.</li>
             </ul>
           </section>
 

--- a/notes.html
+++ b/notes.html
@@ -40,7 +40,9 @@
     <div class="panel-header">
       <h2 id="charName" style="margin:0;"></h2>
       <div class="header-actions">
-        <a href="character.html" id="charLink" class="char-btn icon" title="Till rollperson">🧝</a>
+        <a href="character.html" id="charLink" class="char-btn icon character-btn" title="Till rollperson" aria-label="Till rollperson">
+          <span class="btn-icon icon-character" aria-hidden="true"></span>
+        </a>
         <button id="editBtn" class="char-btn icon" title="Redigera">✏️</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- swap the toolbar and notes header buttons to use the new PNG icons and matching background colors
- restyle info buttons in the index and character views to reuse the new icon component
- refresh help copy and documentation to describe the renamed buttons

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cea9c4507083238a63ddd1bed03f4a