### PR TITLE
Replace button emojis with new icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 - **Ta bort rollperson** raderar den aktuella karaktären.
 - **Export** öppnar en meny där du kan ladda ner alla rollpersoner eller välja en specifik att exportera som JSON-fil.
 - **Import** återställer en eller flera karaktärer från sparade filer.
-- **⚒️**, **⚗️** och **🏺** anger nivå på smed, alkemist och artefaktmakare i ditt sällskap. Dessa nivåer används för att räkna ut rabatter på priser.
+- **<img src="icons/smithing.png" alt="Smed" width="18">**, **⚗️** och **🏺** anger nivå på smed, alkemist och artefaktmakare i ditt sällskap. Dessa nivåer används för att räkna ut rabatter på priser.
 - **🔭** gör att flera filter kombineras med OR i stället för AND, vilket ger en bredare sökning.
 - **↕️ Expandera vy** växlar till vanliga vyn.
-- **ℹ️** visar en snabböversikt av alla knappar.
+- **<img src="icons/info.png" alt="Info" width="16">** visar en snabböversikt av alla knappar.
 
 ### 5. Inventariepanelen
 Via `🎒` kommer du åt allt du har samlat på dig.
@@ -86,14 +86,14 @@ I listan för varje föremål finns knappar för att öka/minska antal, markera 
 
 ### 8. Arbeta med listorna
 Både i index-vyn och i din karaktär visas poster som kort.
-- **Lägg till** eller `+` lägger till posten.
-- `−` tar bort en instans av posten eller hela raden om det bara finns en.
-- **Info** visar beskrivning och eventuella regler.
+- **Lägg till** eller <img src="icons/plus.png" alt="Lägg till" width="16"> lägger till posten.
+- <img src="icons/minus.png" alt="Minska" width="16"> tar bort en instans av posten eller hela raden om det bara finns en.
+- **Info** (<img src="icons/info.png" alt="Info" width="16">) visar beskrivning och eventuella regler.
 - **🔨** låter dig välja en extra kvalitet till ett vapen, rustning eller en artefakt.
 - **☭** markerar en av kvaliteterna som gratis.
 - **🆓** gör hela föremålet gratis vid beräkning av totalkostnad.
 - **↔** finns på artefakter och växlar dess effekt mellan att ge 1 XP eller permanent korruption.
-- **🗑** tar bort posten helt.
+- **<img src="icons/remove.png" alt="Ta bort" width="16">** tar bort posten helt.
 - Monstruösa särdrag som blir gratis via Hamnskifte eller Blodvadare ger ett val mellan Humanoid eller Hamnskifte (−10 XP) när de läggs till.
 - Naturligt vapen, Pansar, Regeneration och Robust kan bara tas en gång och visas som separata poster.
 - Monstruösa särdrag kan inte staplas.
@@ -104,7 +104,7 @@ Se avsnittet ovan. Export öppnar en meny där du kan spara alla karaktärer som
 ### 10. Tips och tricks
 - Alla dina val sparas automatiskt i webblagringen på datorn.
 - Klicka på taggar i en lista för att snabbt filtrera på samma typ eller arketyp.
-- Hjälpmenyn (ℹ️) innehåller en sammanfattning av alla knappar om du behöver snabb hjälp.
+- Hjälpmenyn (<img src="icons/info.png" alt="Info" width="16">) innehåller en sammanfattning av alla knappar om du behöver snabb hjälp.
 
 ## Utveckling och bidrag
 Projektet består av statisk HTML, CSS och JavaScript utan byggsteg. Ändringar i `data/` och `js/` reflekteras direkt i webbläsaren. Förslag, felrapporter och förbättringar tas emot via pull requests.

--- a/css/style.css
+++ b/css/style.css
@@ -147,6 +147,37 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 .char-btn:hover  { opacity: .85; }
 .char-btn:active { transform: scale(.95); opacity: .7; }
 
+.btn-icon {
+  width: 1.45rem;
+  height: 1.45rem;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  display: block;
+  pointer-events: none;
+  user-select: none;
+  flex-shrink: 0;
+}
+.char-btn .btn-icon,
+.party-toggle .btn-icon {
+  width: 1.45rem;
+  height: 1.45rem;
+}
+.card .inv-controls .char-btn:not([data-clear-filters]) .btn-icon {
+  width: calc(var(--ctrl-btn-size) * .6);
+  height: calc(var(--ctrl-btn-size) * .6);
+}
+.mini-btn .btn-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+.btn-icon.inline-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  display: inline-block;
+  vertical-align: middle;
+}
+
 /* Kvadratiska kortkontroller (exkl. "Börja om?") */
 .card .inv-controls .char-btn:not([data-clear-filters]) {
   display: inline-flex;
@@ -2718,6 +2749,9 @@ select.level {
   padding: .25rem .5rem;
   cursor: pointer;
   transition: transform .1s ease, opacity .1s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 #folderManagerPopup .popup-inner.folder-ui .mini-btn:hover  { opacity: .85; }
 #folderManagerPopup .popup-inner.folder-ui .mini-btn:active { transform: scale(.95); opacity: .7; }

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1,6 +1,7 @@
 (function(window){
 function initCharacter() {
   const createEntryCard = window.entryCardFactory.create;
+  const iconHtml = window.iconHtml;
   dom.cName.textContent = store.characters.find(c=>c.id===store.current)?.name||'';
 
   const F = { search:[], typ:[], ark:[], test:[] };
@@ -1179,7 +1180,7 @@ function initCharacter() {
           bodyHtml: infoBodyHtml,
           meta: infoMeta
         });
-        const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
+        const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">${iconHtml('info')}</button>`;
 
         const multi = (p.kan_införskaffas_flera_gånger && typesList.some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
         const total = storeHelper.getCurrentList(store).filter(x=>x.namn===p.namn && !x.trait).length;
@@ -1206,29 +1207,29 @@ function initCharacter() {
           const isDisadv = typesList.includes('Nackdel');
           if (isDisadv) {
             if (total > 0) {
-              const delBtn = `<button data-act="del" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`;
-              const subBtn = `<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">➖</button>`;
-              const addBtn = total < limit ? `<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>` : '';
+              const delBtn = `<button data-act="del" class="char-btn danger icon" data-name="${p.namn}" aria-label="Ta bort">${iconHtml('remove')}</button>`;
+              const subBtn = `<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">${iconHtml('minus')}</button>`;
+              const addBtn = total < limit ? `<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">${iconHtml('plus')}</button>` : '';
               buttonParts.push(delBtn, subBtn);
               if (addBtn) buttonParts.push(addBtn);
             } else {
-              const addBtn = `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`;
+              const addBtn = `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">${iconHtml('plus')}</button>`;
               buttonParts.push(addBtn);
             }
             if (conflictBtn) buttonParts.push(conflictBtn);
           } else {
             const remBtn = total > 0
-              ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
+              ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}" aria-label="Ta bort">${iconHtml('remove')}</button>`
               : '';
             const addBtn = total < limit
-              ? `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`
+              ? `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">${iconHtml('plus')}</button>`
               : '';
             if (remBtn) buttonParts.push(remBtn);
             if (conflictBtn) buttonParts.push(conflictBtn);
             if (addBtn) buttonParts.push(addBtn);
           }
         } else {
-          buttonParts.push(`<button class="char-btn danger icon" data-act="rem">🗑</button>`);
+          buttonParts.push(`<button class="char-btn danger icon" data-act="rem" aria-label="Ta bort">${iconHtml('remove')}</button>`);
           if (conflictBtn) buttonParts.push(conflictBtn);
         }
         const dockPrimary = (p.taggar?.typ || [])[0] || '';

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1,6 +1,7 @@
 (function(window){
 function initIndex() {
   const createEntryCard = window.entryCardFactory.create;
+  const iconHtml = window.iconHtml;
   if (dom.cName) {
     dom.cName.textContent = store.characters.find(c => c.id === store.current)?.name || '';
   }
@@ -470,7 +471,7 @@ function initIndex() {
       cats[cat].forEach(p=>{
         if (p.kolumner && p.rader) {
           const infoHtml = tabellInfoHtml(p);
-          const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info">ℹ️</button>`;
+          const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info">${iconHtml('info')}</button>`;
           const tagsHtml = (p.taggar?.typ || [])
             .map(t => `<span class="tag">${t}</span>`)
             .join(' ');
@@ -646,7 +647,7 @@ function initIndex() {
           bodyHtml: infoBodyHtml,
           meta: infoMeta
         });
-        const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
+        const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">${iconHtml('info')}</button>`;
         const multi = isInv(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         let count;
         if (isInv(p)) {
@@ -677,16 +678,16 @@ function initIndex() {
         if (allowAdd) {
           if (multi) {
             if (count > 0) {
-              buttonGroupParts.push(`<button data-act="del" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`);
-              buttonGroupParts.push(`<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">➖</button>`);
-              if (count < limit) buttonGroupParts.push(`<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
+              buttonGroupParts.push(`<button data-act="del" class="char-btn danger icon" data-name="${p.namn}" aria-label="Ta bort">${iconHtml('remove')}</button>`);
+              buttonGroupParts.push(`<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">${iconHtml('minus')}</button>`);
+              if (count < limit) buttonGroupParts.push(`<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">${iconHtml('plus')}</button>`);
             } else {
-              buttonGroupParts.push(`<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
+              buttonGroupParts.push(`<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">${iconHtml('plus')}</button>`);
             }
           } else {
             const mainBtn = inChar
-              ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
-              : `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`;
+              ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}" aria-label="Ta bort">${iconHtml('remove')}</button>`
+              : `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">${iconHtml('plus')}</button>`;
             buttonGroupParts.push(mainBtn);
           }
         }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -9,6 +9,7 @@
   const OBASE = window.OBASE;
   const moneyToO = window.moneyToO;
   const oToMoney = window.oToMoney;
+  const iconHtml = window.iconHtml;
   const INV_TOOLS_KEY = 'invToolsOpen';
   const INV_INFO_KEY  = 'invInfoOpen';
   const STACKABLE_IDS = ['l1','l11','l27','l6','l12','l13','l28','l30'];
@@ -2035,8 +2036,8 @@ function openVehiclePopup(preselectId, precheckedPaths) {
           <div class="formal-section">
             <div class="formal-title">Pengar
               <div class="money-control">
-                <button id="moneyMinusBtn" data-act="moneyMinus" class="char-btn icon" aria-label="Minska mynt" title="Minska mynt">➖</button>
-                <button id="moneyPlusBtn" data-act="moneyPlus" class="char-btn icon" aria-label="Öka mynt" title="Öka mynt">➕</button>
+                <button id="moneyMinusBtn" data-act="moneyMinus" class="char-btn icon" aria-label="Minska mynt" title="Minska mynt">${iconHtml('minus')}</button>
+                <button id="moneyPlusBtn" data-act="moneyPlus" class="char-btn icon" aria-label="Öka mynt" title="Öka mynt">${iconHtml('plus')}</button>
               </div>
             </div>
             <div class="money-line"><span class="label">Kontant:</span><span class="value">${cash.daler}D ${cash.skilling}S ${cash['örtegar']}Ö</span></div>
@@ -2076,10 +2077,10 @@ ${moneyRow}
           const allowQual = ['Vapen','Sköld','Pil/Lod','Rustning','Artefakt'].some(t => tagTyp.includes(t));
           const canStack = ['kraft','ritual'].includes(entry.bound);
           const btnRow = (isGear && !canStack)
-            ? `<button data-act="del" class="char-btn danger icon">🗑</button>`
-            : `<button data-act="del" class="char-btn danger icon">🗑</button>
-               <button data-act="sub" class="char-btn" aria-label="Minska">➖</button>
-               <button data-act="add" class="char-btn" aria-label="Lägg till">➕</button>`;
+            ? `<button data-act="del" class="char-btn danger icon" aria-label="Ta bort">${iconHtml('remove')}</button>`
+            : `<button data-act="del" class="char-btn danger icon" aria-label="Ta bort">${iconHtml('remove')}</button>
+               <button data-act="sub" class="char-btn" aria-label="Minska">${iconHtml('minus')}</button>
+               <button data-act="add" class="char-btn" aria-label="Lägg till">${iconHtml('plus')}</button>`;
           const freeBtn = `<button data-act="free" class="char-btn${freeCnt? ' danger':''}">🆓</button>`;
           const editBtn = isCustom ? `<button data-act="editCustom" class="char-btn">✏️</button>` : '';
           const freeQBtn = allowQual ? `<button data-act="freeQual" class="char-btn">☭</button>` : '';
@@ -2124,10 +2125,10 @@ ${moneyRow}
                 const cAllowQual = ['Vapen','Sköld','Pil/Lod','Rustning','Artefakt'].some(t => ctagTyp.includes(t));
                 const cCanStack = ['kraft','ritual'].includes(centry.bound);
                 const cBtnRow = (cIsGear && !cCanStack)
-                  ? `<button data-act="del" class="char-btn danger icon">🗑</button>`
-                  : `<button data-act="del" class="char-btn danger icon">🗑</button>
-                     <button data-act="sub" class="char-btn" aria-label="Minska">➖</button>
-                     <button data-act="add" class="char-btn" aria-label="Lägg till">➕</button>`;
+                  ? `<button data-act="del" class="char-btn danger icon" aria-label="Ta bort">${iconHtml('remove')}</button>`
+                  : `<button data-act="del" class="char-btn danger icon" aria-label="Ta bort">${iconHtml('remove')}</button>
+                     <button data-act="sub" class="char-btn" aria-label="Minska">${iconHtml('minus')}</button>
+                     <button data-act="add" class="char-btn" aria-label="Lägg till">${iconHtml('plus')}</button>`;
                 const { desc: cDesc, rowLevel: cRowLevel, freeCnt: cFreeCnt } = buildRowDesc(centry, c);
                 const cDataLevel = cRowLevel ? ` data-level="${cRowLevel}"` : '';
                 const cKey = `${c.id || c.name}|${c.trait || ''}|${cRowLevel || ''}`;

--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@
   const overlayStack = [];
   const openMap = new Map();
   let isPop = false;
+  const iconHtml = window.iconHtml;
   // Count how many history.back() calls we have triggered manually.
   // Using a counter (instead of a boolean) makes rapid open/close
   // sequences robust and prevents desync when multiple popstate
@@ -1245,7 +1246,8 @@ function openFolderManagerPopup() {
     list.innerHTML = folders.map((f, idx) => {
       const cnt = charMap.get(f.id) || 0;
       const esc = s => String(s || '').replace(/[&<>"]/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m]));
-      const delBtn = f.system ? '' : `<button class="mini-btn danger" data-action="delete" title="Ta bort">🗑</button>`;
+      const removeIcon = iconHtml ? iconHtml('remove') : '🗑';
+      const delBtn = f.system ? '' : `<button class="mini-btn danger" data-action="delete" title="Ta bort" aria-label="Ta bort">${removeIcon}</button>`;
       const upDisabled = idx === 0 ? ' disabled' : '';
       const downDisabled = idx === folders.length - 1 ? ' disabled' : '';
       return (

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -7,6 +7,7 @@
    =========================================================== */
 const FILTER_TOOLS_KEY = 'filterToolsOpen';
 const FILTER_SETTINGS_KEY = 'filterSettingsOpen';
+const iconHtml = window.iconHtml || (() => '');
 
 class SharedToolbar extends HTMLElement {
   constructor() {
@@ -201,6 +202,29 @@ class SharedToolbar extends HTMLElement {
         .char-btn.icon   { font-size: 1.1rem; }
         .char-btn:hover  { opacity: .85; }
         .char-btn:active { transform: scale(.95); opacity: .7; }
+
+        .btn-icon {
+          width: 1.45rem;
+          height: 1.45rem;
+          max-width: 100%;
+          max-height: 100%;
+          object-fit: contain;
+          display: block;
+          pointer-events: none;
+          user-select: none;
+          flex-shrink: 0;
+        }
+        .char-btn .btn-icon,
+        .party-toggle .btn-icon {
+          width: 1.45rem;
+          height: 1.45rem;
+        }
+        .btn-icon.inline-icon {
+          width: 1.1rem;
+          height: 1.1rem;
+          display: inline-block;
+          vertical-align: middle;
+        }
         /* Hold solid green, tiny pulses, then smooth fade to blue */
         .focus-highlight {
           position: relative;
@@ -295,9 +319,9 @@ class SharedToolbar extends HTMLElement {
         <!-- Erfarenhetspoäng -->
         <div class="filter-group">
           <div class="xp-control">
-            <button id="xpMinus" class="char-btn icon" type="button" aria-label="Minska XP" title="Minska XP">➖</button>
+            <button id="xpMinus" class="char-btn icon" type="button" aria-label="Minska XP" title="Minska XP">${iconHtml('minus')}</button>
             <input id="xpInput" type="number" min="0" value="0" aria-label="Totala erfarenhetspoäng">
-            <button id="xpPlus" class="char-btn icon" type="button" aria-label="Öka XP" title="Öka XP">➕</button>
+            <button id="xpPlus" class="char-btn icon" type="button" aria-label="Öka XP" title="Öka XP">${iconHtml('plus')}</button>
           </div>
           <div id="xpSummary" class="card exp-counter">
             <div class="card-title">Erfarenhetspoäng</div>
@@ -376,7 +400,7 @@ class SharedToolbar extends HTMLElement {
                     <span class="toggle-desc">
                       <span class="toggle-question">Smed i partyt?</span>
                     </span>
-                    <button id="partySmith" class="party-toggle">⚒️</button>
+                    <button id="partySmith" class="party-toggle" aria-label="Smed i partyt" title="Smed i partyt">${iconHtml('smithing')}</button>
                   </li>
                   <li>
                     <span class="toggle-desc">
@@ -440,7 +464,7 @@ class SharedToolbar extends HTMLElement {
                   <span class="toggle-desc">
                     <span class="toggle-question">Behöver du hjälp?</span>
                   </span>
-                  <button id="infoToggle" class="party-toggle" title="Visa hjälp">ℹ️</button>
+                  <button id="infoToggle" class="party-toggle" title="Visa hjälp" aria-label="Visa hjälp">${iconHtml('info')}</button>
                 </li>
               </ul>
             </div>
@@ -466,7 +490,7 @@ class SharedToolbar extends HTMLElement {
             <label for="customType">Typ</label>
             <div class="custom-type-row">
               <select id="customType"></select>
-              <button id="customTypeAdd" class="char-btn" type="button" aria-label="Lägg till typ" title="Lägg till typ">➕</button>
+              <button id="customTypeAdd" class="char-btn" type="button" aria-label="Lägg till typ" title="Lägg till typ">${iconHtml('plus')}</button>
             </div>
             <div id="customTypeTags" class="tags"></div>
           </div>
@@ -501,7 +525,7 @@ class SharedToolbar extends HTMLElement {
           <div id="customPowerFields" class="filter-group" style="display:none">
             <label>Förmågor</label>
             <div id="customPowerList"></div>
-            <button id="customPowerAdd" class="char-btn" type="button" aria-label="Lägg till förmåga" title="Lägg till förmåga">➕</button>
+            <button id="customPowerAdd" class="char-btn" type="button" aria-label="Lägg till förmåga" title="Lägg till förmåga">${iconHtml('plus')}</button>
           </div>
           <div id="customBoundFields" class="filter-group" style="display:none">
             <label for="customBoundType">Bundet till</label>
@@ -806,7 +830,7 @@ class SharedToolbar extends HTMLElement {
               <label for="newFolderName">+ Ny mapp:</label>
               <div class="inline-controls">
                 <input id="newFolderName" placeholder="Mappnamn">
-                <button id="addFolderBtn" class="char-btn" aria-label="Lägg till mapp" title="Lägg till mapp">➕</button>
+                <button id="addFolderBtn" class="char-btn" aria-label="Lägg till mapp" title="Lägg till mapp">${iconHtml('plus')}</button>
               </div>
             </div>
           </section>
@@ -975,11 +999,11 @@ class SharedToolbar extends HTMLElement {
               <li>Ny/Kopiera/Byt namn/Ta bort: Hanterar karaktärer.</li>
               <li>Mapphantering: Skapa mappar och flytta rollpersoner mellan mappar.</li>
               <li>Export/Import: Säkerhetskopiera eller hämta karaktärer som JSON.</li>
-              <li>⚒️/⚗️/🏺: Välj nivå för smed, alkemist och artefaktmakare (påverkar pris och åtkomst).</li>
+              <li>${iconHtml('smithing', { className: 'inline-icon' })}/⚗️/🏺: Välj nivå för smed, alkemist och artefaktmakare (påverkar pris och åtkomst).</li>
               <li>🔭 Utvidga sökning: Växla till OR-filter (matcha någon tag).</li>
               <li>↕️ Expandera vy: Visar fler detaljer i kort (alla utom Ras, Yrken och Elityrken).</li>
               <li>🏃 Försvar: Välj försvarskaraktärsdrag manuellt.</li>
-              <li>ℹ️ Hjälp: Visar denna panel.</li>
+              <li>${iconHtml('info', { className: 'inline-icon' })} Hjälp: Visar denna panel.</li>
             </ul>
           </section>
 
@@ -1035,7 +1059,7 @@ class SharedToolbar extends HTMLElement {
               <li>🆓 Gör föremål gratis. 💔 Visa konflikter.</li>
               <li>↔ Växla artefaktens kostnad mellan XP och permanent korruption.</li>
               <li>⬇️/⬆️ Lasta på/av föremål till/från färdmedel.</li>
-              <li>🗑 Ta bort posten helt.</li>
+              <li>${iconHtml('remove', { className: 'inline-icon' })} Ta bort posten helt.</li>
             </ul>
           </section>
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -24,6 +24,19 @@
   ];
   const SBASE = 10, OBASE = 10;
 
+  const ICON_CLASS = 'btn-icon';
+
+  function iconHtml(name, opts = {}) {
+    const key = String(name || '').toLowerCase().replace(/[^a-z0-9_-]/g, '');
+    if (!key) return '';
+    const classes = [ICON_CLASS];
+    if (opts && opts.className) {
+      classes.push(String(opts.className));
+    }
+    const classAttr = classes.length ? ` class="${classes.join(' ')}"` : '';
+    return `<img src="icons/${key}.png"${classAttr} alt="" draggable="false">`;
+  }
+
   // Konvertera ett penningobjekt till totalt antal örtegar
   function moneyToO(m) {
     m = m || {};
@@ -391,6 +404,7 @@
   window.EQUIP = EQUIP;
   window.SBASE = SBASE;
   window.OBASE = OBASE;
+  window.iconHtml = iconHtml;
   window.moneyToO = moneyToO;
   window.oToMoney = oToMoney;
   window.isInv = isInv;


### PR DESCRIPTION
## Summary
- add a reusable `iconHtml` helper and CSS rules to render the new toolbar and action icons
- swap the old plus, minus, info, smithing and delete emojis for image icons across index, character and inventory views
- refresh related help text and documentation to reference the new icons

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cf0ef10cc88323855f200b59eccda7