### PR TITLE
Lazy load JSZip when exporting

### DIFF
--- a/character.html
+++ b/character.html
@@ -21,7 +21,6 @@
   <script src="js/elite-req.js"   defer></script>
   <script src="js/entry-card.js" defer></script>
   <script src="js/character-view.js" defer></script>
-  <script src="js/jszip.min.js"     defer></script>
   <script src="js/main.js"            defer></script>
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/djurmask.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
   <script src="js/elite-req.js"   defer></script>
   <script src="js/entry-card.js" defer></script>
   <script src="js/index-view.js"  defer></script>
-  <script src="js/jszip.min.js"   defer></script>
   <script src="js/main.js"         defer></script>
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/djurmask.js" defer></script>

--- a/notes.html
+++ b/notes.html
@@ -20,7 +20,6 @@
   <script src="js/pdf-library.js" defer></script>
   <script src="js/auto-resize.js" defer></script>
   <script src="js/notes-view.js"  defer></script>
-  <script src="js/jszip.min.js"   defer></script>
   <script src="js/main.js"        defer></script>
   <script src="js/exceptionellt.js" defer></script>
   <script src="js/djurmask.js" defer></script>


### PR DESCRIPTION
## Summary
- remove the hardcoded jszip script tag from the HTML entrypoints
- lazily load jszip inside main.js when a zip export is requested
- fall back to the previous multi-file export if jszip fails to load

## Testing
- not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68d0458022c483239495e9d32784e2ef