### PR TITLE
Optimize index view updates and add render profiler

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -106,7 +106,7 @@
     return sortByType(entA, entB);
   }
 
-  function saveInventory(inv) {
+  function saveInventory(inv, options = {}) {
     const nonVeh = [];
     const veh = [];
     inv.forEach(row => {
@@ -119,7 +119,16 @@
     recalcArtifactEffects();
     if (window.updateXP) updateXP();
     if (window.renderTraits) renderTraits();
-    if (window.indexViewUpdate) window.indexViewUpdate();
+    if (!options.skipIndexUpdate && window.indexViewUpdate) {
+      const opts = {
+        reason: options.reason || 'inventory:save',
+        skipActiveTags: options.skipActiveTags !== undefined ? options.skipActiveTags : true
+      };
+      if (options.entries) opts.entries = options.entries;
+      if (options.changedCats) opts.changedCats = options.changedCats;
+      if (options.forceFull || !opts.entries) opts.forceFull = true;
+      window.indexViewUpdate(opts);
+    }
   }
 
   function addWellEquippedItems(inv) {
@@ -2449,10 +2458,10 @@ ${moneyRow}
         }
         const inv = storeHelper.getInventory(store);
         inv.push({ id: entry.id, name: entry.namn, qty:1, gratis:0, gratisKval:[], removedKval:[], artifactEffect: entry.artifactEffect });
-        saveInventory(inv);
+        saveInventory(inv, { skipIndexUpdate: true });
         refreshInventoryFull();
         if (window.indexViewRefreshFilters) window.indexViewRefreshFilters();
-        if (window.indexViewUpdate) window.indexViewUpdate();
+        if (window.indexViewUpdate) window.indexViewUpdate({ reason: 'inventory:custom-add', entries: [entry] });
       });
     };
     if (dom.collapseAllBtn) {
@@ -2594,7 +2603,7 @@ ${moneyRow}
         editCustomEntry(entry, () => {
           refreshInventoryFull();
           if (window.indexViewRefreshFilters) window.indexViewRefreshFilters();
-          if (window.indexViewUpdate) window.indexViewUpdate();
+          if (window.indexViewUpdate) window.indexViewUpdate({ reason: 'inventory:custom-edit', entries: [entry] });
         });
         return;
       }

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -301,7 +301,7 @@
           dom.tstSel.dispatchEvent(new Event('change'));
         }
         storeHelper.setOnlySelected(store, true);
-        if (typeof indexViewUpdate === 'function') indexViewUpdate();
+        if (typeof indexViewUpdate === 'function') indexViewUpdate({ reason: 'traits:filter' });
         return;
       }
       const btn = e.target.closest('.trait-btn');


### PR DESCRIPTION
## Summary
- add render profiler utilities and diff-based snapshot logic to drive partial index list updates
- refactor search, filter, and inventory interactions to use the targeted update pipeline instead of forcing full renders
- adjust global update callers (party toggles, data loads, custom entry handling, etc.) to pass update metadata for focused redraws

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d054b6d418832393f292fd46bdcd8e