### PR TITLE
Optimize trait panel rendering with partial updates

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -421,7 +421,7 @@ function initCharacter() {
       }
       skillCardActions.renderAll();
       updateXP();
-      renderTraits();
+      renderTraits({ source: 'list:update' });
       updateSearchDatalist();
     });
   }
@@ -1570,8 +1570,8 @@ function initCharacter() {
     window.updateScrollLock?.();
   };
 
-  skillCardActions.renderAll(); activeTags(); updateXP(); renderTraits(); updateSearchDatalist();
-  window.indexViewUpdate = () => { skillCardActions.renderAll(); renderTraits(); updateSearchDatalist(); };
+  skillCardActions.renderAll(); activeTags(); updateXP(); renderTraits({ source: 'list:update' }); updateSearchDatalist();
+  window.indexViewUpdate = () => { skillCardActions.renderAll(); renderTraits({ source: 'list:update' }); updateSearchDatalist(); };
   // expose for main.js to refresh dropdowns when switching character
   window.indexViewRefreshFilters = () => { refreshCharacterFilters(); updateSearchDatalist(); };
   window.refreshEffectsPanel = refreshEffectsPanel;
@@ -1629,7 +1629,7 @@ function initCharacter() {
             updateSearchDatalist();
             activeTags();
             skillCardActions.renderAll();
-            renderTraits();
+            renderTraits({ source: 'list:update' });
             dom.sIn.blur();
             window.scrollTo({ top: 0, behavior: 'smooth' });
             return;
@@ -1676,7 +1676,7 @@ function initCharacter() {
         dom.sIn.value=''; dom.typSel.value=dom.arkSel.value=dom.tstSel.value='';
         storeHelper.setOnlySelected(store, false);
         storeHelper.clearRevealedArtifacts(store);
-        activeTags(); skillCardActions.renderAll(); renderTraits(); updateSearchDatalist();
+        activeTags(); skillCardActions.renderAll(); renderTraits({ source: 'list:update' }); updateSearchDatalist();
         return;
       }
       if (tryBomb(sTemp)) {
@@ -1704,7 +1704,7 @@ function initCharacter() {
         F.search = [];
       }
       dom.sIn.value=''; sTemp='';
-      activeTags(); skillCardActions.renderAll(); renderTraits(); updateSearchDatalist();
+      activeTags(); skillCardActions.renderAll(); renderTraits({ source: 'list:update' }); updateSearchDatalist();
     }
   });
   [ ['typSel','typ'], ['arkSel','ark'], ['tstSel','test'] ].forEach(([sel,key])=>{
@@ -1713,17 +1713,17 @@ function initCharacter() {
       if (sel === 'tstSel' && !v) {
         F[key] = [];
         storeHelper.setOnlySelected(store, false);
-        activeTags(); skillCardActions.renderAll(); renderTraits(); updateSearchDatalist();
+        activeTags(); skillCardActions.renderAll(); renderTraits({ source: 'list:update' }); updateSearchDatalist();
         return;
       }
       if (sel === 'typSel' && v === ONLY_SELECTED_VALUE) {
         storeHelper.setOnlySelected(store, true);
         dom[sel].value = '';
-        activeTags(); skillCardActions.renderAll(); renderTraits(); updateSearchDatalist();
+        activeTags(); skillCardActions.renderAll(); renderTraits({ source: 'list:update' }); updateSearchDatalist();
         return;
       }
       if(v&&!F[key].includes(v)) F[key].push(v);
-      dom[sel].value=''; activeTags(); skillCardActions.renderAll(); renderTraits(); updateSearchDatalist();
+      dom[sel].value=''; activeTags(); skillCardActions.renderAll(); renderTraits({ source: 'list:update' }); updateSearchDatalist();
     });
   });
   dom.active.addEventListener('click',e=>{
@@ -1733,7 +1733,7 @@ function initCharacter() {
     else if(sec==='onlySel'){ storeHelper.setOnlySelected(store,false); }
     else F[sec]=F[sec].filter(x=>x!==val);
     if(sec==='test'){ storeHelper.setOnlySelected(store,false); dom.tstSel.value=''; }
-    activeTags(); skillCardActions.renderAll(); renderTraits(); updateSearchDatalist();
+    activeTags(); skillCardActions.renderAll(); renderTraits({ source: 'list:update' }); updateSearchDatalist();
   });
 
   // Treat clicks on tags anywhere as filter selections
@@ -1746,7 +1746,7 @@ function initCharacter() {
     const val = tag.dataset.val;
     if (!F[section].includes(val)) F[section].push(val);
     if (section === 'typ') openCatsOnce.add(val);
-    activeTags(); skillCardActions.renderAll(); renderTraits();
+    activeTags(); skillCardActions.renderAll(); renderTraits({ source: 'list:update' });
   });
 
   function formatLevels(list){
@@ -1832,7 +1832,7 @@ function initCharacter() {
       refreshCharacterFilters();
       activeTags();
       skillCardActions.renderAll();
-      renderTraits();
+      renderTraits({ source: 'list:update' });
       updateSearchDatalist();
       if (window.indexViewRefreshFilters) window.indexViewRefreshFilters();
       if (window.indexViewUpdate) window.indexViewUpdate();
@@ -2022,7 +2022,7 @@ function initCharacter() {
     }
     skillCardActions.syncLists(beforeSnapshot, list);
     updateXP();
-    renderTraits();
+    renderTraits({ source: 'list:update' });
     updateSearchDatalist();
     if (act === 'add') {
       flashAdded(name, tr);
@@ -2060,7 +2060,7 @@ function initCharacter() {
               ent.trait=spec;
               storeHelper.setCurrentList(store,list); updateXP();
               skillCardActions.syncLists(beforeSnapshot || [], list);
-              renderTraits(); updateSearchDatalist();
+              renderTraits({ source: 'list:update' }); updateSearchDatalist();
             });
             return;
           }
@@ -2068,7 +2068,7 @@ function initCharacter() {
           delete ent.trait;
           storeHelper.setCurrentList(store,list); updateXP();
           skillCardActions.syncLists(beforeSnapshot || [], list);
-          renderTraits(); updateSearchDatalist();
+          renderTraits({ source: 'list:update' }); updateSearchDatalist();
           return;
         }
       }
@@ -2079,7 +2079,7 @@ function initCharacter() {
     } else {
       skillCardActions.renderAll();
     }
-    renderTraits(); updateSearchDatalist();
+    renderTraits({ source: 'list:update' }); updateSearchDatalist();
     flashAdded(name, tr);
   });
 }

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1480,7 +1480,7 @@ function initIndex() {
               }
               if (addedToList || hidden) {
                 if (window.updateXP) updateXP();
-                if (window.renderTraits) renderTraits();
+                if (window.renderTraits) renderTraits({ source: 'list:update' });
               }
               if (hidden && p.id) {
                 storeHelper.addRevealedArtifact(store, p.id);
@@ -1631,7 +1631,7 @@ function initIndex() {
             await checkDisadvWarning();
             storeHelper.setCurrentList(store,list); updateXP();
             applyRefresh(p);
-            renderTraits();
+            renderTraits({ source: 'list:update' });
             flashAdded(added.namn, added.trait);
           });
           return;
@@ -1644,7 +1644,7 @@ function initIndex() {
             await checkDisadvWarning();
             storeHelper.setCurrentList(store,list); updateXP();
             applyRefresh(p);
-            renderTraits();
+            renderTraits({ source: 'list:update' });
             flashAdded(added.namn, added.trait);
           });
           return;
@@ -1665,7 +1665,7 @@ function initIndex() {
             await checkDisadvWarning();
             storeHelper.setCurrentList(store,list); updateXP();
             applyRefresh(p);
-            renderTraits();
+            renderTraits({ source: 'list:update' });
             flashAdded(added.namn, added.trait);
           });
           return;
@@ -1700,7 +1700,7 @@ function initIndex() {
             invUtil.saveInventory(inv); invUtil.renderInventory();
           }
           applyRefresh(p);
-          renderTraits();
+          renderTraits({ source: 'list:update' });
           flashAdded(added.namn, added.trait);
         };
         if (isMonstrousTrait(p)) {
@@ -1760,7 +1760,7 @@ function initIndex() {
             let list = storeHelper.getCurrentList(store).filter(x => !(x.id === p.id && x.noInv));
             storeHelper.setCurrentList(store, list);
             if (window.updateXP) updateXP();
-            if (window.renderTraits) renderTraits();
+            if (window.renderTraits) renderTraits({ source: 'list:update' });
             if (hidden) storeHelper.removeRevealedArtifact(store, p.id);
           }
         }
@@ -1878,7 +1878,7 @@ function initIndex() {
       }
     }
     activeTags();
-    renderTraits();
+    renderTraits({ source: 'list:update' });
     if (act==='add') {
       flashAdded(name, tr);
     } else if (act==='sub' || act==='del' || act==='rem') {
@@ -1921,7 +1921,7 @@ function initIndex() {
               ent.trait=spec;
               storeHelper.setCurrentList(store,list); updateXP();
               applyLevelRefresh(name);
-              renderTraits();
+              renderTraits({ source: 'list:update' });
             });
             return;
           }
@@ -1929,7 +1929,7 @@ function initIndex() {
           delete ent.trait;
           storeHelper.setCurrentList(store,list); updateXP();
           applyLevelRefresh(name);
-          renderTraits();
+          renderTraits({ source: 'list:update' });
           return;
         }
       }
@@ -1974,13 +1974,13 @@ function initIndex() {
         });
         storeHelper.setCurrentList(store,list); updateXP();
         applyLevelRefresh([...affected]);
-        renderTraits();
+        renderTraits({ source: 'list:update' });
         flashAdded(name, tr);
         return;
       }
       storeHelper.setCurrentList(store,list); updateXP();
       applyLevelRefresh(name);
-      renderTraits();
+      renderTraits({ source: 'list:update' });
       flashAdded(name, tr);
       return;
     }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -118,7 +118,7 @@
     storeHelper.setInventory(store, inv);
     recalcArtifactEffects();
     if (window.updateXP) updateXP();
-    if (window.renderTraits) renderTraits();
+    if (window.renderTraits) renderTraits({ source: 'inventory:update' });
     if (window.indexViewUpdate) window.indexViewUpdate();
   }
 
@@ -2659,7 +2659,7 @@ ${moneyRow}
                 let list = storeHelper.getCurrentList(store).filter(x => !(x.id === row.id && x.noInv));
                 storeHelper.setCurrentList(store, list);
                 if (window.updateXP) updateXP();
-                if (window.renderTraits) renderTraits();
+                if (window.renderTraits) renderTraits({ source: 'inventory:update' });
                 if (hidden) storeHelper.removeRevealedArtifact(store, row.id || row.name);
               }
             }
@@ -2767,7 +2767,7 @@ ${moneyRow}
               }
               if ((addedToList || hidden)) {
                 if (window.updateXP) updateXP();
-                if (window.renderTraits) renderTraits();
+                if (window.renderTraits) renderTraits({ source: 'inventory:update' });
               }
               if (hidden && entry.id) {
                 storeHelper.addRevealedArtifact(store, entry.id);
@@ -2837,7 +2837,7 @@ ${moneyRow}
               let list = storeHelper.getCurrentList(store).filter(x => !(x.id === row.id && x.noInv));
               storeHelper.setCurrentList(store, list);
               if (window.updateXP) updateXP();
-              if (window.renderTraits) renderTraits();
+              if (window.renderTraits) renderTraits({ source: 'inventory:update' });
               if (hidden) storeHelper.removeRevealedArtifact(store, row.id || row.name);
             }
           }

--- a/js/main.js
+++ b/js/main.js
@@ -588,7 +588,7 @@ function boot() {
   bindToolbar();
 
   if (dom.traits && typeof renderTraits === 'function') {
-    renderTraits();
+    renderTraits({ source: 'init' });
     if (typeof bindTraits === 'function') bindTraits();
   }
   if (ROLE === 'index')     initIndex();
@@ -638,7 +638,7 @@ function applyCharacterChange() {
     if (typeof window.updateXP === 'function') updateXP();
 
     // Ensure traits panel reflects the new character regardless of inventory path
-    if (typeof window.renderTraits === 'function') renderTraits();
+    if (typeof window.renderTraits === 'function') renderTraits({ source: 'character-change' });
 
     // Re-render main content depending on view
     if (typeof window.indexViewRefreshFilters === 'function') window.indexViewRefreshFilters();
@@ -1085,7 +1085,7 @@ function bindToolbar() {
       const next = { ...t };
       KEYS.forEach(k => { next[k] = 10; });
       storeHelper.setTraits(store, next);
-      if (window.renderTraits) renderTraits();
+      if (window.renderTraits) renderTraits({ source: 'traits:reset' });
     }
   });
 
@@ -1154,7 +1154,7 @@ function bindToolbar() {
         if (trait === null) return;
         dom.defBtn.classList.toggle('active', Boolean(trait));
         storeHelper.setDefenseTrait(store, trait);
-        if (window.renderTraits) renderTraits();
+        if (window.renderTraits) renderTraits({ source: 'defense:change' });
       });
     });
   }

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -145,148 +145,415 @@
     return 'Kvick';
   }
 
-  function renderTraits(){
-    if(!dom.traits) return;
-    const data = storeHelper.getTraits(store);
-    const KEYS = ['Diskret','Kvick','Listig','Stark','Tr\u00e4ffs\u00e4ker','Vaksam','Viljestark','\u00d6vertygande'];
+  const TRAIT_KEYS = ['Diskret','Kvick','Listig','Stark','Tr\u00e4ffs\u00e4ker','Vaksam','Viljestark','\u00d6vertygande'];
 
-    const list  = storeHelper.getCurrentList(store);
-    const effects = storeHelper.getArtifactEffects(store);
+  // Map UI entry points that trigger trait re-renders and whether they need
+  // a full refresh or allow partial updates. This doubles as documentation of
+  // which user interactions hit renderTraits and what they change.
+  const TRAIT_RENDER_EVENT_MAP = {
+    init: {
+      mode: 'full',
+      triggers: ['Initial boot sequence (main.js boot)']
+    },
+    'character-change': {
+      mode: 'full',
+      triggers: ['Aktiv rollperson byts/importeras (main.js applyCharacterChange)']
+    },
+    'traits:adjust': {
+      mode: 'partial',
+      triggers: ['Knappjusteringar i panelen för karakt\u00e4rsdrag (traits-utils.js)']
+    },
+    'traits:reset': {
+      mode: 'full',
+      triggers: ['\u00c5terst\u00e4ll karakt\u00e4rsdrag via verktygsf\u00e4ltet (main.js)']
+    },
+    'inventory:update': {
+      mode: 'full',
+      triggers: ['Inventarie\u00e4ndringar, kvaliteter och artefakter (inventory-utils.js)']
+    },
+    'list:update': {
+      mode: 'full',
+      triggers: ['F\u00f6rtecknings- och f\u00f6rm\u00e5gejusteringar (character-view.js & index-view.js)']
+    },
+    'defense:change': {
+      mode: 'full',
+      triggers: ['Val av f\u00f6rsvarskarakt\u00e4rsdrag via popup (main.js)']
+    },
+    default: {
+      mode: 'full',
+      triggers: ['Okategoriserade anrop']
+    }
+  };
+
+  const traitNodes = new Map();
+  let lastTraitState = new Map();
+  let lastTotals = { total: null, maxTot: null, className: '' };
+
+  function uniqueValidTraits(arr) {
+    const out = [];
+    const seen = new Set();
+    arr.forEach(key => {
+      if (typeof key !== 'string') return;
+      if (!TRAIT_KEYS.includes(key)) return;
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push(key);
+    });
+    return out;
+  }
+
+  function normalizeRenderOptions(input) {
+    if (!input) return { source: 'unknown', changedTraits: [], forceFull: false };
+    if (typeof input === 'string') {
+      return { source: input, changedTraits: [], forceFull: false };
+    }
+    if (typeof input !== 'object') {
+      return { source: 'unknown', changedTraits: [], forceFull: false };
+    }
+
+    const list = [];
+    if (Array.isArray(input.changedTraits)) list.push(...input.changedTraits);
+    if (typeof input.changedTrait === 'string') list.push(input.changedTrait);
+    if (typeof input.trait === 'string') list.push(input.trait);
+
+    const source = typeof input.source === 'string' ? input.source : 'unknown';
+    const changedTraits = uniqueValidTraits(list);
+    const forceFull = Boolean(input.forceFull || input.full);
+
+    return { source, changedTraits, forceFull };
+  }
+
+  function descriptorsEqual(a, b) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      const da = a[i];
+      const db = b[i];
+      if (!da || !db) return false;
+      if (da.type !== db.type) return false;
+      if (da.type === 'extra' && da.text !== db.text) return false;
+    }
+    return true;
+  }
+
+  function isTraitStateEqual(prev, next) {
+    if (!prev || !next) return false;
+    if (prev.value !== next.value) return false;
+    if (prev.count !== next.count) return false;
+    if (!descriptorsEqual(prev.before, next.before)) return false;
+    if (!descriptorsEqual(prev.extras, next.extras)) return false;
+    if (!descriptorsEqual(prev.after, next.after)) return false;
+    return true;
+  }
+
+  function computeTraitSnapshot() {
+    const data = storeHelper.getTraits(store) || {};
+    const list = storeHelper.getCurrentList(store) || [];
+    const effects = storeHelper.getArtifactEffects(store) || {};
     const permBase = storeHelper.calcPermanentCorruption(list, effects);
     const hasEarth = list.some(p => p.namn === 'Jordnära');
-    const bonus = window.exceptionSkill ? exceptionSkill.getBonuses(list) : {};
-    const maskBonus = window.maskSkill ? maskSkill.getBonuses(storeHelper.getInventory(store)) : {};
+    const bonus = window.exceptionSkill ? (exceptionSkill.getBonuses(list) || {}) : {};
+    const maskBonus = window.maskSkill
+      ? (maskSkill.getBonuses(storeHelper.getInventory(store)) || {})
+      : {};
+
     const counts = {};
     const vals = {};
-    KEYS.forEach(k => {
+    TRAIT_KEYS.forEach(k => {
       counts[k] = list.filter(p => (p.taggar?.test || []).includes(k)).length;
       vals[k] = (data[k] || 0) + (bonus[k] || 0) + (maskBonus[k] || 0);
     });
+
     const hasKraftprov = list.some(p => p.namn === 'Kraftprov');
     const hasHardnackad = list.some(p => p.namn === 'Hårdnackad');
     const hasSjalastark = list.some(p => p.namn === 'Själastark');
-
-    const strongGiftLevel = storeHelper.abilityLevel(list, 'Stark gåva');
-    const strongGift = strongGiftLevel >= 1;
-
+    const strongGift = storeHelper.abilityLevel(list, 'Stark gåva') >= 1;
     const resistCount = list.filter(p => p.namn === 'Motståndskraft').length;
-    const sensCount   = list.filter(p => p.namn === 'Korruptionskänslig').length;
+    const sensCount = list.filter(p => p.namn === 'Korruptionskänslig').length;
 
-    const valWill = vals['Viljestark'];
-    const baseMax   = strongGift ? valWill + 5 : valWill;
+    const valWill = vals['Viljestark'] || 0;
+    const baseMax = strongGift ? valWill + 5 : valWill;
     const threshBase = strongGift ? valWill : Math.ceil(valWill / 2);
     const maxCor = baseMax + (hasSjalastark ? 1 : 0);
-    let   thresh = threshBase + resistCount - sensCount;
+    let thresh = threshBase + resistCount - sensCount;
     const darkPerm = storeHelper.calcDarkPastPermanentCorruption(list, thresh);
     const effectsWithDark = { ...effects, corruption: (effects.corruption || 0) + darkPerm };
 
     const defTrait = getDefenseTraitName(list);
-    const defs = calcDefense(vals[defTrait]);
+    const defs = calcDefense(vals[defTrait] || 0);
 
-    dom.traits.innerHTML = KEYS.map(k => {
-      const val = vals[k];
-      const hardy = hasHardnackad && k === 'Stark' ? 1 : 0;
-      const talBase = hasKraftprov && k === 'Stark' ? val + 5 : Math.max(10, val);
-      let tal  = talBase;
-      let pain = 0;
-      let extra = '';
-      let beforeExtra = '';
-      let afterExtra = `<button class="trait-count" data-trait="${k}">Förmågor: ${counts[k]}</button>`;
-      if (k === 'Stark') {
+    const states = new Map();
+
+    const addExtra = (arr, text) => {
+      const val = String(text || '').trim();
+      if (!val) return;
+      arr.push({ type: 'extra', text: val });
+    };
+
+    TRAIT_KEYS.forEach(key => {
+      const val = vals[key] || 0;
+      const before = [];
+      const extras = [];
+      const after = [];
+
+      if (key === 'Stark') {
+        before.push({ type: 'count' });
         const base = storeHelper.calcCarryCapacity(val, list);
-        tal  += hardy;
-        pain = storeHelper.calcPainThreshold(val, list, effectsWithDark);
-        beforeExtra = `<button class="trait-count" data-trait="${k}">Förmågor: ${counts[k]}</button>` + `<div class="trait-extra">Bärkapacitet: ${formatWeight(base)}</div>`;
-        afterExtra = '';
-        extra = `<div class="trait-extra">Tålighet: ${tal} • Smärtgräns: ${pain}</div>`;
-      } else if (k === 'Viljestark') {
+        const hardy = hasHardnackad ? 1 : 0;
+        const talBase = hasKraftprov ? val + 5 : Math.max(10, val);
+        const tal = talBase + hardy;
+        const pain = storeHelper.calcPainThreshold(val, list, effectsWithDark);
+        addExtra(before, `Bärkapacitet: ${formatWeight(base)}`);
+        addExtra(extras, `Tålighet: ${tal} • Smärtgräns: ${pain}`);
+      } else {
+        after.push({ type: 'count' });
+      }
+
+      if (key === 'Viljestark') {
         let perm = hasEarth ? (permBase % 2) : permBase;
         perm += darkPerm;
-        extra = `<div class="trait-extra">Permanent korruption: ${perm}</div>` + `<div class="trait-extra">Maximal korruption: ${maxCor} • Korruptionströskel: ${thresh}</div>`;
+        addExtra(extras, `Permanent korruption: ${perm}`);
+        addExtra(extras, `Maximal korruption: ${maxCor} • Korruptionströskel: ${thresh}`);
       }
-      if (k === 'Diskret') {
+      if (key === 'Diskret') {
         if (storeHelper.abilityLevel(list, 'Fint') >= 1) {
-          extra += '<div class="trait-extra">Kan användas som träffsäker för attacker i närstrid med kort eller precist vapen</div>';
+          addExtra(extras, 'Kan användas som träffsäker för attacker i närstrid med kort eller precist vapen');
         }
         if (storeHelper.abilityLevel(list, 'Lönnstöt') >= 1) {
-          extra += '<div class="trait-extra">Kan användas som träffsäker för attacker med Övertag</div>';
+          addExtra(extras, 'Kan användas som träffsäker för attacker med Övertag');
         }
       }
-      if (k === 'Kvick' && storeHelper.abilityLevel(list, 'Koreograferad strid') >= 1) {
-        extra += '<div class="trait-extra">Kan användas som träffsäker för attacker som utförs efter en förflyttning</div>';
+      if (key === 'Kvick' && storeHelper.abilityLevel(list, 'Koreograferad strid') >= 1) {
+        addExtra(extras, 'Kan användas som träffsäker för attacker som utförs efter en förflyttning');
       }
-      if (k === 'Listig' && storeHelper.abilityLevel(list, 'Taktiker') >= 3) {
-        extra += '<div class="trait-extra">Kan användas som träffsäker för attacker med allt utom tunga vapen</div>';
+      if (key === 'Listig' && storeHelper.abilityLevel(list, 'Taktiker') >= 3) {
+        addExtra(extras, 'Kan användas som träffsäker för attacker med allt utom tunga vapen');
       }
-      if (k === 'Vaksam') {
+      if (key === 'Vaksam') {
         const sjatteSinneLvl = Math.max(
           storeHelper.abilityLevel(list, 'Sjätte Sinne'),
           storeHelper.abilityLevel(list, 'Sjätte sinne')
         );
         if (sjatteSinneLvl >= 3) {
-          extra += '<div class="trait-extra">Kan användas som träffsäker</div>';
+          addExtra(extras, 'Kan användas som träffsäker');
         } else if (sjatteSinneLvl >= 1) {
-          extra += '<div class="trait-extra">Kan användas som träffsäker för attacker med avståndsvapen</div>';
+          addExtra(extras, 'Kan användas som träffsäker för attacker med avståndsvapen');
         }
       }
-      if (k === 'Stark' && storeHelper.abilityLevel(list, 'Järnnäve') >= 1) {
-        extra += '<div class="trait-extra">Kan användas som träffsäker för attacker i närstrid</div>';
+      if (key === 'Stark' && storeHelper.abilityLevel(list, 'Järnnäve') >= 1) {
+        addExtra(extras, 'Kan användas som träffsäker för attacker i närstrid');
       }
-      if (k === 'Övertygande' && storeHelper.abilityLevel(list, 'Dominera') >= 1) {
-        extra += '<div class="trait-extra">Kan användas som träffsäker för attacker i närstrid</div>';
+      if (key === '\u00d6vertygande' && storeHelper.abilityLevel(list, 'Dominera') >= 1) {
+        addExtra(extras, 'Kan användas som träffsäker för attacker i närstrid');
       }
-      if (k === 'Övertygande' && storeHelper.abilityLevel(list, 'Ledare') >= 1) {
-        extra += '<div class="trait-extra">Kan användas istället för Viljestark vid användandet av mystiska förmågor och ritualer</div>';
+      if (key === '\u00d6vertygande' && storeHelper.abilityLevel(list, 'Ledare') >= 1) {
+        addExtra(extras, 'Kan användas istället för Viljestark vid användandet av mystiska förmågor och ritualer');
       }
-      if (k === defTrait) {
-        const defHtml = defs.map(d => `<div class="trait-extra">Försvar${d.name ? ' (' + d.name + ')' : ''}: ${d.value}</div>`).join('');
-        extra += defHtml;
+      if (key === defTrait) {
+        defs.forEach(d => {
+          const label = d.name ? `Försvar (${d.name})` : 'Försvar';
+          addExtra(extras, `${label}: ${d.value}`);
+        });
       }
-      return `
-      <div class="trait" data-key="${k}">
-        <div class="trait-name">${k}</div>
-        <div class="trait-controls">
-          <button class="trait-btn" data-d="-5">−5</button>
-          <button class="trait-btn" data-d="-1">−1</button>
-          <div class="trait-value">${val}</div>
-          <button class="trait-btn" data-d="1">+1</button>
-          <button class="trait-btn" data-d="5">+5</button>
-        </div>
-        ${beforeExtra}
-        ${extra}
-        ${afterExtra}
-      </div>`;
-    }).join('');
 
-    const total = KEYS.reduce((sum,k)=>sum+(data[k]||0)+(bonus[k]||0)+(maskBonus[k]||0),0);
+      states.set(key, {
+        key,
+        value: val,
+        count: counts[key] || 0,
+        before,
+        extras,
+        after
+      });
+    });
 
-    const lvlMap = { Novis: 1, 'Gesäll': 2, 'Mästare': 3 };
+    const total = TRAIT_KEYS.reduce((sum, key) => sum + (vals[key] || 0), 0);
+    const lvlMap = { Novis: 1, 'Ges\u00e4ll': 2, 'M\u00e4stare': 3 };
     let maxTot = 80;
     list.forEach(it => {
-      if (it.namn === 'Exceptionellt karaktärsdrag') {
-        maxTot += lvlMap[it.nivå] || 0;
+      if (it.namn === 'Exceptionellt karakt\u00e4rsdrag') {
+        maxTot += lvlMap[it.niv\u00e5] || 0;
       }
     });
-    const inv = storeHelper.getInventory(store);
+    const inv = storeHelper.getInventory(store) || [];
     inv.forEach(row => {
-      if (row.id === 'l9' && row.trait) maxTot += 1;
+      if (row && row.id === 'l9' && row.trait) maxTot += 1;
     });
-    if (dom.traitsTot) dom.traitsTot.textContent = total;
-    if (dom.traitsMax) dom.traitsMax.textContent = maxTot;
-    const parent = dom.traitsTot.closest('.traits-total');
-    if (parent) {
+
+    let parentClass = '';
+    if (total === maxTot) parentClass = 'good';
+    else if (total < maxTot) parentClass = 'under';
+    else parentClass = 'over';
+
+    return { states, total, maxTot, parentClass };
+  }
+
+  function ensureTraitNode(key) {
+    if (traitNodes.has(key)) return traitNodes.get(key);
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'trait';
+    wrapper.dataset.key = key;
+
+    const nameEl = document.createElement('div');
+    nameEl.className = 'trait-name';
+    nameEl.textContent = key;
+
+    const controlsEl = document.createElement('div');
+    controlsEl.className = 'trait-controls';
+    const makeBtn = (delta, label) => {
+      const btn = document.createElement('button');
+      btn.className = 'trait-btn';
+      btn.dataset.d = String(delta);
+      btn.textContent = label;
+      return btn;
+    };
+    const btnMinus5 = makeBtn(-5, '−5');
+    const btnMinus1 = makeBtn(-1, '−1');
+    const valueEl = document.createElement('div');
+    valueEl.className = 'trait-value';
+    const btnPlus1 = makeBtn(1, '+1');
+    const btnPlus5 = makeBtn(5, '+5');
+    controlsEl.append(btnMinus5, btnMinus1, valueEl, btnPlus1, btnPlus5);
+
+    const anchor = document.createComment('trait-anchor');
+
+    const countBtn = document.createElement('button');
+    countBtn.className = 'trait-count';
+    countBtn.dataset.trait = key;
+
+    wrapper.append(nameEl, controlsEl, anchor);
+    dom.traits.appendChild(wrapper);
+
+    const entry = {
+      key,
+      wrapper,
+      controlsEl,
+      valueEl,
+      anchor,
+      countBtn,
+      extraPool: []
+    };
+
+    traitNodes.set(key, entry);
+    return entry;
+  }
+
+  function syncTraitNode(entry, state) {
+    if (!entry || !state) return;
+
+    entry.valueEl.textContent = String(state.value ?? 0);
+    entry.countBtn.dataset.trait = state.key;
+    entry.countBtn.textContent = `Förmågor: ${state.count}`;
+
+    const desired = [];
+    let extraIdx = 0;
+    const useExtra = text => {
+      let el = entry.extraPool[extraIdx];
+      if (!el) {
+        el = document.createElement('div');
+        el.className = 'trait-extra';
+        entry.extraPool[extraIdx] = el;
+      }
+      el.textContent = text;
+      desired.push(el);
+      extraIdx += 1;
+    };
+    const pushDescriptor = desc => {
+      if (!desc) return;
+      if (desc.type === 'count') {
+        desired.push(entry.countBtn);
+      } else if (desc.type === 'extra') {
+        useExtra(desc.text);
+      }
+    };
+
+    state.before.forEach(pushDescriptor);
+    state.extras.forEach(pushDescriptor);
+    state.after.forEach(pushDescriptor);
+
+    const parent = entry.wrapper;
+    const ref = entry.anchor;
+
+    desired.forEach(node => {
+      parent.insertBefore(node, ref);
+    });
+
+    const keep = new Set(desired);
+    let cur = entry.controlsEl.nextSibling;
+    while (cur && cur !== ref) {
+      const next = cur.nextSibling;
+      if (!keep.has(cur)) parent.removeChild(cur);
+      cur = next;
+    }
+  }
+
+  function updateTotals(total, maxTot, className) {
+    if (dom.traitsTot && lastTotals.total !== total) {
+      dom.traitsTot.textContent = String(total);
+    }
+    if (dom.traitsMax && lastTotals.maxTot !== maxTot) {
+      dom.traitsMax.textContent = String(maxTot);
+    }
+    const parent = dom.traitsTot ? dom.traitsTot.closest('.traits-total') : null;
+    if (parent && lastTotals.className !== className) {
       parent.classList.remove('good','under','over');
-      if (total === maxTot) {
-        parent.classList.add('good');
-      } else if (total < maxTot) {
-        parent.classList.add('under');
-      } else {
-        parent.classList.add('over');
+      if (className) parent.classList.add(className);
+    }
+    lastTotals = { total, maxTot, className };
+  }
+
+  function renderTraits(options){
+    if (!dom.traits) return;
+
+    const opts = normalizeRenderOptions(options);
+    const config = TRAIT_RENDER_EVENT_MAP[opts.source] || TRAIT_RENDER_EVENT_MAP.default;
+    const firstRender = traitNodes.size === 0;
+
+    const partialCandidates = (config.mode === 'partial' && !opts.forceFull)
+      ? opts.changedTraits
+      : [];
+    const hasPartialTargets = partialCandidates.length > 0;
+    const needsFull = opts.forceFull || firstRender || config.mode !== 'partial' || !hasPartialTargets;
+
+    if (firstRender) {
+      while (dom.traits.firstChild) {
+        dom.traits.removeChild(dom.traits.firstChild);
       }
     }
 
+    TRAIT_KEYS.forEach(ensureTraitNode);
+
+    const snapshot = computeTraitSnapshot();
+    const states = snapshot.states;
+
+    const changedKeys = new Set();
+    if (needsFull) {
+      TRAIT_KEYS.forEach(key => changedKeys.add(key));
+    } else {
+      partialCandidates.forEach(key => changedKeys.add(key));
+    }
+
+    TRAIT_KEYS.forEach(key => {
+      const prev = lastTraitState.get(key);
+      const next = states.get(key);
+      if (!isTraitStateEqual(prev, next)) {
+        changedKeys.add(key);
+      }
+    });
+
+    TRAIT_KEYS.forEach(key => {
+      if (!changedKeys.has(key)) return;
+      const entry = ensureTraitNode(key);
+      const next = states.get(key);
+      if (next) syncTraitNode(entry, next);
+    });
+
+    lastTraitState = states;
+
+    updateTotals(snapshot.total, snapshot.maxTot, snapshot.parentClass);
+
     if (dom.traitStats) {
-      dom.traitStats.textContent = "";
+      dom.traitStats.textContent = '';
     }
   }
 
@@ -317,7 +584,7 @@
       const next  = Math.max(0, (t[key] || 0) + d);
       t[key] = Math.max(min - bonus, next);
       storeHelper.setTraits(store, t);
-      renderTraits();
+      renderTraits({ source: 'traits:adjust', changedTraits: [key] });
     });
   }
 


### PR DESCRIPTION
## Summary
- document trait render event sources and track whether each needs full or partial updates
- rebuild renderTraits to reuse DOM nodes and only sync changed trait entries while keeping totals in sync
- update all callers to provide render reasons so inventory and list changes trigger full refreshes while button presses stay partial

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d054dc66bc8323a4f3bec24016e974