### PR TITLE
Gracefully handle blocked localStorage in UI panels

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -12,6 +12,12 @@
   const INV_TOOLS_KEY = 'invToolsOpen';
   const INV_INFO_KEY  = 'invInfoOpen';
   const STACKABLE_IDS = ['l1','l11','l27','l6','l12','l13','l28','l30'];
+  const safeStorageGet = typeof window.safeLocalStorageGet === 'function'
+    ? window.safeLocalStorageGet
+    : (key, fallback = null) => ({ value: fallback, found: false });
+  const safeStorageSet = typeof window.safeLocalStorageSet === 'function'
+    ? window.safeLocalStorageSet
+    : () => false;
   // Local helper to safely access the toolbar shadow root without relying on main.js scope
   const getToolbarRoot = () => {
     const el = document.querySelector('shared-toolbar');
@@ -2194,8 +2200,12 @@ function openVehiclePopup(preselectId, precheckedPaths) {
   function buildFormalCards(openKeys, vehicles, cash, summary) {
     const toolsKey = '__tools__';
     const infoKey  = '__info__';
-    const toolsLS = localStorage.getItem(INV_TOOLS_KEY) === '1';
-    const infoLS  = localStorage.getItem(INV_INFO_KEY) === '1';
+    const defaultTools = openKeys.has(toolsKey) ? '1' : '0';
+    const defaultInfo  = openKeys.has(infoKey) ? '1' : '0';
+    const { value: toolsVal } = safeStorageGet(INV_TOOLS_KEY, defaultTools);
+    const { value: infoVal }  = safeStorageGet(INV_INFO_KEY, defaultInfo);
+    const toolsLS = toolsVal === '1';
+    const infoLS  = infoVal === '1';
     if (toolsLS) openKeys.add(toolsKey); else openKeys.delete(toolsKey);
     if (infoLS)  openKeys.add(infoKey);  else openKeys.delete(infoKey);
     const vehicleBtns = vehicles
@@ -2428,8 +2438,8 @@ function openVehiclePopup(preselectId, precheckedPaths) {
       const { toolsKey, infoKey, toolsCard, infoCard } = buildFormalCards(openKeys, vehicles, cash, summary);
       ensureFormalCard(toolsKey, toolsCard, openKeys.has(toolsKey));
       ensureFormalCard(infoKey, infoCard, openKeys.has(infoKey));
-      localStorage.setItem(INV_TOOLS_KEY, openKeys.has(toolsKey) ? '1' : '0');
-      localStorage.setItem(INV_INFO_KEY,  openKeys.has(infoKey) ? '1' : '0');
+      safeStorageSet(INV_TOOLS_KEY, openKeys.has(toolsKey) ? '1' : '0');
+      safeStorageSet(INV_INFO_KEY,  openKeys.has(infoKey) ? '1' : '0');
       dom.unusedOut = $T('unusedOut');
       dom.dragToggle = $T('dragToggle');
     }
@@ -2578,9 +2588,9 @@ function openVehiclePopup(preselectId, precheckedPaths) {
         cards.forEach(li => {
           li.classList.toggle('compact', anyOpen);
           if (li.dataset.special === '__tools__') {
-            localStorage.setItem(INV_TOOLS_KEY, anyOpen ? '0' : '1');
+            safeStorageSet(INV_TOOLS_KEY, anyOpen ? '0' : '1');
           } else if (li.dataset.special === '__info__') {
-            localStorage.setItem(INV_INFO_KEY, anyOpen ? '0' : '1');
+            safeStorageSet(INV_INFO_KEY, anyOpen ? '0' : '1');
           }
         });
         updateCollapseBtnState();
@@ -3070,7 +3080,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
             const isCompact = li.classList.toggle('compact');
             updateCollapseBtnState();
             const key = li.dataset.special === '__tools__' ? INV_TOOLS_KEY : INV_INFO_KEY;
-            localStorage.setItem(key, isCompact ? '0' : '1');
+            safeStorageSet(key, isCompact ? '0' : '1');
           }
           return;
         }

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -7,6 +7,12 @@
    =========================================================== */
 const FILTER_TOOLS_KEY = 'filterToolsOpen';
 const FILTER_SETTINGS_KEY = 'filterSettingsOpen';
+const safeStorageGet = typeof window.safeLocalStorageGet === 'function'
+  ? window.safeLocalStorageGet
+  : (key, fallback = null) => ({ value: fallback, found: false });
+const safeStorageSet = typeof window.safeLocalStorageSet === 'function'
+  ? window.safeLocalStorageSet
+  : () => false;
 
 class SharedToolbar extends HTMLElement {
   constructor() {
@@ -1076,14 +1082,16 @@ class SharedToolbar extends HTMLElement {
   restoreFilterCollapse() {
     const toolsCard = this.shadowRoot.getElementById('filterFormalCard');
     const settingsCard = this.shadowRoot.getElementById('filterSettingsCard');
-    const toolsVal = localStorage.getItem(FILTER_TOOLS_KEY);
-    const settingsVal = localStorage.getItem(FILTER_SETTINGS_KEY);
+    const toolsDefault = toolsCard && !toolsCard.classList.contains('compact') ? '1' : '0';
+    const settingsDefault = settingsCard && !settingsCard.classList.contains('compact') ? '1' : '0';
+    const { value: toolsVal, found: hasTools } = safeStorageGet(FILTER_TOOLS_KEY, toolsDefault);
+    const { value: settingsVal, found: hasSettings } = safeStorageGet(FILTER_SETTINGS_KEY, settingsDefault);
     const toolsOpen = toolsVal === '1';
     const settingsOpen = settingsVal === '1';
     if (toolsCard) toolsCard.classList.toggle('compact', !toolsOpen);
     if (settingsCard) settingsCard.classList.toggle('compact', !settingsOpen);
-    if (toolsVal === null) localStorage.setItem(FILTER_TOOLS_KEY, toolsOpen ? '1' : '0');
-    if (settingsVal === null) localStorage.setItem(FILTER_SETTINGS_KEY, settingsOpen ? '1' : '0');
+    if (!hasTools) safeStorageSet(FILTER_TOOLS_KEY, toolsOpen ? '1' : '0');
+    if (!hasSettings) safeStorageSet(FILTER_SETTINGS_KEY, settingsOpen ? '1' : '0');
   }
 
   updateFilterCollapseBtn() {
@@ -1105,7 +1113,7 @@ class SharedToolbar extends HTMLElement {
         if (card) {
           const isCompact = card.classList.toggle('compact');
           const key = card.id === 'filterFormalCard' ? FILTER_TOOLS_KEY : FILTER_SETTINGS_KEY;
-          localStorage.setItem(key, isCompact ? '0' : '1');
+          safeStorageSet(key, isCompact ? '0' : '1');
           this.updateFilterCollapseBtn();
         }
       }
@@ -1126,9 +1134,9 @@ class SharedToolbar extends HTMLElement {
       cards.forEach(c => {
         c.classList.toggle('compact', anyOpen);
         if (c.id === 'filterFormalCard') {
-          localStorage.setItem(FILTER_TOOLS_KEY, c.classList.contains('compact') ? '0' : '1');
+          safeStorageSet(FILTER_TOOLS_KEY, c.classList.contains('compact') ? '0' : '1');
         } else if (c.id === 'filterSettingsCard') {
-          localStorage.setItem(FILTER_SETTINGS_KEY, c.classList.contains('compact') ? '0' : '1');
+          safeStorageSet(FILTER_SETTINGS_KEY, c.classList.contains('compact') ? '0' : '1');
         }
       });
       // Ensure non-collapsible cards remain open
@@ -1144,7 +1152,7 @@ class SharedToolbar extends HTMLElement {
       if (card) {
         const isCompact = card.classList.toggle('compact');
         const key = card.id === 'filterFormalCard' ? FILTER_TOOLS_KEY : FILTER_SETTINGS_KEY;
-        localStorage.setItem(key, isCompact ? '0' : '1');
+        safeStorageSet(key, isCompact ? '0' : '1');
         this.updateFilterCollapseBtn();
       }
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -24,6 +24,46 @@
   ];
   const SBASE = 10, OBASE = 10;
 
+  function safeLocalStorageGet(key, fallback = null) {
+    const result = { value: fallback, found: false };
+    if (!key || typeof key !== 'string') return result;
+    try {
+      const storage = window.localStorage;
+      if (!storage) return result;
+      const raw = storage.getItem(key);
+      if (raw === null || raw === undefined) return result;
+      result.value = raw;
+      result.found = true;
+      return result;
+    } catch (err) {
+      return result;
+    }
+  }
+
+  function safeLocalStorageSet(key, value) {
+    if (!key || typeof key !== 'string') return false;
+    try {
+      const storage = window.localStorage;
+      if (!storage) return false;
+      storage.setItem(key, value);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
+  function safeLocalStorageRemove(key) {
+    if (!key || typeof key !== 'string') return false;
+    try {
+      const storage = window.localStorage;
+      if (!storage) return false;
+      storage.removeItem(key);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
   // Konvertera ett penningobjekt till totalt antal örtegar
   function moneyToO(m) {
     m = m || {};
@@ -419,4 +459,7 @@
   window.catComparator = catComparator;
   window.catName = catName;
   window.lookupEntry = lookupEntry;
+  window.safeLocalStorageGet = safeLocalStorageGet;
+  window.safeLocalStorageSet = safeLocalStorageSet;
+  window.safeLocalStorageRemove = safeLocalStorageRemove;
 })(window);


### PR DESCRIPTION
## Summary
- add shared helpers in `utils.js` that wrap localStorage access with fallbacks
- update inventory utilities to rely on the safe storage helpers for card state persistence
- use the safe storage helpers for filter panel toggles in the shared toolbar so the UI stays responsive even if persistence fails

## Testing
- ⚠️ not run (static site with no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d0f3bd8d5c8323b8023c19c9bb33ca