### PR TITLE
Rework entry card layout for abilities

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -791,6 +791,19 @@ input:focus, select:focus, textarea:focus {
   transition: outline .1s ease, outline-offset .1s ease, box-shadow .1s ease;
 }
 
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .6rem;
+}
+
+.card-title-actions {
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+}
+
 .card.vehicle-over {
   background: var(--danger-bg);
 }
@@ -868,9 +881,51 @@ input:focus, select:focus, textarea:focus {
   white-space: nowrap;
   flex: 0 0 auto;
 }
-.card-title .xp-cost {
+.card-level-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .45rem;
+}
+
+.card-level-row .card-level {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.card-level-row .card-xp {
   margin-left: auto;
-  align-self: center;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+}
+
+.card-tags-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .35rem .45rem;
+}
+
+.card-tags-row > .tags,
+.card-tags-row > .entry-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+}
+
+.card-tags-row .entry-tags {
+  flex-direction: row;
+  max-height: none;
+  width: auto;
+  align-content: flex-start;
+}
+
+.card-aux-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .35rem;
 }
 .tag.xp-cost {
   font-size: .85rem;
@@ -888,6 +943,10 @@ input:focus, select:focus, textarea:focus {
 }
 .card.compact .entry-tags-block,
 .card.compact .entry-tags-mobile {
+  display: none !important;
+}
+.card.compact .card-tags-row,
+.card.compact .card-aux-row {
   display: none !important;
 }
 

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1199,8 +1199,9 @@ function initCharacter() {
           ? `<button data-act="${editAction}" class="char-btn" data-name="${p.namn}"${idAttr}>✏️</button>`
           : '';
         const infoBtnHtml = showInfo ? infoBtn : '';
+        const titleActions = [];
         const buttonParts = [];
-        if (infoBtnHtml) buttonParts.push(infoBtnHtml);
+        if (infoBtnHtml) titleActions.push(infoBtnHtml);
         if (editBtn) buttonParts.push(editBtn);
         if (multi) {
           const isDisadv = typesList.includes('Nackdel');
@@ -1253,6 +1254,7 @@ function initCharacter() {
           levelHtml: hideDetails ? '' : lvlSel,
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '',
           leftSections,
+          titleActions,
           buttonSections: buttonParts
         });
 

--- a/js/entry-card.js
+++ b/js/entry-card.js
@@ -36,7 +36,8 @@
       levelHtml = '',
       descHtml = '',
       leftSections = [],
-      buttonSections = []
+      buttonSections = [],
+      titleActions = []
     } = options;
 
     const li = document.createElement('li');
@@ -47,13 +48,38 @@
 
     applyDataset(li, dataset);
 
-    const tagsBlock = tagsHtml ? `<div class="tags entry-tags-block">${tagsHtml}</div>` : '';
-    const controlsHtml = wrapControls(leftSections, buttonSections);
+    const leftParts = Array.isArray(leftSections) ? leftSections.filter(Boolean) : [];
+    const buttonParts = Array.isArray(buttonSections) ? buttonSections.filter(Boolean) : [];
+    const titleActionParts = Array.isArray(titleActions) ? titleActions.filter(Boolean) : [];
+
+    const tagParts = [];
+    const auxParts = [];
+    leftParts.forEach(part => {
+      const str = typeof part === 'string' ? part : '';
+      if (str.includes('entry-tags')) tagParts.push(part);
+      else auxParts.push(part);
+    });
+
+    const tagSources = [];
+    if (tagsHtml) tagSources.push(`<div class="tags entry-tags-block">${tagsHtml}</div>`);
+    if (tagParts.length) tagSources.push(...tagParts);
+    const tagsRow = tagSources.length ? `<div class="card-tags-row">${tagSources.join('')}</div>` : '';
+
+    const auxRow = auxParts.length ? `<div class="card-aux-row">${auxParts.join('')}</div>` : '';
+    const levelRow = (levelHtml || xpHtml)
+      ? `<div class="card-level-row"><div class="card-level">${levelHtml || ''}</div>${xpHtml ? `<div class="card-xp">${xpHtml}</div>` : ''}</div>`
+      : '';
+    const actionsHtml = titleActionParts.length
+      ? `<div class="card-title-actions">${titleActionParts.join('')}</div>`
+      : '';
+    const headerHtml = `<div class="card-header"><div class="card-title"><span>${nameHtml}</span></div>${actionsHtml}</div>`;
+    const controlsHtml = wrapControls([], buttonParts);
 
     li.innerHTML = `
-      <div class="card-title"><span>${nameHtml}</span>${xpHtml}</div>
-      ${tagsBlock}
-      ${levelHtml || ''}
+      ${headerHtml}
+      ${levelRow}
+      ${tagsRow}
+      ${auxRow}
       ${descHtml || ''}
       ${controlsHtml}
     `;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -671,26 +671,27 @@ function initIndex() {
           ? `<button class="char-btn" data-elite-req="${p.namn}">🏋🏻‍♂️</button>`
           : '';
         const allowAdd = !(isService(p) || isEmployment(p));
-        const buttonGroupParts = [];
-        if (showInfo) buttonGroupParts.push(infoBtn);
-        if (editBtn) buttonGroupParts.push(editBtn);
+        const titleActions = [];
+        const actionButtons = [];
+        if (showInfo) titleActions.push(infoBtn);
+        if (editBtn) actionButtons.push(editBtn);
         if (allowAdd) {
           if (multi) {
             if (count > 0) {
-              buttonGroupParts.push(`<button data-act="del" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`);
-              buttonGroupParts.push(`<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">➖</button>`);
-              if (count < limit) buttonGroupParts.push(`<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
+              actionButtons.push(`<button data-act="del" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`);
+              actionButtons.push(`<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">➖</button>`);
+              if (count < limit) actionButtons.push(`<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
             } else {
-              buttonGroupParts.push(`<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
+              actionButtons.push(`<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
             }
           } else {
             const mainBtn = inChar
               ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
               : `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`;
-            buttonGroupParts.push(mainBtn);
+            actionButtons.push(mainBtn);
           }
         }
-        if (eliteBtn) buttonGroupParts.push(eliteBtn);
+        if (eliteBtn) actionButtons.push(eliteBtn);
         const leftSections = [];
         if (metaBadges) leftSections.push(metaBadges);
         if (shouldDockTags && dockedTagsHtml) leftSections.push(dockedTagsHtml);
@@ -708,7 +709,8 @@ function initIndex() {
           levelHtml: hideDetails ? '' : lvlSel,
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${cardDesc}</div>` : '',
           leftSections,
-          buttonSections: buttonGroupParts
+          titleActions,
+          buttonSections: actionButtons
         });
         listEl.appendChild(li);
         if (searchActive && terms.length) {


### PR DESCRIPTION
## Summary
- restructure the entry card template so the info action sits on the title row, level/xp share a row, and controls sit at the bottom
- update list rendering to treat the info icon as a title action while keeping other controls in the action row
- refresh card styling to support dedicated rows for level, tags, and auxiliary metadata

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d105817fcc83238f9eca9dfa93ac55