### PR TITLE
Make entry info button icon-only

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -804,6 +804,21 @@ input:focus, select:focus, textarea:focus {
   gap: .35rem;
 }
 
+.card-title-actions .char-btn.info-btn {
+  background: none;
+  color: var(--txt);
+  padding: 0;
+}
+
+.card-title-actions .char-btn.info-btn:active {
+  transform: none;
+}
+
+.card-title-actions .char-btn.info-btn:focus-visible {
+  outline: 2px solid var(--txt);
+  outline-offset: 2px;
+}
+
 .card.vehicle-over {
   background: var(--danger-bg);
 }

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1179,7 +1179,7 @@ function initCharacter() {
           bodyHtml: infoBodyHtml,
           meta: infoMeta
         });
-        const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
+        const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
 
         const multi = (p.kan_införskaffas_flera_gånger && typesList.some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
         const total = storeHelper.getCurrentList(store).filter(x=>x.namn===p.namn && !x.trait).length;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -470,7 +470,7 @@ function initIndex() {
       cats[cat].forEach(p=>{
         if (p.kolumner && p.rader) {
           const infoHtml = tabellInfoHtml(p);
-          const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info">ℹ️</button>`;
+          const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info">ℹ️</button>`;
           const tagsHtml = (p.taggar?.typ || [])
             .map(t => `<span class="tag">${t}</span>`)
             .join(' ');
@@ -646,7 +646,7 @@ function initIndex() {
           bodyHtml: infoBodyHtml,
           meta: infoMeta
         });
-        const infoBtn = `<button class="char-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
+        const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
         const multi = isInv(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         let count;
         if (isInv(p)) {


### PR DESCRIPTION
## Summary
- add a dedicated `info-btn` class to info buttons on entry cards so they can be styled independently
- remove the accent background from entry header info buttons so that they appear as plain clickable emojis

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d10ad5053c8323a205034707e31619