### PR TITLE
Adjust entry card layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -798,6 +798,19 @@ input:focus, select:focus, textarea:focus {
   gap: .6rem;
 }
 
+.card-header-right {
+  display: flex;
+  align-items: center;
+  gap: .45rem;
+  margin-left: auto;
+}
+
+.card-xp {
+  display: flex;
+  align-items: center;
+  gap: .35rem;
+}
+
 .card-title-actions {
   display: flex;
   align-items: center;
@@ -908,11 +921,12 @@ input:focus, select:focus, textarea:focus {
   min-width: 0;
 }
 
-.card-level-row .card-xp {
-  margin-left: auto;
+.card-level-row .card-level-actions {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
+  gap: .35rem;
+  margin-left: auto;
 }
 
 .card-tags-row {

--- a/js/entry-card.js
+++ b/js/entry-card.js
@@ -49,7 +49,7 @@
     applyDataset(li, dataset);
 
     const leftParts = Array.isArray(leftSections) ? leftSections.filter(Boolean) : [];
-    const buttonParts = Array.isArray(buttonSections) ? buttonSections.filter(Boolean) : [];
+    let buttonParts = Array.isArray(buttonSections) ? buttonSections.filter(Boolean) : [];
     const titleActionParts = Array.isArray(titleActions) ? titleActions.filter(Boolean) : [];
 
     const tagParts = [];
@@ -66,13 +66,21 @@
     const tagsRow = tagSources.length ? `<div class="card-tags-row">${tagSources.join('')}</div>` : '';
 
     const auxRow = auxParts.length ? `<div class="card-aux-row">${auxParts.join('')}</div>` : '';
-    const levelRow = (levelHtml || xpHtml)
-      ? `<div class="card-level-row"><div class="card-level">${levelHtml || ''}</div>${xpHtml ? `<div class="card-xp">${xpHtml}</div>` : ''}</div>`
+    let inlineAddButton = '';
+    if (levelHtml && buttonParts.length) {
+      const addIdx = buttonParts.findIndex(part => typeof part === 'string' && /data-act=['"]add['"]/.test(part));
+      if (addIdx !== -1) {
+        inlineAddButton = buttonParts.splice(addIdx, 1)[0];
+      }
+    }
+    const levelRow = (levelHtml || inlineAddButton)
+      ? `<div class="card-level-row"><div class="card-level">${levelHtml || ''}</div>${inlineAddButton ? `<div class="card-level-actions">${inlineAddButton}</div>` : ''}</div>`
       : '';
-    const actionsHtml = titleActionParts.length
-      ? `<div class="card-title-actions">${titleActionParts.join('')}</div>`
-      : '';
-    const headerHtml = `<div class="card-header"><div class="card-title"><span>${nameHtml}</span></div>${actionsHtml}</div>`;
+    const headerExtras = [];
+    if (xpHtml) headerExtras.push(`<div class="card-xp">${xpHtml}</div>`);
+    if (titleActionParts.length) headerExtras.push(`<div class="card-title-actions">${titleActionParts.join('')}</div>`);
+    const headerRight = headerExtras.length ? `<div class="card-header-right">${headerExtras.join('')}</div>` : '';
+    const headerHtml = `<div class="card-header"><div class="card-title"><span>${nameHtml}</span></div>${headerRight}</div>`;
     const controlsHtml = wrapControls([], buttonParts);
 
     li.innerHTML = `


### PR DESCRIPTION
## Summary
- move the XP pill into the card header so it sits at the top-right while keeping the info button placement
- inline the add button with the level selector and ensure the tag row renders immediately beneath that control row
- refresh supporting styles for the header, inline actions, and XP wrapper to match the new layout

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d10f3d693483239bfaa025fa14f01e