### PR TITLE
Show type and tradition tags on cards

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1156,17 +1156,28 @@ function initCharacter() {
         const xpTag = `<span class="tag xp-cost">Erf: ${xpText}</span>`;
         const typesList = Array.isArray(p.taggar?.typ) ? p.taggar.typ : [];
         const filterTagData = [];
+        const primaryTagParts = [];
         typesList
           .filter(Boolean)
-          .forEach((t, idx) => filterTagData.push({ section: 'typ', value: t, label: t, hidden: idx === 0 }));
+          .forEach((t, idx) => {
+            const tag = { section: 'typ', value: t, label: t, hidden: idx === 0 };
+            filterTagData.push(tag);
+            primaryTagParts.push(renderFilterTag(tag));
+          });
         const trTags = explodeTags(p.taggar?.ark_trad);
         const arkList = trTags.length ? trTags : (Array.isArray(p.taggar?.ark_trad) ? ['Traditionslös'] : []);
-        arkList.forEach(t => filterTagData.push({ section: 'ark', value: t, label: t }));
+        arkList.forEach(t => {
+          const tag = { section: 'ark', value: t, label: t };
+          filterTagData.push(tag);
+          primaryTagParts.push(renderFilterTag(tag));
+        });
         (p.taggar?.test || [])
           .filter(Boolean)
           .forEach(t => filterTagData.push({ section: 'test', value: t, label: t }));
+        const primaryTagsHtml = primaryTagParts.join(' ');
         const visibleTagData = filterTagData.filter(tag => !tag.hidden);
-        const tagHtmlParts = visibleTagData.map(tag => renderFilterTag(tag));
+        const dockableTagData = visibleTagData.filter(tag => tag.section !== 'typ' && tag.section !== 'ark');
+        const tagHtmlParts = dockableTagData.map(tag => renderFilterTag(tag));
         const infoTagHtmlParts = filterTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = tagHtmlParts.join(' ');
         const infoTagsHtml = [xpTag]
@@ -1234,9 +1245,9 @@ function initCharacter() {
         }
         const dockPrimary = (p.taggar?.typ || [])[0] || '';
         const shouldDockTags = DOCK_TAG_TYPES.has(dockPrimary);
-        const dockedTagsHtml = shouldDockTags ? renderDockedTags(visibleTagData) : '';
-        const mobileTagsHtml = (!compact && !shouldDockTags && visibleTagData.length)
-          ? renderDockedTags(visibleTagData, 'entry-tags-mobile')
+        const dockedTagsHtml = shouldDockTags ? renderDockedTags(dockableTagData) : '';
+        const mobileTagsHtml = (!compact && !shouldDockTags && dockableTagData.length)
+          ? renderDockedTags(dockableTagData, 'entry-tags-mobile')
           : '';
         const leftSections = [];
         if (shouldDockTags && dockedTagsHtml) leftSections.push(dockedTagsHtml);
@@ -1250,6 +1261,7 @@ function initCharacter() {
           dataset,
           nameHtml: `${p.namn}${badge}`,
           xpHtml,
+          primaryTagsHtml,
           tagsHtml: (!compact && !shouldDockTags && tagsHtml) ? tagsHtml : '',
           levelHtml: hideDetails ? '' : lvlSel,
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '',

--- a/js/entry-card.js
+++ b/js/entry-card.js
@@ -33,6 +33,7 @@
       nameHtml = '',
       xpHtml = '',
       tagsHtml = '',
+      primaryTagsHtml = '',
       levelHtml = '',
       descHtml = '',
       leftSections = [],
@@ -61,6 +62,7 @@
     });
 
     const tagSources = [];
+    if (primaryTagsHtml) tagSources.push(`<div class="tags entry-tags-block primary-tags">${primaryTagsHtml}</div>`);
     if (tagsHtml) tagSources.push(`<div class="tags entry-tags-block">${tagsHtml}</div>`);
     if (tagParts.length) tagSources.push(...tagParts);
     const tagsRow = tagSources.length ? `<div class="card-tags-row">${tagSources.join('')}</div>` : '';

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -595,17 +595,28 @@ function initIndex() {
         const xpTag = (xpVal != null || isElityrke(p)) ? `<span class="tag xp-cost">Erf: ${xpText}</span>` : '';
         const renderFilterTag = (tag, extra = '') => `<span class="tag filter-tag" data-section="${tag.section}" data-val="${tag.value}"${extra}>${tag.label}</span>`;
         const filterTagData = [];
+        const primaryTagParts = [];
         (p.taggar?.typ || [])
           .filter(Boolean)
-          .forEach((t, idx) => filterTagData.push({ section: 'typ', value: t, label: QUAL_TYPE_MAP[t] || t, hidden: idx === 0 }));
+          .forEach((t, idx) => {
+            const tag = { section: 'typ', value: t, label: QUAL_TYPE_MAP[t] || t, hidden: idx === 0 };
+            filterTagData.push(tag);
+            primaryTagParts.push(renderFilterTag(tag));
+          });
         const trTags = explodeTags(p.taggar?.ark_trad);
         const arkList = trTags.length ? trTags : (Array.isArray(p.taggar?.ark_trad) ? ['Traditionslös'] : []);
-        arkList.forEach(t => filterTagData.push({ section: 'ark', value: t, label: t }));
+        arkList.forEach(t => {
+          const tag = { section: 'ark', value: t, label: t };
+          filterTagData.push(tag);
+          primaryTagParts.push(renderFilterTag(tag));
+        });
         (p.taggar?.test || [])
           .filter(Boolean)
           .forEach(t => filterTagData.push({ section: 'test', value: t, label: t }));
+        const primaryTagsHtml = primaryTagParts.join(' ');
         const visibleTagData = filterTagData.filter(tag => !tag.hidden);
-        const filterTagHtml = visibleTagData.map(tag => renderFilterTag(tag));
+        const dockableTagData = visibleTagData.filter(tag => tag.section !== 'typ' && tag.section !== 'ark');
+        const filterTagHtml = dockableTagData.map(tag => renderFilterTag(tag));
         const infoFilterTagHtml = filterTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = filterTagHtml.join(' ');
         const infoTagsHtml = [xpTag].concat(infoFilterTagHtml).filter(Boolean).join(' ');
@@ -616,9 +627,9 @@ function initIndex() {
           const cls = ['entry-tags', extraClass].filter(Boolean).join(' ');
           return `<div class="${cls}">${tags.map(tag => renderFilterTag(tag)).join('')}</div>`;
         };
-        const dockedTagsHtml = shouldDockTags ? renderDockedTags(visibleTagData) : '';
-        const mobileTagsHtml = (!compact && !shouldDockTags && visibleTagData.length)
-          ? renderDockedTags(visibleTagData, 'entry-tags-mobile')
+        const dockedTagsHtml = shouldDockTags ? renderDockedTags(dockableTagData) : '';
+        const mobileTagsHtml = (!compact && !shouldDockTags && dockableTagData.length)
+          ? renderDockedTags(dockableTagData, 'entry-tags-mobile')
           : '';
         const xpHtml = (xpVal != null || isElityrke(p)) ? `<span class="xp-cost">Erf: ${xpText}</span>` : '';
         // Compact meta badges (P/V/level) using short labels for mobile space
@@ -705,6 +716,7 @@ function initIndex() {
           dataset,
           nameHtml: `${p.namn}${badge}`,
           xpHtml,
+          primaryTagsHtml,
           tagsHtml: (!compact && !shouldDockTags && tagsHtml) ? tagsHtml : '',
           levelHtml: hideDetails ? '' : lvlSel,
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${cardDesc}</div>` : '',


### PR DESCRIPTION
## Summary
- add a dedicated primary tag slot to entry cards so type/tradition tags can always be displayed
- compute and inject type and Ark_trad tags for each card in the index view while reserving docking for secondary tags
- mirror the same primary tag handling in the character view so the tags show up consistently across views

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1141fdf508323b232b50a6802d7b9