### PR TITLE
Align inline add/remove buttons for level selector entries

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -169,7 +169,8 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 .char-btn:active { transform: scale(.95); opacity: .7; }
 
 /* Kvadratiska kortkontroller (exkl. "Börja om?") */
-.card .inv-controls .char-btn:not([data-clear-filters]) {
+.card .inv-controls .char-btn:not([data-clear-filters]),
+.card-level-row .card-level-actions .char-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/js/entry-card.js
+++ b/js/entry-card.js
@@ -68,15 +68,17 @@
     const tagsRow = tagSources.length ? `<div class="card-tags-row">${tagSources.join('')}</div>` : '';
 
     const auxRow = auxParts.length ? `<div class="card-aux-row">${auxParts.join('')}</div>` : '';
-    let inlineAddButton = '';
+    let inlineLevelButton = '';
     if (levelHtml && buttonParts.length) {
-      const addIdx = buttonParts.findIndex(part => typeof part === 'string' && /data-act=['"]add['"]/.test(part));
-      if (addIdx !== -1) {
-        inlineAddButton = buttonParts.splice(addIdx, 1)[0];
+      const findIdx = (pattern) => buttonParts.findIndex(part => typeof part === 'string' && pattern.test(part));
+      let btnIdx = findIdx(/data-act=['"]add['"]);
+      if (btnIdx === -1) btnIdx = findIdx(/data-act=['"](rem|del)['"]);
+      if (btnIdx !== -1) {
+        inlineLevelButton = buttonParts.splice(btnIdx, 1)[0];
       }
     }
-    const levelRow = (levelHtml || inlineAddButton)
-      ? `<div class="card-level-row"><div class="card-level">${levelHtml || ''}</div>${inlineAddButton ? `<div class="card-level-actions">${inlineAddButton}</div>` : ''}</div>`
+    const levelRow = (levelHtml || inlineLevelButton)
+      ? `<div class="card-level-row"><div class="card-level">${levelHtml || ''}</div>${inlineLevelButton ? `<div class="card-level-actions">${inlineLevelButton}</div>` : ''}</div>`
       : '';
     const headerExtras = [];
     if (xpHtml) headerExtras.push(`<div class="card-xp">${xpHtml}</div>`);


### PR DESCRIPTION
## Summary
- inline the primary entry action (add/remove) next to the level selector so both buttons share the same placement
- reuse the square control button styling for inline action buttons to keep layout consistent

## Testing
- not run (project does not include automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d119d34fa883238d8d178ca086c549