### PR TITLE
Show locked level hint on index view

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1077,28 +1077,28 @@ input:focus, select:focus, textarea:focus {
 }
 
 .level-block.level-locked {
-  border-color: rgba(246, 65, 65, .45);
-  background: rgba(59, 28, 28, .55);
-  box-shadow: inset 0 0 0 1px rgba(246, 65, 65, .2);
+  border-color: rgba(246, 65, 65, .22);
+  background: rgba(59, 28, 28, .12);
+  box-shadow: inset 0 0 0 1px rgba(246, 65, 65, .08);
 }
 
 .level-block.level-locked summary {
-  color: #f8c9c4;
+  color: #e9d6d2;
 }
 
 .level-block.level-locked summary::after {
-  border-color: rgba(249, 170, 170, .85);
+  border-color: rgba(249, 188, 188, .42);
 }
 
 .level-block.level-locked .level-content {
-  border-top-color: rgba(246, 65, 65, .35);
+  border-top-color: rgba(246, 65, 65, .14);
 }
 
 .level-block.level-locked:hover,
 .level-block.level-locked:focus-within {
-  border-color: rgba(246, 65, 65, .65);
-  background: rgba(74, 31, 31, .7);
-  box-shadow: inset 0 0 0 1px rgba(246, 65, 65, .3);
+  border-color: rgba(246, 65, 65, .32);
+  background: rgba(74, 31, 31, .2);
+  box-shadow: inset 0 0 0 1px rgba(246, 65, 65, .14);
 }
 
 @media (max-width: 520px) {

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -491,9 +491,12 @@ function initIndex() {
         }
         return;
         }
+        const charEntry = charList.find(c => c.namn === p.namn);
+        const levelStr = typeof charEntry?.nivå === 'string' ? charEntry.nivå.trim() : '';
         const isEx = p.namn === 'Exceptionellt karakt\u00e4rsdrag';
-        const inChar = isEx ? false : charList.some(c=>c.namn===p.namn);
-        const curLvl = charList.find(c=>c.namn===p.namn)?.nivå
+        const charLevel = !isEx && levelStr ? levelStr : null;
+        const inChar = isEx ? false : !!charEntry;
+        const curLvl = charLevel
           || LVL.find(l => p.nivåer?.[l]) || 'Novis';
         const availLvls = LVL.filter(l => p.nivåer?.[l]);
         const lvlSel = availLvls.length > 1
@@ -502,7 +505,7 @@ function initIndex() {
             </select>`
           : '';
         const hideDetails = isRas(p) || isYrke(p) || isElityrke(p);
-        let desc = abilityHtml(p);
+        let desc = abilityHtml(p, charLevel || undefined);
         let cardDesc = desc;
         const infoMeta = [];
         let priceText = '';
@@ -587,7 +590,6 @@ function initIndex() {
         }
         let infoBodyHtml = desc;
         if (infoBodyExtras.length) infoBodyHtml += infoBodyExtras.join('');
-        const charEntry = charList.find(c => c.namn === p.namn);
         const xpSource = charEntry ? charEntry : { ...p, nivå: curLvl };
         const xpVal = (isInv(p) || isEmployment(p) || isService(p)) ? null : storeHelper.calcEntryXP(xpSource, charList);
         let xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';

--- a/js/text-format.js
+++ b/js/text-format.js
@@ -56,10 +56,11 @@
       orderedKeys = rawKeys.sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }));
     }
 
-    const isCharacterPage = typeof document !== 'undefined' && document.body?.dataset?.role === 'character';
+    const pageRole = typeof document !== 'undefined' ? document.body?.dataset?.role : '';
     const normalizedMax = typeof maxLevel === 'string' ? maxLevel : '';
     const highestUnlockedIdx = normalizedMax ? orderedKeys.indexOf(normalizedMax) : -1;
-    const applyLocks = isCharacterPage && normalizedMax && highestUnlockedIdx >= 0;
+    const allowLocks = normalizedMax && highestUnlockedIdx >= 0;
+    const applyLocks = allowLocks && (pageRole === 'character' || pageRole === 'index');
 
     const levelBlocks = [];
     orderedKeys.forEach((key, idx) => {


### PR DESCRIPTION
## Summary
- soften the locked level styling so it is just a subtle red hint
- pass the current character level to ability details in the index view when available
- allow ability rendering to apply locked-level styling on the index page when a character owns the ability

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d11b335af88323bc9776ca26c1be08