### PR TITLE
Replace regex button detection with includes

### DIFF
--- a/js/entry-card.js
+++ b/js/entry-card.js
@@ -70,9 +70,14 @@
     const auxRow = auxParts.length ? `<div class="card-aux-row">${auxParts.join('')}</div>` : '';
     let inlineLevelButton = '';
     if (levelHtml && buttonParts.length) {
-      const findIdx = (pattern) => buttonParts.findIndex(part => typeof part === 'string' && pattern.test(part));
-      let btnIdx = findIdx(/data-act=['"]add['"]);
-      if (btnIdx === -1) btnIdx = findIdx(/data-act=['"](rem|del)['"]);
+      const findIdx = (matcher) => buttonParts.findIndex(part => typeof part === 'string' && matcher(part));
+      let btnIdx = findIdx(part => part.includes('data-act="add"') || part.includes("data-act='add'"));
+      if (btnIdx === -1) {
+        btnIdx = findIdx(part =>
+          part.includes('data-act="rem"') || part.includes("data-act='rem'") ||
+          part.includes('data-act="del"') || part.includes("data-act='del'")
+        );
+      }
       if (btnIdx !== -1) {
         inlineLevelButton = buttonParts.splice(btnIdx, 1)[0];
       }


### PR DESCRIPTION
## Summary
- replace the regex-based button lookup in `entry-card.js` with string `includes` checks for add/remove controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d11d6ec52c8323bb8ea059c8d5a9e2