### PR TITLE
Add info boxes to entry cards for key tags and facts

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -927,6 +927,66 @@ input:focus, select:focus, textarea:focus {
   margin-left: auto;
 }
 
+.card-info-box {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .4rem .75rem;
+  width: 100%;
+  background: rgba(255, 255, 255, .04);
+  border: 1px solid rgba(255, 255, 255, .08);
+  border-radius: .75rem;
+  padding: .55rem .85rem;
+  margin: .45rem 0;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .28);
+}
+
+.card-level-row + .card-info-box {
+  margin-top: .35rem;
+}
+
+.card-info-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+  flex: 1 1 280px;
+  min-width: 0;
+}
+
+.card-info-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .3rem 1.1rem;
+  align-items: center;
+  justify-content: flex-start;
+  flex: 0 1 auto;
+}
+
+.card-info-fact {
+  display: inline-flex;
+  align-items: baseline;
+  gap: .4rem;
+  font-size: .95rem;
+  line-height: 1.25;
+}
+
+.card-info-fact-label {
+  color: var(--subtxt);
+  font-weight: 600;
+  font-size: .82rem;
+  letter-spacing: .01em;
+}
+
+.card-info-fact-value {
+  color: var(--txt);
+  font-weight: 600;
+}
+
+.inv-controls-left .card-info-box {
+  margin: 0;
+  flex: 1 1 260px;
+  padding: .5rem .75rem;
+}
+
 .card-tags-row {
   display: flex;
   flex-wrap: wrap;

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1137,6 +1137,7 @@ function initCharacter() {
       cats[cat].forEach(g=>{
         const p = g.entry;
         const availLvls = LVL.filter(l=>p.nivåer?.[l]);
+        const hasLevels = availLvls.length>0;
         const lvlSel = availLvls.length>1
           ? `<select class="level" data-name="${p.namn}"${p.trait?` data-trait="${p.trait}"`:''}>
               ${availLvls.map(l=>`<option${l===p.nivå?' selected':''}>${l}</option>`).join('')}
@@ -1192,7 +1193,30 @@ function initCharacter() {
           .concat(infoTagHtmlParts)
           .filter(Boolean)
           .join(' ');
+        const infoBoxTagParts = infoTagHtmlParts.filter(Boolean);
+        const infoBoxTagsHtml = infoBoxTagParts.length
+          ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
+          : '';
+        const infoBoxFacts = infoMeta.filter(meta => {
+          if (!meta) return false;
+          const value = meta.value;
+          if (value === undefined || value === null || value === '') return false;
+          const label = String(meta.label || '').toLowerCase();
+          return label.includes('pris') || label.includes('dagslön') || label.includes('vikt');
+        });
+        const infoBoxFactsHtml = infoBoxFacts.length
+          ? `<div class="card-info-facts">${infoBoxFacts.map(f => {
+              const label = String(f.label ?? '').trim();
+              const value = String(f.value ?? '').trim();
+              if (!label || !value) return '';
+              return `<div class="card-info-fact"><span class="card-info-fact-label">${label}</span><span class="card-info-fact-value">${value}</span></div>`;
+            }).filter(Boolean).join('')}</div>`
+          : '';
+        const infoBoxHtml = (infoBoxTagsHtml || infoBoxFactsHtml)
+          ? `<div class="card-info-box">${infoBoxTagsHtml}${infoBoxFactsHtml}</div>`
+          : '';
         const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
+        const levelHtml = hideDetails ? '' : lvlSel;
         const infoPanelHtml = buildInfoPanelHtml({
           tagsHtml: infoTagsHtml,
           bodyHtml: infoBodyHtml,
@@ -1271,7 +1295,9 @@ function initCharacter() {
           xpHtml,
           primaryTagsHtml,
           tagsHtml: (!compact && !shouldDockTags && tagsHtml) ? tagsHtml : '',
-          levelHtml: hideDetails ? '' : lvlSel,
+          infoBox: infoBoxHtml,
+          hasLevels,
+          levelHtml,
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '',
           leftSections,
           titleActions,

--- a/js/entry-card.js
+++ b/js/entry-card.js
@@ -38,13 +38,17 @@
       descHtml = '',
       leftSections = [],
       buttonSections = [],
-      titleActions = []
+      titleActions = [],
+      infoBox = '',
+      hasLevels = false
     } = options;
 
     const li = document.createElement('li');
     const classNames = ['card'];
     if (compact) classNames.push('compact');
     classNames.push(...normalizeClasses(classes));
+    if (hasLevels) classNames.push('has-levels');
+    else classNames.push('no-levels');
     li.className = classNames.join(' ');
 
     applyDataset(li, dataset);
@@ -52,6 +56,7 @@
     const leftParts = Array.isArray(leftSections) ? leftSections.filter(Boolean) : [];
     let buttonParts = Array.isArray(buttonSections) ? buttonSections.filter(Boolean) : [];
     const titleActionParts = Array.isArray(titleActions) ? titleActions.filter(Boolean) : [];
+    const infoBoxHtml = typeof infoBox === 'string' ? infoBox : '';
 
     const tagParts = [];
     const auxParts = [];
@@ -85,16 +90,23 @@
     const levelRow = (levelHtml || inlineLevelButton)
       ? `<div class="card-level-row"><div class="card-level">${levelHtml || ''}</div>${inlineLevelButton ? `<div class="card-level-actions">${inlineLevelButton}</div>` : ''}</div>`
       : '';
+    const hasLevelRow = Boolean(levelRow);
+    const levelSection = hasLevelRow
+      ? `${levelRow}${infoBoxHtml ? infoBoxHtml : ''}`
+      : '';
+    const infoBoxAboveTags = (!hasLevelRow && hasLevels && infoBoxHtml) ? infoBoxHtml : '';
+    const controlsLeftParts = (!hasLevelRow && !hasLevels && infoBoxHtml) ? [infoBoxHtml] : [];
     const headerExtras = [];
     if (xpHtml) headerExtras.push(`<div class="card-xp">${xpHtml}</div>`);
     if (titleActionParts.length) headerExtras.push(`<div class="card-title-actions">${titleActionParts.join('')}</div>`);
     const headerRight = headerExtras.length ? `<div class="card-header-right">${headerExtras.join('')}</div>` : '';
     const headerHtml = `<div class="card-header"><div class="card-title"><span>${nameHtml}</span></div>${headerRight}</div>`;
-    const controlsHtml = wrapControls([], buttonParts);
+    const controlsHtml = wrapControls(controlsLeftParts, buttonParts);
 
     li.innerHTML = `
       ${headerHtml}
-      ${levelRow}
+      ${levelSection}
+      ${infoBoxAboveTags}
       ${tagsRow}
       ${auxRow}
       ${descHtml || ''}

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -499,6 +499,7 @@ function initIndex() {
         const curLvl = charLevel
           || LVL.find(l => p.nivåer?.[l]) || 'Novis';
         const availLvls = LVL.filter(l => p.nivåer?.[l]);
+        const hasLevels = availLvls.length > 0;
         const lvlSel = availLvls.length > 1
           ? `<select class="level" data-name="${p.namn}">
               ${availLvls.map(l=>`<option${l===curLvl?' selected':''}>${l}</option>`).join('')}
@@ -622,6 +623,28 @@ function initIndex() {
         const infoFilterTagHtml = filterTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = filterTagHtml.join(' ');
         const infoTagsHtml = [xpTag].concat(infoFilterTagHtml).filter(Boolean).join(' ');
+        const infoBoxTagParts = infoFilterTagHtml.filter(Boolean);
+        const infoBoxTagsHtml = infoBoxTagParts.length
+          ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
+          : '';
+        const infoBoxFacts = infoMeta.filter(meta => {
+          if (!meta) return false;
+          const value = meta.value;
+          if (value === undefined || value === null || value === '') return false;
+          const label = String(meta.label || '').toLowerCase();
+          return label.includes('pris') || label.includes('dagslön') || label.includes('vikt');
+        });
+        const infoBoxFactsHtml = infoBoxFacts.length
+          ? `<div class="card-info-facts">${infoBoxFacts.map(f => {
+              const label = String(f.label ?? '').trim();
+              const value = String(f.value ?? '').trim();
+              if (!label || !value) return '';
+              return `<div class="card-info-fact"><span class="card-info-fact-label">${label}</span><span class="card-info-fact-value">${value}</span></div>`;
+            }).filter(Boolean).join('')}</div>`
+          : '';
+        const infoBoxHtml = (infoBoxTagsHtml || infoBoxFactsHtml)
+          ? `<div class="card-info-box">${infoBoxTagsHtml}${infoBoxFactsHtml}</div>`
+          : '';
         const dockPrimary = (p.taggar?.typ || [])[0] || '';
         const shouldDockTags = DOCK_TAG_TYPES.has(dockPrimary);
         const renderDockedTags = (tags, extraClass = '') => {
@@ -634,6 +657,7 @@ function initIndex() {
           ? renderDockedTags(dockableTagData, 'entry-tags-mobile')
           : '';
         const xpHtml = (xpVal != null || isElityrke(p)) ? `<span class="xp-cost">Erf: ${xpText}</span>` : '';
+        const levelHtml = hideDetails ? '' : lvlSel;
         // Compact meta badges (P/V/level) using short labels for mobile space
         const lvlBadgeVal = (availLvls.length > 0) ? curLvl : '';
         const lvlShort =
@@ -720,7 +744,9 @@ function initIndex() {
           xpHtml,
           primaryTagsHtml,
           tagsHtml: (!compact && !shouldDockTags && tagsHtml) ? tagsHtml : '',
-          levelHtml: hideDetails ? '' : lvlSel,
+          infoBox: infoBoxHtml,
+          hasLevels,
+          levelHtml,
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${cardDesc}</div>` : '',
           leftSections,
           titleActions,


### PR DESCRIPTION
## Summary
- extend the entry card factory to accept info box markup and tag cards with level availability for placement
- surface non-XP info tags plus price and weight facts in entry info boxes in both index and character views
- style the new info box so it spans beneath level selectors or wraps with controls when levels are absent

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d11ded7bf083238a12c9d234381ab7