### PR TITLE
Separate lock styling and collapsing behaviour

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1052,13 +1052,6 @@ input:focus, select:focus, textarea:focus {
   border-color: var(--txt);
 }
 
-.level-block:hover,
-.level-block:focus-within {
-  border-color: rgba(255, 255, 255, .18);
-  background: rgba(42, 37, 33, .88);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .05);
-}
-
 .level-block summary:focus-visible {
   outline: 2px solid var(--txt);
   outline-offset: 2px;
@@ -1093,13 +1086,6 @@ input:focus, select:focus, textarea:focus {
 
 .level-block.level-locked .level-content {
   border-top-color: rgba(246, 65, 65, .14);
-}
-
-.level-block.level-locked:hover,
-.level-block.level-locked:focus-within {
-  border-color: rgba(246, 65, 65, .32);
-  background: rgba(74, 31, 31, .2);
-  box-shadow: inset 0 0 0 1px rgba(246, 65, 65, .14);
 }
 
 @media (max-width: 520px) {

--- a/js/text-format.js
+++ b/js/text-format.js
@@ -60,7 +60,8 @@
     const normalizedMax = typeof maxLevel === 'string' ? maxLevel : '';
     const highestUnlockedIdx = normalizedMax ? orderedKeys.indexOf(normalizedMax) : -1;
     const allowLocks = normalizedMax && highestUnlockedIdx >= 0;
-    const applyLocks = allowLocks && (pageRole === 'character' || pageRole === 'index');
+    const shouldStyleLock = allowLocks && (pageRole === 'character' || pageRole === 'index');
+    const shouldCollapseLocked = allowLocks && pageRole === 'character';
 
     const levelBlocks = [];
     orderedKeys.forEach((key, idx) => {
@@ -68,11 +69,12 @@
       if (!raw) return;
       const content = formatText(typeof raw === 'string' ? raw : String(raw));
       if (!content) return;
-      const isUnlocked = !applyLocks || idx <= highestUnlockedIdx;
+      const isUnlocked = idx <= highestUnlockedIdx;
       const classes = ['level-block'];
-      if (applyLocks && idx > highestUnlockedIdx) classes.push('level-locked');
+      if (shouldStyleLock && !isUnlocked) classes.push('level-locked');
+      const isOpen = !shouldCollapseLocked || isUnlocked;
       levelBlocks.push(`
-        <details class="${classes.join(' ')}"${isUnlocked ? ' open' : ''}>
+        <details class="${classes.join(' ')}"${isOpen ? ' open' : ''}>
           <summary>${key}</summary>
           <div class="level-content">${content}</div>
         </details>


### PR DESCRIPTION
## Summary
- split ability lock handling so only the character view collapses locked levels while keeping the locked styling in both views
- remove hover and focus highlight styling from level blocks to avoid visual changes on scroll or click

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1208d99648323abbc5c2a03e5df28