### PR TITLE
Hide Traditionslös tags from entry displays

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -134,9 +134,10 @@ function initCharacter() {
   const renderFilterTag = (tag, extra = '') => `<span class="tag filter-tag" data-section="${tag.section}" data-val="${tag.value}"${extra}>${tag.label}</span>`;
 
   const renderDockedTags = (tags, extraClass = '') => {
-    if (!Array.isArray(tags) || !tags.length) return '';
+    const visibleTags = (Array.isArray(tags) ? tags : []).filter(tag => tag && !tag.hidden);
+    if (!visibleTags.length) return '';
     const cls = ['entry-tags', extraClass].filter(Boolean).join(' ');
-    return `<div class="${cls}">${tags.map(tag => renderFilterTag(tag)).join('')}</div>`;
+    return `<div class="${cls}">${visibleTags.map(tag => renderFilterTag(tag)).join('')}</div>`;
   };
 
   const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, m => ({
@@ -1171,14 +1172,15 @@ function initCharacter() {
           .forEach((t, idx) => {
             const tag = { section: 'typ', value: t, label: t, hidden: idx === 0 };
             filterTagData.push(tag);
-            primaryTagParts.push(renderFilterTag(tag));
+            if (!tag.hidden) primaryTagParts.push(renderFilterTag(tag));
           });
         const trTags = explodeTags(p.taggar?.ark_trad);
         const arkList = trTags.length ? trTags : (Array.isArray(p.taggar?.ark_trad) ? ['Traditionslös'] : []);
         arkList.forEach(t => {
-          const tag = { section: 'ark', value: t, label: t };
+          const isTraditionslos = String(t || '').trim() === 'Traditionslös';
+          const tag = { section: 'ark', value: t, label: t, hidden: isTraditionslos };
           filterTagData.push(tag);
-          primaryTagParts.push(renderFilterTag(tag));
+          if (!tag.hidden) primaryTagParts.push(renderFilterTag(tag));
         });
         (p.taggar?.test || [])
           .filter(Boolean)
@@ -1187,7 +1189,7 @@ function initCharacter() {
         const visibleTagData = filterTagData.filter(tag => !tag.hidden);
         const dockableTagData = visibleTagData.filter(tag => tag.section !== 'typ' && tag.section !== 'ark');
         const tagHtmlParts = dockableTagData.map(tag => renderFilterTag(tag));
-        const infoTagHtmlParts = filterTagData.map(tag => renderFilterTag(tag));
+        const infoTagHtmlParts = visibleTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = tagHtmlParts.join(' ');
         const infoTagsHtml = [xpTag]
           .concat(infoTagHtmlParts)

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -604,14 +604,15 @@ function initIndex() {
           .forEach((t, idx) => {
             const tag = { section: 'typ', value: t, label: QUAL_TYPE_MAP[t] || t, hidden: idx === 0 };
             filterTagData.push(tag);
-            primaryTagParts.push(renderFilterTag(tag));
+            if (!tag.hidden) primaryTagParts.push(renderFilterTag(tag));
           });
         const trTags = explodeTags(p.taggar?.ark_trad);
         const arkList = trTags.length ? trTags : (Array.isArray(p.taggar?.ark_trad) ? ['Traditionslös'] : []);
         arkList.forEach(t => {
-          const tag = { section: 'ark', value: t, label: t };
+          const isTraditionslos = String(t || '').trim() === 'Traditionslös';
+          const tag = { section: 'ark', value: t, label: t, hidden: isTraditionslos };
           filterTagData.push(tag);
-          primaryTagParts.push(renderFilterTag(tag));
+          if (!tag.hidden) primaryTagParts.push(renderFilterTag(tag));
         });
         (p.taggar?.test || [])
           .filter(Boolean)
@@ -620,7 +621,7 @@ function initIndex() {
         const visibleTagData = filterTagData.filter(tag => !tag.hidden);
         const dockableTagData = visibleTagData.filter(tag => tag.section !== 'typ' && tag.section !== 'ark');
         const filterTagHtml = dockableTagData.map(tag => renderFilterTag(tag));
-        const infoFilterTagHtml = filterTagData.map(tag => renderFilterTag(tag));
+        const infoFilterTagHtml = visibleTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = filterTagHtml.join(' ');
         const infoTagsHtml = [xpTag].concat(infoFilterTagHtml).filter(Boolean).join(' ');
         const infoBoxTagParts = infoFilterTagHtml.filter(Boolean);
@@ -648,9 +649,10 @@ function initIndex() {
         const dockPrimary = (p.taggar?.typ || [])[0] || '';
         const shouldDockTags = DOCK_TAG_TYPES.has(dockPrimary);
         const renderDockedTags = (tags, extraClass = '') => {
-          if (!tags.length) return '';
+          const visibleTags = (Array.isArray(tags) ? tags : []).filter(tag => tag && !tag.hidden);
+          if (!visibleTags.length) return '';
           const cls = ['entry-tags', extraClass].filter(Boolean).join(' ');
-          return `<div class="${cls}">${tags.map(tag => renderFilterTag(tag)).join('')}</div>`;
+          return `<div class="${cls}">${visibleTags.map(tag => renderFilterTag(tag)).join('')}</div>`;
         };
         const dockedTagsHtml = shouldDockTags ? renderDockedTags(dockableTagData) : '';
         const mobileTagsHtml = (!compact && !shouldDockTags && dockableTagData.length)


### PR DESCRIPTION
## Summary
- mark "Traditionslös" tags as hidden when assembling entry card metadata so they are omitted from rendered tag lists while remaining selectable in filters
- apply the same hidden-tag handling in the character view, filtering hidden tags out before building any HTML for cards or info panels

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d12b87eb94832396ebba0add9064dd