### PR TITLE
Align level-based card controls and tidy table entries

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1033,7 +1033,33 @@ input:focus, select:focus, textarea:focus {
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .28);
 }
 
+.card-info-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .45rem;
+  align-items: stretch;
+  margin: .45rem 0;
+}
+
+.card-info-row .card-info-box {
+  flex: 1 1 260px;
+  margin: 0;
+}
+
+.card-info-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+  align-items: center;
+  justify-content: flex-end;
+  margin-left: auto;
+}
+
 .card-level-row + .card-info-box {
+  margin-top: .35rem;
+}
+
+.card-level-row + .card-info-row {
   margin-top: .35rem;
 }
 

--- a/js/entry-card.js
+++ b/js/entry-card.js
@@ -57,6 +57,27 @@
     let buttonParts = Array.isArray(buttonSections) ? buttonSections.filter(Boolean) : [];
     const titleActionParts = Array.isArray(titleActions) ? titleActions.filter(Boolean) : [];
     const infoBoxHtml = typeof infoBox === 'string' ? infoBox : '';
+    const actionIdxs = [];
+    buttonParts.forEach((part, idx) => {
+      if (typeof part !== 'string') return;
+      if (/data-act=(["'])(add|sub|rem|del)\1/.test(part)) actionIdxs.push(idx);
+    });
+    let inlineLevelButton = '';
+    let infoBoxActionButtons = [];
+    if (actionIdxs.length) {
+      if (hasLevels && infoBoxHtml) {
+        infoBoxActionButtons = actionIdxs.map(idx => buttonParts[idx]).filter(Boolean);
+        const idxSet = new Set(actionIdxs);
+        buttonParts = buttonParts.filter((_, idx) => !idxSet.has(idx));
+      } else if (levelHtml) {
+        const idx = actionIdxs[0];
+        inlineLevelButton = buttonParts[idx];
+        buttonParts.splice(idx, 1);
+      }
+    }
+    const infoBoxBlockHtml = infoBoxActionButtons.length
+      ? `<div class="card-info-row">${infoBoxHtml}<div class="card-info-actions">${infoBoxActionButtons.join('')}</div></div>`
+      : infoBoxHtml;
 
     const tagParts = [];
     const auxParts = [];
@@ -73,29 +94,15 @@
     const tagsRow = tagSources.length ? `<div class="card-tags-row">${tagSources.join('')}</div>` : '';
 
     const auxRow = auxParts.length ? `<div class="card-aux-row">${auxParts.join('')}</div>` : '';
-    let inlineLevelButton = '';
-    if (levelHtml && buttonParts.length) {
-      const findIdx = (matcher) => buttonParts.findIndex(part => typeof part === 'string' && matcher(part));
-      let btnIdx = findIdx(part => part.includes('data-act="add"') || part.includes("data-act='add'"));
-      if (btnIdx === -1) {
-        btnIdx = findIdx(part =>
-          part.includes('data-act="rem"') || part.includes("data-act='rem'") ||
-          part.includes('data-act="del"') || part.includes("data-act='del'")
-        );
-      }
-      if (btnIdx !== -1) {
-        inlineLevelButton = buttonParts.splice(btnIdx, 1)[0];
-      }
-    }
     const levelRow = (levelHtml || inlineLevelButton)
       ? `<div class="card-level-row"><div class="card-level">${levelHtml || ''}</div>${inlineLevelButton ? `<div class="card-level-actions">${inlineLevelButton}</div>` : ''}</div>`
       : '';
     const hasLevelRow = Boolean(levelRow);
     const levelSection = hasLevelRow
-      ? `${levelRow}${infoBoxHtml ? infoBoxHtml : ''}`
+      ? `${levelRow}${infoBoxBlockHtml ? infoBoxBlockHtml : ''}`
       : '';
-    const infoBoxAboveTags = (!hasLevelRow && hasLevels && infoBoxHtml) ? infoBoxHtml : '';
-    const controlsLeftParts = (!hasLevelRow && !hasLevels && infoBoxHtml) ? [infoBoxHtml] : [];
+    const infoBoxAboveTags = (!hasLevelRow && hasLevels && infoBoxBlockHtml) ? infoBoxBlockHtml : '';
+    const controlsLeftParts = (!hasLevelRow && !hasLevels && infoBoxBlockHtml) ? [infoBoxBlockHtml] : [];
     const headerExtras = [];
     if (xpHtml) headerExtras.push(`<div class="card-xp">${xpHtml}</div>`);
     if (titleActionParts.length) headerExtras.push(`<div class="card-title-actions">${titleActionParts.join('')}</div>`);

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -471,25 +471,20 @@ function initIndex() {
         if (p.kolumner && p.rader) {
           const infoHtml = tabellInfoHtml(p);
           const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info">ℹ️</button>`;
-          const tagsHtml = (p.taggar?.typ || [])
-            .map(t => `<span class="tag">${t}</span>`)
-            .join(' ');
-          const tagsDiv = tagsHtml ? `<div class="tags entry-tags-block">${tagsHtml}</div>` : '';
-          const tagsMobile = tagsHtml ? `<div class="entry-tags entry-tags-mobile">${tagsHtml}</div>` : '';
-        const li = document.createElement('li');
-        li.className = 'card';
-        li.dataset.name = p.namn;
-        if (p.id) li.dataset.id = p.id;
-        li.innerHTML = `
-            <div class="card-title"><span>${p.namn}</span></div>
-            ${tagsDiv}
-            <div class="inv-controls">${tagsMobile}${infoBtn}</div>`;
-        listEl.appendChild(li);
-        if (searchActive && terms.length) {
-          const titleSpan = li.querySelector('.card-title > span');
-          if (titleSpan) highlightInElement(titleSpan, terms);
-        }
-        return;
+          const dataset = { name: p.namn };
+          if (p.id) dataset.id = p.id;
+          const li = createEntryCard({
+            compact,
+            dataset,
+            nameHtml: p.namn,
+            titleActions: [infoBtn]
+          });
+          listEl.appendChild(li);
+          if (searchActive && terms.length) {
+            const titleSpan = li.querySelector('.card-title > span');
+            if (titleSpan) highlightInElement(titleSpan, terms);
+          }
+          return;
         }
         const charEntry = charList.find(c => c.namn === p.namn);
         const levelStr = typeof charEntry?.nivå === 'string' ? charEntry.nivå.trim() : '';


### PR DESCRIPTION
## Summary
- move level-based entry action buttons next to the info box
- add layout rules for the info/action row so buttons sit beside metadata
- render table entries with the shared card factory so they drop the type tag and reuse the header action slot

## Testing
- no automated tests (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d13b1a96588323af5086ce49f74366