### PR TITLE
Flytta entry-kontroller till korthuvud och jämna ut storlekar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -872,6 +872,8 @@ input:focus, select:focus, textarea:focus {
   margin-top: .6rem;
 }
 .card {
+  --card-title-font-size: calc(1.34rem - 2px);
+  --card-title-action-size: calc(var(--card-title-font-size) * 1.05);
   background: var(--card);
   border: 2px solid var(--card-border);
   border-radius: 1rem;
@@ -894,6 +896,8 @@ input:focus, select:focus, textarea:focus {
   display: flex;
   align-items: center;
   gap: .45rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   margin-left: auto;
 }
 
@@ -901,18 +905,33 @@ input:focus, select:focus, textarea:focus {
   display: flex;
   align-items: center;
   gap: .35rem;
+  font-size: var(--card-title-font-size);
 }
 
 .card-title-actions {
   display: flex;
   align-items: center;
   gap: .35rem;
+  font-size: var(--card-title-font-size);
+}
+
+.card-title-actions .char-btn {
+  width: var(--card-title-action-size);
+  height: var(--card-title-action-size);
+  min-width: var(--card-title-action-size);
+  min-height: var(--card-title-action-size);
+  border-radius: 50%;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--card-title-font-size);
+  line-height: 1;
 }
 
 .card-title-actions .char-btn.info-btn {
   background: none;
   color: var(--txt);
-  padding: 0;
 }
 
 .card-title-actions .char-btn.info-btn:active {
@@ -952,7 +971,7 @@ input:focus, select:focus, textarea:focus {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  font-size: calc(1.34rem - 2px);
+  font-size: var(--card-title-font-size);
   font-weight: 600;
 }
 #invList .card-title {
@@ -987,18 +1006,20 @@ input:focus, select:focus, textarea:focus {
 .xp-cost {
   display: inline-flex;
   align-items: center;
-  padding: .22rem .72rem;
+  justify-content: center;
+  padding: 0 .9em;
   background: var(--xp-pill-bg);
   color: var(--xp-pill-text);
-  font-size: .9rem;
+  font-size: 1em;
   font-weight: 600;
-  line-height: 1.1;
+  line-height: 1;
   border-radius: 999px;
   border: 1px solid var(--xp-pill-border);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, .04), 0 1px 2px rgba(0, 0, 0, .4);
   text-shadow: 0 1px 1px rgba(0, 0, 0, .35);
   letter-spacing: .01em;
   white-space: nowrap;
+  min-height: var(--card-title-action-size);
   flex: 0 0 auto;
 }
 .card-level-row {
@@ -1687,10 +1708,6 @@ select.level {
     --entry-tag-row: 1.25rem;
     gap: .2rem .28rem;
     max-height: none;
-  }
-  .xp-cost {
-    font-size: .78rem;
-    padding: .18rem .6rem;
   }
   .tag.xp-cost {
     font-size: .72rem;

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1245,37 +1245,37 @@ function initCharacter() {
           : '';
         const infoBtnHtml = showInfo ? infoBtn : '';
         const titleActions = [];
-        const buttonParts = [];
+        const controlButtons = [];
         if (infoBtnHtml) titleActions.push(infoBtnHtml);
-        if (editBtn) buttonParts.push(editBtn);
+        if (editBtn) controlButtons.push(editBtn);
         if (multi) {
           const isDisadv = typesList.includes('Nackdel');
           if (isDisadv) {
             if (total > 0) {
-              const delBtn = `<button data-act="del" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`;
-              const subBtn = `<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">➖</button>`;
-              const addBtn = total < limit ? `<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>` : '';
-              buttonParts.push(delBtn, subBtn);
-              if (addBtn) buttonParts.push(addBtn);
+              const delBtn = `<button data-act="del" class="char-btn danger icon header-action" data-name="${p.namn}">🗑</button>`;
+              const subBtn = `<button data-act="sub" class="char-btn header-action" data-name="${p.namn}" aria-label="Minska">➖</button>`;
+              const addBtn = total < limit ? `<button data-act="add" class="char-btn header-action" data-name="${p.namn}" aria-label="Lägg till">➕</button>` : '';
+              titleActions.push(delBtn, subBtn);
+              if (addBtn) titleActions.push(addBtn);
             } else {
-              const addBtn = `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`;
-              buttonParts.push(addBtn);
+              const addBtn = `<button data-act="add" class="char-btn add-btn header-action" data-name="${p.namn}" aria-label="Lägg till">➕</button>`;
+              titleActions.push(addBtn);
             }
-            if (conflictBtn) buttonParts.push(conflictBtn);
+            if (conflictBtn) controlButtons.push(conflictBtn);
           } else {
             const remBtn = total > 0
-              ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
+              ? `<button data-act="rem" class="char-btn danger icon header-action" data-name="${p.namn}">🗑</button>`
               : '';
             const addBtn = total < limit
-              ? `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`
+              ? `<button data-act="add" class="char-btn add-btn header-action" data-name="${p.namn}" aria-label="Lägg till">➕</button>`
               : '';
-            if (remBtn) buttonParts.push(remBtn);
-            if (conflictBtn) buttonParts.push(conflictBtn);
-            if (addBtn) buttonParts.push(addBtn);
+            if (remBtn) titleActions.push(remBtn);
+            if (conflictBtn) controlButtons.push(conflictBtn);
+            if (addBtn) titleActions.push(addBtn);
           }
         } else {
-          buttonParts.push(`<button class="char-btn danger icon" data-act="rem">🗑</button>`);
-          if (conflictBtn) buttonParts.push(conflictBtn);
+          titleActions.push(`<button class="char-btn danger icon header-action" data-act="rem">🗑</button>`);
+          if (conflictBtn) controlButtons.push(conflictBtn);
         }
         const dockPrimary = (p.taggar?.typ || [])[0] || '';
         const shouldDockTags = DOCK_TAG_TYPES.has(dockPrimary);
@@ -1303,7 +1303,7 @@ function initCharacter() {
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '',
           leftSections,
           titleActions,
-          buttonSections: buttonParts
+          buttonSections: controlButtons
         });
 
         listEl.appendChild(li);

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -706,26 +706,26 @@ function initIndex() {
           : '';
         const allowAdd = !(isService(p) || isEmployment(p));
         const titleActions = [];
-        const actionButtons = [];
-        if (showInfo) titleActions.push(infoBtn);
-        if (editBtn) actionButtons.push(editBtn);
+        const controlButtons = [];
+        titleActions.push(infoBtn);
+        if (editBtn) controlButtons.push(editBtn);
         if (allowAdd) {
           if (multi) {
             if (count > 0) {
-              actionButtons.push(`<button data-act="del" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`);
-              actionButtons.push(`<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">➖</button>`);
-              if (count < limit) actionButtons.push(`<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
+              titleActions.push(`<button data-act="del" class="char-btn danger icon header-action" data-name="${p.namn}">🗑</button>`);
+              titleActions.push(`<button data-act="sub" class="char-btn header-action" data-name="${p.namn}" aria-label="Minska">➖</button>`);
+              if (count < limit) titleActions.push(`<button data-act="add" class="char-btn header-action" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
             } else {
-              actionButtons.push(`<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
+              titleActions.push(`<button data-act="add" class="char-btn add-btn header-action" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
             }
           } else {
             const mainBtn = inChar
-              ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
-              : `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`;
-            actionButtons.push(mainBtn);
+              ? `<button data-act="rem" class="char-btn danger icon header-action" data-name="${p.namn}">🗑</button>`
+              : `<button data-act="add" class="char-btn add-btn header-action" data-name="${p.namn}" aria-label="Lägg till">➕</button>`;
+            titleActions.push(mainBtn);
           }
         }
-        if (eliteBtn) actionButtons.push(eliteBtn);
+        if (eliteBtn) controlButtons.push(eliteBtn);
         const leftSections = [];
         if (metaBadges) leftSections.push(metaBadges);
         if (shouldDockTags && dockedTagsHtml) leftSections.push(dockedTagsHtml);
@@ -747,7 +747,7 @@ function initIndex() {
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${cardDesc}</div>` : '',
           leftSections,
           titleActions,
-          buttonSections: actionButtons
+          buttonSections: controlButtons
         });
         listEl.appendChild(li);
         if (searchActive && terms.length) {


### PR DESCRIPTION
## Summary
- flytta lägg till/ta bort/minus-kontroller till kortens header bredvid info-knappen
- justera styling så att header-knappar och erf-pill matchar rubrikens storlek och får rund form
- spegla uppdateringarna i karaktärsvyn och behåll övriga kontroller i kortfoten

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d140355aa88323855f1166d1fd897e