### PR TITLE
Make card info box flex container

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1022,6 +1022,8 @@ input:focus, select:focus, textarea:focus {
 }
 
 .card-info-box {
+  display: flex;
+  align-items: flex-start;
   flex-wrap: wrap;
   gap: .4rem .75rem;
   width: 100%;


### PR DESCRIPTION
## Summary
- add flexbox layout to the card info box container so tag and fact sections can sit side by side when space allows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d14280f8908323a84f831457a1e18a