### PR TITLE
Align Tabeller cards with standard header actions

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -471,25 +471,27 @@ function initIndex() {
         if (p.kolumner && p.rader) {
           const infoHtml = tabellInfoHtml(p);
           const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info">ℹ️</button>`;
-          const tagsHtml = (p.taggar?.typ || [])
-            .map(t => `<span class="tag">${t}</span>`)
-            .join(' ');
-          const tagsDiv = tagsHtml ? `<div class="tags entry-tags-block">${tagsHtml}</div>` : '';
-          const tagsMobile = tagsHtml ? `<div class="entry-tags entry-tags-mobile">${tagsHtml}</div>` : '';
-        const li = document.createElement('li');
-        li.className = 'card';
-        li.dataset.name = p.namn;
-        if (p.id) li.dataset.id = p.id;
-        li.innerHTML = `
-            <div class="card-title"><span>${p.namn}</span></div>
-            ${tagsDiv}
-            <div class="inv-controls">${tagsMobile}${infoBtn}</div>`;
-        listEl.appendChild(li);
-        if (searchActive && terms.length) {
-          const titleSpan = li.querySelector('.card-title > span');
-          if (titleSpan) highlightInElement(titleSpan, terms);
-        }
-        return;
+          const dataset = { name: p.namn };
+          if (p.id) dataset.id = p.id;
+          const visibleTags = (p.taggar?.typ || [])
+            .map(t => String(t || '').trim())
+            .filter(t => t && !/^tabell(er)?$/i.test(t));
+          const tagsHtml = visibleTags.length
+            ? visibleTags.map(t => `<span class="tag">${t}</span>`).join(' ')
+            : '';
+          const li = createEntryCard({
+            compact,
+            dataset,
+            nameHtml: p.namn,
+            tagsHtml,
+            titleActions: [infoBtn]
+          });
+          listEl.appendChild(li);
+          if (searchActive && terms.length) {
+            const titleSpan = li.querySelector('.card-title > span');
+            if (titleSpan) highlightInElement(titleSpan, terms);
+          }
+          return;
         }
         const charEntry = charList.find(c => c.namn === p.namn);
         const levelStr = typeof charEntry?.nivå === 'string' ? charEntry.nivå.trim() : '';


### PR DESCRIPTION
## Summary
- render Tabeller entries via the shared entry card factory so they share the same header layout
- omit the Tabell type tag when building these cards for a consistent appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d158e275d08323b06ef0f6e10f4c72