### PR TITLE
Hide Traditionslös tag from card displays

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1171,14 +1171,14 @@ function initCharacter() {
           .forEach((t, idx) => {
             const tag = { section: 'typ', value: t, label: t, hidden: idx === 0 };
             filterTagData.push(tag);
-            primaryTagParts.push(renderFilterTag(tag));
+            if (!tag.hidden) primaryTagParts.push(renderFilterTag(tag));
           });
         const trTags = explodeTags(p.taggar?.ark_trad);
         const arkList = trTags.length ? trTags : (Array.isArray(p.taggar?.ark_trad) ? ['Traditionslös'] : []);
         arkList.forEach(t => {
-          const tag = { section: 'ark', value: t, label: t };
+          const tag = { section: 'ark', value: t, label: t, hidden: t === 'Traditionslös' };
           filterTagData.push(tag);
-          primaryTagParts.push(renderFilterTag(tag));
+          if (!tag.hidden) primaryTagParts.push(renderFilterTag(tag));
         });
         (p.taggar?.test || [])
           .filter(Boolean)
@@ -1187,7 +1187,7 @@ function initCharacter() {
         const visibleTagData = filterTagData.filter(tag => !tag.hidden);
         const dockableTagData = visibleTagData.filter(tag => tag.section !== 'typ' && tag.section !== 'ark');
         const tagHtmlParts = dockableTagData.map(tag => renderFilterTag(tag));
-        const infoTagHtmlParts = filterTagData.map(tag => renderFilterTag(tag));
+        const infoTagHtmlParts = visibleTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = tagHtmlParts.join(' ');
         const infoTagsHtml = [xpTag]
           .concat(infoTagHtmlParts)

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -604,14 +604,14 @@ function initIndex() {
           .forEach((t, idx) => {
             const tag = { section: 'typ', value: t, label: QUAL_TYPE_MAP[t] || t, hidden: idx === 0 };
             filterTagData.push(tag);
-            primaryTagParts.push(renderFilterTag(tag));
+            if (!tag.hidden) primaryTagParts.push(renderFilterTag(tag));
           });
         const trTags = explodeTags(p.taggar?.ark_trad);
         const arkList = trTags.length ? trTags : (Array.isArray(p.taggar?.ark_trad) ? ['Traditionslös'] : []);
         arkList.forEach(t => {
-          const tag = { section: 'ark', value: t, label: t };
+          const tag = { section: 'ark', value: t, label: t, hidden: t === 'Traditionslös' };
           filterTagData.push(tag);
-          primaryTagParts.push(renderFilterTag(tag));
+          if (!tag.hidden) primaryTagParts.push(renderFilterTag(tag));
         });
         (p.taggar?.test || [])
           .filter(Boolean)
@@ -620,7 +620,7 @@ function initIndex() {
         const visibleTagData = filterTagData.filter(tag => !tag.hidden);
         const dockableTagData = visibleTagData.filter(tag => tag.section !== 'typ' && tag.section !== 'ark');
         const filterTagHtml = dockableTagData.map(tag => renderFilterTag(tag));
-        const infoFilterTagHtml = filterTagData.map(tag => renderFilterTag(tag));
+        const infoFilterTagHtml = visibleTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = filterTagHtml.join(' ');
         const infoTagsHtml = [xpTag].concat(infoFilterTagHtml).filter(Boolean).join(' ');
         const infoBoxTagParts = infoFilterTagHtml.filter(Boolean);


### PR DESCRIPTION
## Summary
- mark the fallback Traditionslös arketyp tag as hidden when preparing tag data for entry cards
- filter hidden tags out of all card-facing tag sections in both the index and character views while keeping them available for filtering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d15a6024d88323ac04f94b62e70e3a