### PR TITLE
Align inventory info rows inline

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1032,6 +1032,7 @@ input:focus, select:focus, textarea:focus {
   padding: .55rem .85rem;
   margin: .45rem 0;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, .28);
+  align-items: center;
 }
 
 .card-level-row + .card-info-box {
@@ -1044,6 +1045,7 @@ input:focus, select:focus, textarea:focus {
   gap: .35rem;
   flex: 1 1 280px;
   min-width: 0;
+  align-items: center;
 }
 
 .card-info-facts {
@@ -1053,6 +1055,31 @@ input:focus, select:focus, textarea:focus {
   align-items: center;
   justify-content: flex-start;
   flex: 0 1 auto;
+}
+
+.card-info-inline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: .35rem .6rem;
+  width: 100%;
+}
+
+.card-info-inline .card-info-tags {
+  flex: 1 1 auto;
+}
+
+.card-info-inline .card-info-facts {
+  flex: 0 0 auto;
+  gap: .3rem .8rem;
+}
+
+.card-info-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: .85rem;
+  color: var(--subtxt);
 }
 
 .card-info-fact {

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1194,9 +1194,6 @@ function initCharacter() {
           .filter(Boolean)
           .join(' ');
         const infoBoxTagParts = infoTagHtmlParts.filter(Boolean);
-        const infoBoxTagsHtml = infoBoxTagParts.length
-          ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
-          : '';
         const infoBoxFacts = infoMeta.filter(meta => {
           if (!meta) return false;
           const value = meta.value;
@@ -1204,16 +1201,42 @@ function initCharacter() {
           const label = String(meta.label || '').toLowerCase();
           return label.includes('pris') || label.includes('dagslön') || label.includes('vikt');
         });
-        const infoBoxFactsHtml = infoBoxFacts.length
-          ? `<div class="card-info-facts">${infoBoxFacts.map(f => {
-              const label = String(f.label ?? '').trim();
-              const value = String(f.value ?? '').trim();
-              if (!label || !value) return '';
-              return `<div class="card-info-fact"><span class="card-info-fact-label">${label}</span><span class="card-info-fact-value">${value}</span></div>`;
-            }).filter(Boolean).join('')}</div>`
-          : '';
-        const infoBoxHtml = (infoBoxTagsHtml || infoBoxFactsHtml)
-          ? `<div class="card-info-box">${infoBoxTagsHtml}${infoBoxFactsHtml}</div>`
+        const infoBoxFactParts = infoBoxFacts
+          .map(f => {
+            const label = String(f.label ?? '').trim();
+            const value = String(f.value ?? '').trim();
+            if (!label || !value) return '';
+            return `<div class="card-info-fact"><span class="card-info-fact-label">${label}</span><span class="card-info-fact-value">${value}</span></div>`;
+          })
+          .filter(Boolean);
+        let infoBoxContentHtml = '';
+        if (isInv(p) && (infoBoxTagParts.length || infoBoxFactParts.length)) {
+          const inlineTagsHtml = infoBoxTagParts.length
+            ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
+            : '';
+          const inlineFactsHtml = infoBoxFactParts.length
+            ? `<div class="card-info-facts">${infoBoxFactParts.join('')}</div>`
+            : '';
+          const arrowHtml = inlineTagsHtml && inlineFactsHtml
+            ? `<span class="card-info-arrow" aria-hidden="true">&rarr;</span>`
+            : '';
+          const inlineParts = [inlineTagsHtml, arrowHtml, inlineFactsHtml]
+            .filter(Boolean)
+            .join('');
+          infoBoxContentHtml = inlineParts
+            ? `<div class="card-info-inline">${inlineParts}</div>`
+            : '';
+        } else {
+          const infoBoxTagsHtml = infoBoxTagParts.length
+            ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
+            : '';
+          const infoBoxFactsHtml = infoBoxFactParts.length
+            ? `<div class="card-info-facts">${infoBoxFactParts.join('')}</div>`
+            : '';
+          infoBoxContentHtml = `${infoBoxTagsHtml}${infoBoxFactsHtml}`;
+        }
+        const infoBoxHtml = infoBoxContentHtml
+          ? `<div class="card-info-box">${infoBoxContentHtml}</div>`
           : '';
         const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
         const levelHtml = hideDetails ? '' : lvlSel;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -626,9 +626,6 @@ function initIndex() {
         const tagsHtml = filterTagHtml.join(' ');
         const infoTagsHtml = [xpTag].concat(infoFilterTagHtml).filter(Boolean).join(' ');
         const infoBoxTagParts = infoFilterTagHtml.filter(Boolean);
-        const infoBoxTagsHtml = infoBoxTagParts.length
-          ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
-          : '';
         const infoBoxFacts = infoMeta.filter(meta => {
           if (!meta) return false;
           const value = meta.value;
@@ -636,16 +633,42 @@ function initIndex() {
           const label = String(meta.label || '').toLowerCase();
           return label.includes('pris') || label.includes('dagslön') || label.includes('vikt');
         });
-        const infoBoxFactsHtml = infoBoxFacts.length
-          ? `<div class="card-info-facts">${infoBoxFacts.map(f => {
-              const label = String(f.label ?? '').trim();
-              const value = String(f.value ?? '').trim();
-              if (!label || !value) return '';
-              return `<div class="card-info-fact"><span class="card-info-fact-label">${label}</span><span class="card-info-fact-value">${value}</span></div>`;
-            }).filter(Boolean).join('')}</div>`
-          : '';
-        const infoBoxHtml = (infoBoxTagsHtml || infoBoxFactsHtml)
-          ? `<div class="card-info-box">${infoBoxTagsHtml}${infoBoxFactsHtml}</div>`
+        const infoBoxFactParts = infoBoxFacts
+          .map(f => {
+            const label = String(f.label ?? '').trim();
+            const value = String(f.value ?? '').trim();
+            if (!label || !value) return '';
+            return `<div class="card-info-fact"><span class="card-info-fact-label">${label}</span><span class="card-info-fact-value">${value}</span></div>`;
+          })
+          .filter(Boolean);
+        let infoBoxContentHtml = '';
+        if (isInv(p) && (infoBoxTagParts.length || infoBoxFactParts.length)) {
+          const inlineTagsHtml = infoBoxTagParts.length
+            ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
+            : '';
+          const inlineFactsHtml = infoBoxFactParts.length
+            ? `<div class="card-info-facts">${infoBoxFactParts.join('')}</div>`
+            : '';
+          const arrowHtml = inlineTagsHtml && inlineFactsHtml
+            ? `<span class="card-info-arrow" aria-hidden="true">&rarr;</span>`
+            : '';
+          const inlineParts = [inlineTagsHtml, arrowHtml, inlineFactsHtml]
+            .filter(Boolean)
+            .join('');
+          infoBoxContentHtml = inlineParts
+            ? `<div class="card-info-inline">${inlineParts}</div>`
+            : '';
+        } else {
+          const infoBoxTagsHtml = infoBoxTagParts.length
+            ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
+            : '';
+          const infoBoxFactsHtml = infoBoxFactParts.length
+            ? `<div class="card-info-facts">${infoBoxFactParts.join('')}</div>`
+            : '';
+          infoBoxContentHtml = `${infoBoxTagsHtml}${infoBoxFactsHtml}`;
+        }
+        const infoBoxHtml = infoBoxContentHtml
+          ? `<div class="card-info-box">${infoBoxContentHtml}</div>`
           : '';
         const dockPrimary = (p.taggar?.typ || [])[0] || '';
         const shouldDockTags = DOCK_TAG_TYPES.has(dockPrimary);


### PR DESCRIPTION
## Summary
- render inventory entry info as a single inline block with tags, arrow and price/weight details in both the index and character views
- add shared arrow markup and fact formatting reuse for inventory entries while keeping existing layout for other cards
- update card info styling to support the inline row without affecting non-inventory entries

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d15e7938848323bf282611d6ddf044