### PR TITLE
Adjust single level entry layout

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1137,7 +1137,8 @@ function initCharacter() {
       cats[cat].forEach(g=>{
         const p = g.entry;
         const availLvls = LVL.filter(l=>p.nivåer?.[l]);
-        const hasLevels = availLvls.length>0;
+        const hasSingleLevel = availLvls.length === 1;
+        const hasLevels = availLvls.length>1;
         const lvlSel = availLvls.length>1
           ? `<select class="level" data-name="${p.namn}"${p.trait?` data-trait="${p.trait}"`:''}>
               ${availLvls.map(l=>`<option${l===p.nivå?' selected':''}>${l}</option>`).join('')}
@@ -1189,11 +1190,21 @@ function initCharacter() {
         const tagHtmlParts = dockableTagData.map(tag => renderFilterTag(tag));
         const infoTagHtmlParts = visibleTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = tagHtmlParts.join(' ');
+        const lvlBadgeVal = availLvls.length ? p.nivå : '';
+        const lvlShort =
+          lvlBadgeVal === 'Mästare' ? 'M'
+          : (lvlBadgeVal === 'Gesäll' ? 'G'
+          : (lvlBadgeVal === 'Novis' ? 'N' : ''));
+        const levelTagHtml = (hasSingleLevel && lvlShort)
+          ? `<span class="tag level-tag" title="${lvlBadgeVal}">${lvlShort}</span>`
+          : '';
+        const infoTagParts = infoTagHtmlParts.slice();
+        if (levelTagHtml) infoTagParts.push(levelTagHtml);
         const infoTagsHtml = [xpTag]
-          .concat(infoTagHtmlParts)
+          .concat(infoTagParts)
           .filter(Boolean)
           .join(' ');
-        const infoBoxTagParts = infoTagHtmlParts.filter(Boolean);
+        const infoBoxTagParts = infoTagParts.filter(Boolean);
         const infoBoxTagsHtml = infoBoxTagParts.length
           ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
           : '';

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -501,7 +501,8 @@ function initIndex() {
         const curLvl = charLevel
           || LVL.find(l => p.nivåer?.[l]) || 'Novis';
         const availLvls = LVL.filter(l => p.nivåer?.[l]);
-        const hasLevels = availLvls.length > 0;
+        const hasSingleLevel = availLvls.length === 1;
+        const hasLevels = availLvls.length > 1;
         const lvlSel = availLvls.length > 1
           ? `<select class="level" data-name="${p.namn}">
               ${availLvls.map(l=>`<option${l===curLvl?' selected':''}>${l}</option>`).join('')}
@@ -624,8 +625,13 @@ function initIndex() {
         const filterTagHtml = dockableTagData.map(tag => renderFilterTag(tag));
         const infoFilterTagHtml = visibleTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = filterTagHtml.join(' ');
-        const infoTagsHtml = [xpTag].concat(infoFilterTagHtml).filter(Boolean).join(' ');
-        const infoBoxTagParts = infoFilterTagHtml.filter(Boolean);
+        const levelTagHtml = (hasSingleLevel && lvlShort)
+          ? `<span class="tag level-tag" title="${lvlBadgeVal}">${lvlShort}</span>`
+          : '';
+        const infoTagParts = infoFilterTagHtml.slice();
+        if (levelTagHtml) infoTagParts.push(levelTagHtml);
+        const infoTagsHtml = [xpTag].concat(infoTagParts).filter(Boolean).join(' ');
+        const infoBoxTagParts = infoTagParts.filter(Boolean);
         const infoBoxTagsHtml = infoBoxTagParts.length
           ? `<div class="card-info-tags tags">${infoBoxTagParts.join(' ')}</div>`
           : '';


### PR DESCRIPTION
## Summary
- treat single-level entries like other entries without moving the control buttons
- add an info-box level tag so single-level entries display their N/G/M marker

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d15f03f04c83239157a01315d8f1ef