### PR TITLE
Handle single-level entries in list views

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1137,8 +1137,9 @@ function initCharacter() {
       cats[cat].forEach(g=>{
         const p = g.entry;
         const availLvls = LVL.filter(l=>p.nivåer?.[l]);
-        const hasLevels = availLvls.length>0;
-        const lvlSel = availLvls.length>1
+        const hasAnyLevel = availLvls.length > 0;
+        const hasLevelSelect = availLvls.length > 1;
+        const lvlSel = hasLevelSelect
           ? `<select class="level" data-name="${p.namn}"${p.trait?` data-trait="${p.trait}"`:''}>
               ${availLvls.map(l=>`<option${l===p.nivå?' selected':''}>${l}</option>`).join('')}
             </select>`
@@ -1189,11 +1190,21 @@ function initCharacter() {
         const tagHtmlParts = dockableTagData.map(tag => renderFilterTag(tag));
         const infoTagHtmlParts = visibleTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = tagHtmlParts.join(' ');
-        const infoTagsHtml = [xpTag]
+        const lvlBadgeVal = hasAnyLevel ? (p.nivå || availLvls[0] || '') : '';
+        const lvlShort =
+          lvlBadgeVal === 'Mästare' ? 'M'
+          : (lvlBadgeVal === 'Gesäll' ? 'G'
+          : (lvlBadgeVal === 'Novis' ? 'N' : ''));
+        const singleLevelTagHtml = (!hasLevelSelect && lvlShort && lvlBadgeVal)
+          ? `<span class="tag level-tag" title="${lvlBadgeVal}">${lvlShort}</span>`
+          : '';
+        const infoTagParts = [xpTag]
           .concat(infoTagHtmlParts)
-          .filter(Boolean)
-          .join(' ');
+          .filter(Boolean);
+        if (singleLevelTagHtml) infoTagParts.push(singleLevelTagHtml);
+        const infoTagsHtml = infoTagParts.join(' ');
         const infoBoxTagParts = infoTagHtmlParts.filter(Boolean);
+        if (singleLevelTagHtml) infoBoxTagParts.push(singleLevelTagHtml);
         const infoBoxFacts = infoMeta.filter(meta => {
           if (!meta) return false;
           const value = meta.value;
@@ -1239,7 +1250,7 @@ function initCharacter() {
           ? `<div class="card-info-box">${infoBoxContentHtml}</div>`
           : '';
         const xpHtml = `<span class="xp-cost">Erf: ${xpText}</span>`;
-        const levelHtml = hideDetails ? '' : lvlSel;
+        const levelHtml = hideDetails ? '' : (hasLevelSelect ? lvlSel : '');
         const infoPanelHtml = buildInfoPanelHtml({
           tagsHtml: infoTagsHtml,
           bodyHtml: infoBodyHtml,
@@ -1319,7 +1330,7 @@ function initCharacter() {
           primaryTagsHtml,
           tagsHtml: (!compact && !shouldDockTags && tagsHtml) ? tagsHtml : '',
           infoBox: infoBoxHtml,
-          hasLevels,
+          hasLevels: hasLevelSelect,
           levelHtml,
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${desc}${raceInfo}${traitInfo}</div>` : '',
           leftSections,

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -501,8 +501,9 @@ function initIndex() {
         const curLvl = charLevel
           || LVL.find(l => p.nivåer?.[l]) || 'Novis';
         const availLvls = LVL.filter(l => p.nivåer?.[l]);
-        const hasLevels = availLvls.length > 0;
-        const lvlSel = availLvls.length > 1
+        const hasAnyLevel = availLvls.length > 0;
+        const hasLevelSelect = availLvls.length > 1;
+        const lvlSel = hasLevelSelect
           ? `<select class="level" data-name="${p.namn}">
               ${availLvls.map(l=>`<option${l===curLvl?' selected':''}>${l}</option>`).join('')}
             </select>`
@@ -624,8 +625,19 @@ function initIndex() {
         const filterTagHtml = dockableTagData.map(tag => renderFilterTag(tag));
         const infoFilterTagHtml = visibleTagData.map(tag => renderFilterTag(tag));
         const tagsHtml = filterTagHtml.join(' ');
-        const infoTagsHtml = [xpTag].concat(infoFilterTagHtml).filter(Boolean).join(' ');
+        const lvlBadgeVal = hasAnyLevel ? curLvl : '';
+        const lvlShort =
+          lvlBadgeVal === 'Mästare' ? 'M'
+          : (lvlBadgeVal === 'Gesäll' ? 'G'
+          : (lvlBadgeVal === 'Novis' ? 'N' : ''));
+        const singleLevelTagHtml = (!hasLevelSelect && lvlShort && lvlBadgeVal)
+          ? `<span class="tag level-tag" title="${lvlBadgeVal}">${lvlShort}</span>`
+          : '';
+        const infoTagParts = [xpTag].concat(infoFilterTagHtml).filter(Boolean);
+        if (singleLevelTagHtml) infoTagParts.push(singleLevelTagHtml);
+        const infoTagsHtml = infoTagParts.join(' ');
         const infoBoxTagParts = infoFilterTagHtml.filter(Boolean);
+        if (singleLevelTagHtml) infoBoxTagParts.push(singleLevelTagHtml);
         const infoBoxFacts = infoMeta.filter(meta => {
           if (!meta) return false;
           const value = meta.value;
@@ -682,13 +694,8 @@ function initIndex() {
           ? renderDockedTags(dockableTagData, 'entry-tags-mobile')
           : '';
         const xpHtml = (xpVal != null || isElityrke(p)) ? `<span class="xp-cost">Erf: ${xpText}</span>` : '';
-        const levelHtml = hideDetails ? '' : lvlSel;
+        const levelHtml = hideDetails ? '' : (hasLevelSelect ? lvlSel : '');
         // Compact meta badges (P/V/level) using short labels for mobile space
-        const lvlBadgeVal = (availLvls.length > 0) ? curLvl : '';
-        const lvlShort =
-          lvlBadgeVal === 'Mästare' ? 'M'
-          : (lvlBadgeVal === 'Gesäll' ? 'G'
-          : (lvlBadgeVal === 'Novis' ? 'N' : ''));
         const priceBadgeLabel = (priceLabel || 'Pris').replace(':','');
         const priceBadgeText = priceLabel === 'Dagslön:' ? 'Dagslön' : 'P';
         const badgeParts = [];
@@ -770,7 +777,7 @@ function initIndex() {
           primaryTagsHtml,
           tagsHtml: (!compact && !shouldDockTags && tagsHtml) ? tagsHtml : '',
           infoBox: infoBoxHtml,
-          hasLevels,
+          hasLevels: hasLevelSelect,
           levelHtml,
           descHtml: (!compact && !hideDetails) ? `<div class="card-desc">${cardDesc}</div>` : '',
           leftSections,


### PR DESCRIPTION
## Summary
- treat single-level entries like other entries by skipping the level row
- add a single-letter level tag to info boxes when only one level is available
- update both the index and character views to share the new behavior

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d161aa1b8883239dda51907aa3d703