### PR TITLE
Remove card info arrow element

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1074,14 +1074,6 @@ input:focus, select:focus, textarea:focus {
   gap: .3rem .8rem;
 }
 
-.card-info-arrow {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: .85rem;
-  color: var(--subtxt);
-}
-
 .card-info-fact {
   display: inline-flex;
   align-items: baseline;

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1228,10 +1228,7 @@ function initCharacter() {
           const inlineFactsHtml = infoBoxFactParts.length
             ? `<div class="card-info-facts">${infoBoxFactParts.join('')}</div>`
             : '';
-          const arrowHtml = inlineTagsHtml && inlineFactsHtml
-            ? `<span class="card-info-arrow" aria-hidden="true">&rarr;</span>`
-            : '';
-          const inlineParts = [inlineTagsHtml, arrowHtml, inlineFactsHtml]
+          const inlineParts = [inlineTagsHtml, inlineFactsHtml]
             .filter(Boolean)
             .join('');
           infoBoxContentHtml = inlineParts

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -661,10 +661,7 @@ function initIndex() {
           const inlineFactsHtml = infoBoxFactParts.length
             ? `<div class="card-info-facts">${infoBoxFactParts.join('')}</div>`
             : '';
-          const arrowHtml = inlineTagsHtml && inlineFactsHtml
-            ? `<span class="card-info-arrow" aria-hidden="true">&rarr;</span>`
-            : '';
-          const inlineParts = [inlineTagsHtml, arrowHtml, inlineFactsHtml]
+          const inlineParts = [inlineTagsHtml, inlineFactsHtml]
             .filter(Boolean)
             .join('');
           infoBoxContentHtml = inlineParts


### PR DESCRIPTION
## Summary
- remove the inline arrow indicator from card info markup in both list and character views
- drop the unused arrow styling rule from the stylesheet

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d164e257f48323981b237238c605cc