### PR TITLE
Fix off-canvas panel shadow bleed on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1717,7 +1717,7 @@ select.level {
   max-width: none; /* vi sätter nedan individuellt */
   height: 100%;
   background: var(--panel);
-  box-shadow: -4px 0 20px #0009;
+  box-shadow: none;
   transition: right .25s ease;
   z-index: 1000;
   overflow-y: auto;
@@ -1762,6 +1762,7 @@ select.level {
 #effectsPanel.open,
 #conflictPanel.open {
   right: 0;
+  box-shadow: -4px 0 20px #0009;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Summary
- remove the default box shadow from the off-canvas panels when closed so it no longer appears on mobile
- reapply the shadow when a panel has the `.open` class to keep the visual separation when visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d28454996c8323a230f74d0576ec07