### PR TITLE
Handle UI commands from search Enter

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1488,6 +1488,13 @@ function initCharacter() {
       dom.sIn.blur();
       const termTry = (sTemp || '').trim();
       const term = sTemp.toLowerCase();
+      if (termTry && window.tryUICommand && window.tryUICommand(termTry)) {
+        dom.sIn.value = '';
+        sTemp = '';
+        updateSearchDatalist();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+        return;
+      }
         // Ignorera sökförslag på Enter; hantera bara skriven text
       if (term === 'webapp') {
         const ua = navigator.userAgent.toLowerCase();

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -942,6 +942,13 @@ function initIndex() {
       dom.sIn.blur();
       const termTry = (sTemp || '').trim();
       const term = sTemp.toLowerCase();
+      if (termTry && window.tryUICommand && window.tryUICommand(termTry)) {
+        dom.sIn.value = '';
+        sTemp = '';
+        updateSearchDatalist();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+        return;
+      }
         // Ignorera sökförslag på Enter; hantera bara skriven text
         // Command: [N] random: <kategori> — pick N random entries in category
         {


### PR DESCRIPTION
## Summary
- run typed UI commands from the main search field when pressing Enter so highlight behavior triggers
- apply the same handling to the character view search while keeping cleanup logic intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d28db2341483238f68d921c77d6082