### PR TITLE
Persist filter selections on change

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1045,6 +1045,7 @@ function initCharacter() {
     F.typ .forEach(v=>push(`<span class="tag removable" data-type="typ" data-val="${v}">${v} ✕</span>`));
     F.ark .forEach(v=>push(`<span class="tag removable" data-type="ark" data-val="${v}">${v} ✕</span>`));
     F.test.forEach(v=>push(`<span class="tag removable" data-type="test" data-val="${v}">${v} ✕</span>`));
+    saveState();
   };
 
   const filtered = () => {


### PR DESCRIPTION
## Summary
- trigger a state save each time the active filters list updates
- ensure the latest search and tag filters persist across reloads, including on mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d51cdd711c8323b912539eea771e22