### PR TITLE
Fix info button layout on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -916,6 +916,7 @@ input:focus, select:focus, textarea:focus {
 .entry-row-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-areas: "main xp actions";
   align-items: center;
   gap: .45rem;
 }
@@ -959,6 +960,7 @@ input:focus, select:focus, textarea:focus {
 }
 
 .entry-header-main {
+  grid-area: main;
   display: flex;
   align-items: center;
   gap: .45rem;
@@ -976,6 +978,14 @@ input:focus, select:focus, textarea:focus {
   align-items: center;
   gap: .35rem;
   justify-content: flex-end;
+}
+
+.entry-header-xp {
+  grid-area: xp;
+}
+
+.entry-header-actions {
+  grid-area: actions;
 }
 
 /* nivåväljare i åtgärdsraden */
@@ -1547,6 +1557,9 @@ input:focus, select:focus, textarea:focus {
 @media (max-width: 680px) {
   .entry-row-header {
     grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-areas:
+      "main actions"
+      "xp xp";
     gap: .4rem;
   }
 


### PR DESCRIPTION
## Summary
- add grid areas to the entry card header so action buttons keep their position
- update the mobile grid layout to keep the info button on the first row while letting XP wrap

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d51c28a6508323b20b02bc9ce9e341