### PR TITLE
Adjust mobile layout for XP tag

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1559,14 +1559,15 @@ input:focus, select:focus, textarea:focus {
 
 @media (max-width: 680px) {
   .entry-row-header {
-    grid-template-columns: minmax(0, 1fr) auto;
-    grid-template-areas:
-      "main actions"
-      "xp xp";
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-template-areas: "main xp actions";
     gap: .4rem;
   }
 
-  .entry-row-header .entry-header-xp,
+  .entry-row-header .entry-header-xp {
+    justify-content: flex-end;
+  }
+
   .entry-row-header .entry-header-actions {
     justify-content: flex-start;
   }


### PR DESCRIPTION
## Summary
- keep the experience tag in the top row of entry headers on small screens by updating the mobile grid layout
- right-align the experience value so it sits directly to the left of the info button on phones

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d51fb4f8088323a1628a7bd2b0541d