### PR TITLE
Replace toolbar and action icons with SVGs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -198,6 +198,35 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   transition: transform .1s ease, opacity .1s ease;
 }
 .char-btn.danger { background: var(--danger); }
+
+.char-btn.icon { gap: .35rem; }
+
+.btn-icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  display: block;
+  pointer-events: none;
+}
+
+.char-btn.icon .btn-icon {
+  width: 1.35rem;
+  height: 1.35rem;
+}
+
+.party-toggle .btn-icon {
+  width: 1.3rem;
+  height: 1.3rem;
+}
+
+.mini-btn .btn-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.icon-only {
+  font-size: 0 !important;
+  line-height: 0;
+}
 .char-btn.icon   { font-size: 1.1rem; }
 .char-btn:hover  { opacity: .85; }
 .char-btn:active { transform: scale(.95); opacity: .7; }
@@ -1770,7 +1799,12 @@ select.level {
 .trait-xp-buttons .char-btn.icon {
   width: 2.45rem;
   height: 2.45rem;
-  font-size: 1.05rem;
+  padding: 0;
+}
+
+.trait-xp-buttons .char-btn.icon .btn-icon {
+  width: 1.4rem;
+  height: 1.4rem;
 }
 
 .trait-xp-buttons input {
@@ -1990,7 +2024,11 @@ select.level {
   .trait-xp-buttons .char-btn.icon {
     width: 2.2rem;
     height: 2.2rem;
-    font-size: 1rem;
+    padding: 0;
+  }
+  .trait-xp-buttons .char-btn.icon .btn-icon {
+    width: 1.25rem;
+    height: 1.25rem;
   }
   .trait-xp-buttons input {
     width: 5rem;
@@ -3440,6 +3478,10 @@ select.level {
   padding: .25rem .5rem;
   cursor: pointer;
   transition: transform .1s ease, opacity .1s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .25rem;
 }
 #folderManagerPopup .popup-inner.folder-ui .mini-btn:hover  { opacity: .85; }
 #folderManagerPopup .popup-inner.folder-ui .mini-btn:active { transform: scale(.95); opacity: .7; }

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1,4 +1,5 @@
 (function(window){
+const icon = (name, opts) => window.iconHtml ? window.iconHtml(name, opts) : '';
 function initCharacter() {
   const createEntryCard = window.entryCardFactory.create;
   dom.cName.textContent = store.characters.find(c=>c.id===store.current)?.name||'';
@@ -1282,7 +1283,7 @@ function initCharacter() {
           bodyHtml: infoBodyHtml,
           meta: infoMeta
         });
-        const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
+        const infoBtn = `<button class="char-btn icon icon-only info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">${icon('info')}</button>`;
 
         const multi = (p.kan_införskaffas_flera_gånger && typesList.some(t => ["Fördel","Nackdel"].includes(t))) && !p.trait;
         const total = storeHelper.getCurrentList(store).filter(x=>x.namn===p.namn && !x.trait).length;
@@ -1310,29 +1311,29 @@ function initCharacter() {
           const isDisadv = typesList.includes('Nackdel');
           if (isDisadv) {
             if (total > 0) {
-              const delBtn = `<button data-act="del" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`;
-              const subBtn = `<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">➖</button>`;
-              const addBtn = total < limit ? `<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>` : '';
+              const delBtn = `<button data-act="del" class="char-btn danger icon icon-only" data-name="${p.namn}">${icon('remove')}</button>`;
+              const subBtn = `<button data-act="sub" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Minska">${icon('minus')}</button>`;
+              const addBtn = total < limit ? `<button data-act="add" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>` : '';
               buttonParts.push(delBtn, subBtn);
               if (addBtn) buttonParts.push(addBtn);
             } else {
-              const addBtn = `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`;
+              const addBtn = `<button data-act="add" class="char-btn icon icon-only add-btn" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`;
               buttonParts.push(addBtn);
             }
             if (conflictBtn) buttonParts.push(conflictBtn);
           } else {
             const remBtn = total > 0
-              ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
+              ? `<button data-act="rem" class="char-btn danger icon icon-only" data-name="${p.namn}">${icon('remove')}</button>`
               : '';
             const addBtn = total < limit
-              ? `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`
+              ? `<button data-act="add" class="char-btn icon icon-only add-btn" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`
               : '';
             if (remBtn) buttonParts.push(remBtn);
             if (conflictBtn) buttonParts.push(conflictBtn);
             if (addBtn) buttonParts.push(addBtn);
           }
         } else {
-          buttonParts.push(`<button class="char-btn danger icon" data-act="rem">🗑</button>`);
+          buttonParts.push(`<button class="char-btn danger icon icon-only" data-act="rem">${icon('remove')}</button>`);
           if (conflictBtn) buttonParts.push(conflictBtn);
         }
         const dockPrimary = (p.taggar?.typ || [])[0] || '';

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1,4 +1,5 @@
 (function(window){
+const icon = (name, opts) => window.iconHtml ? window.iconHtml(name, opts) : '';
 function initIndex() {
   const createEntryCard = window.entryCardFactory.create;
   if (dom.cName) {
@@ -676,7 +677,7 @@ function initIndex() {
         const meta = ensureEntryMeta(p) || {};
         if (p.kolumner && p.rader) {
           const infoHtml = tabellInfoHtml(p);
-          const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info">ℹ️</button>`;
+          const infoBtn = `<button class="char-btn icon icon-only info-btn" data-info="${encodeURIComponent(infoHtml)}" data-tabell="1" aria-label="Visa info">${icon('info')}</button>`;
           const dataset = { name: p.namn };
           if (p.id) dataset.id = p.id;
           const visibleTags = (meta.typList || [])
@@ -925,7 +926,7 @@ function initIndex() {
           bodyHtml: infoBodyHtml,
           meta: infoMeta
         });
-        const infoBtn = `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
+        const infoBtn = `<button class="char-btn icon icon-only info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">${icon('info')}</button>`;
         const multi = isInv(p) || (p.kan_införskaffas_flera_gånger && (p.taggar.typ || []).some(t => ["Fördel","Nackdel"].includes(t)));
         let count;
         if (isInv(p)) {
@@ -957,16 +958,16 @@ function initIndex() {
         if (allowAdd) {
           if (multi) {
             if (count > 0) {
-              actionButtons.push(`<button data-act="del" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`);
-              actionButtons.push(`<button data-act="sub" class="char-btn" data-name="${p.namn}" aria-label="Minska">➖</button>`);
-              if (count < limit) actionButtons.push(`<button data-act="add" class="char-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
+              actionButtons.push(`<button data-act="del" class="char-btn danger icon icon-only" data-name="${p.namn}">${icon('remove')}</button>`);
+              actionButtons.push(`<button data-act="sub" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Minska">${icon('minus')}</button>`);
+              if (count < limit) actionButtons.push(`<button data-act="add" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`);
             } else {
-              actionButtons.push(`<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`);
+              actionButtons.push(`<button data-act="add" class="char-btn icon icon-only add-btn" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`);
             }
           } else {
             const mainBtn = inChar
-              ? `<button data-act="rem" class="char-btn danger icon" data-name="${p.namn}">🗑</button>`
-              : `<button data-act="add" class="char-btn add-btn" data-name="${p.namn}" aria-label="Lägg till">➕</button>`;
+              ? `<button data-act="rem" class="char-btn danger icon icon-only" data-name="${p.namn}">${icon('remove')}</button>`
+              : `<button data-act="add" class="char-btn icon icon-only add-btn" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`;
             actionButtons.push(mainBtn);
           }
         }

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -3,6 +3,7 @@
    =========================================================== */
 
 (function(window){
+  const icon = (name, opts) => window.iconHtml ? window.iconHtml(name, opts) : '';
   const F = { invTxt: '', typ: [], ark: [], test: [] };
   // Bring shared currency bases into local scope
   const SBASE = window.SBASE;
@@ -2224,8 +2225,8 @@ function openVehiclePopup(preselectId, precheckedPaths) {
           <div class="formal-section">
             <div class="formal-title">Pengar
               <div class="money-control">
-                <button id="moneyMinusBtn" data-act="moneyMinus" class="char-btn icon" aria-label="Minska mynt" title="Minska mynt">➖</button>
-                <button id="moneyPlusBtn" data-act="moneyPlus" class="char-btn icon" aria-label="Öka mynt" title="Öka mynt">➕</button>
+                <button id="moneyMinusBtn" data-act="moneyMinus" class="char-btn icon icon-only" aria-label="Minska mynt" title="Minska mynt">${icon('minus')}</button>
+                <button id="moneyPlusBtn" data-act="moneyPlus" class="char-btn icon icon-only" aria-label="Öka mynt" title="Öka mynt">${icon('plus')}</button>
               </div>
             </div>
             <div class="money-line"><span class="label">Kontant:</span><span class="value">${cash.daler}D ${cash.skilling}S ${cash['örtegar']}Ö</span></div>
@@ -2272,12 +2273,12 @@ function openVehiclePopup(preselectId, precheckedPaths) {
       const canStack = ['kraft','ritual'].includes(entry.bound);
       const buttonParts = [];
       if (isGear && !canStack) {
-        buttonParts.push('<button data-act="del" class="char-btn danger icon">🗑</button>');
+        buttonParts.push(`<button data-act="del" class="char-btn danger icon icon-only">${icon('remove')}</button>`);
       } else {
         buttonParts.push(
-          '<button data-act="del" class="char-btn danger icon">🗑</button>',
-          '<button data-act="sub" class="char-btn" aria-label="Minska">➖</button>',
-          '<button data-act="add" class="char-btn" aria-label="Lägg till">➕</button>'
+          `<button data-act="del" class="char-btn danger icon icon-only">${icon('remove')}</button>`,
+          `<button data-act="sub" class="char-btn icon icon-only" aria-label="Minska">${icon('minus')}</button>`,
+          `<button data-act="add" class="char-btn icon icon-only" aria-label="Lägg till">${icon('plus')}</button>`
         );
       }
       if (isCustom) buttonParts.push('<button data-act="editCustom" class="char-btn">✏️</button>');
@@ -2348,7 +2349,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
         const bodyStr = typeof bodyHtml === 'string' ? bodyHtml : String(bodyHtml || '');
         if (!tagsHtml.trim() && !metaItems.length && !bodyStr.trim()) return '';
         const infoPanelHtml = buildInfoPanelHtml({ tagsHtml, bodyHtml: bodyStr, meta: metaItems });
-        return `<button class="char-btn info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">ℹ️</button>`;
+        return `<button class="char-btn icon icon-only info-btn" data-info="${encodeURIComponent(infoPanelHtml)}" aria-label="Visa info">${icon('info')}</button>`;
       };
 
       const infoBtnHtml = buildInfoButton({
@@ -2410,12 +2411,12 @@ function openVehiclePopup(preselectId, precheckedPaths) {
         const cCanStack = ['kraft','ritual'].includes(centry.bound);
         const cButtons = [];
         if (cIsGear && !cCanStack) {
-          cButtons.push('<button data-act="del" class="char-btn danger icon">🗑</button>');
+          cButtons.push(`<button data-act="del" class="char-btn danger icon icon-only">${icon('remove')}</button>`);
         } else {
           cButtons.push(
-            '<button data-act="del" class="char-btn danger icon">🗑</button>',
-            '<button data-act="sub" class="char-btn" aria-label="Minska">➖</button>',
-            '<button data-act="add" class="char-btn" aria-label="Lägg till">➕</button>'
+            `<button data-act="del" class="char-btn danger icon icon-only">${icon('remove')}</button>`,
+            `<button data-act="sub" class="char-btn icon icon-only" aria-label="Minska">${icon('minus')}</button>`,
+            `<button data-act="add" class="char-btn icon icon-only" aria-label="Lägg till">${icon('plus')}</button>`
           );
         }
         if (cTagTyp.includes('Hemmagjort')) cButtons.push('<button data-act="editCustom" class="char-btn">✏️</button>');

--- a/js/main.js
+++ b/js/main.js
@@ -1401,7 +1401,7 @@ function openFolderManagerPopup() {
     list.innerHTML = folders.map((f, idx) => {
       const cnt = charMap.get(f.id) || 0;
       const esc = s => String(s || '').replace(/[&<>"]/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m]));
-      const delBtn = f.system ? '' : `<button class="mini-btn danger" data-action="delete" title="Ta bort">🗑</button>`;
+      const delBtn = f.system ? '' : `<button class="mini-btn danger icon-only" data-action="delete" title="Ta bort">${window.iconHtml ? window.iconHtml('remove') : '🗑'}</button>`;
       const upDisabled = idx === 0 ? ' disabled' : '';
       const downDisabled = idx === folders.length - 1 ? ' disabled' : '';
       return (

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -14,6 +14,8 @@ const FILTER_CARD_KEY_MAP = Object.freeze({
   filterSettingsCard: FILTER_SETTINGS_KEY
 });
 
+const icon = (name, opts) => window.iconHtml ? window.iconHtml(name, opts) : '';
+
 class SharedToolbar extends HTMLElement {
   constructor() {
     super();
@@ -220,13 +222,13 @@ class SharedToolbar extends HTMLElement {
           <span class="exp-counter">XP: <span id="xpOut">0</span></span>
         </div>
         <div class="button-row">
-          <button  id="traitsToggle" class="char-btn icon" title="Egenskaper">📊</button>
+          <button  id="traitsToggle" class="char-btn icon icon-only" title="Egenskaper">${icon('egenskaper')}</button>
           <a       id="inventoryLink" class="char-btn icon nav-link" title="Inventarievy" href="inventory.html">
-            🎒 <span id="invBadge">0</span>
+            ${icon('inventarie')}<span id="invBadge">0</span>
           </a>
-          <a       id="indexLink" class="char-btn icon nav-link" title="Index" href="index.html">📇</a>
-          <a       id="characterLink" class="char-btn icon nav-link" title="Rollperson" href="character.html">🧝</a>
-          <button  id="filterToggle" class="char-btn icon" title="Filter">⚙️</button>
+          <a       id="indexLink" class="char-btn icon icon-only nav-link" title="Index" href="index.html">${icon('index')}</a>
+          <a       id="characterLink" class="char-btn icon icon-only nav-link" title="Rollperson" href="character.html">${icon('character')}</a>
+          <button  id="filterToggle" class="char-btn icon icon-only" title="Filter">${icon('settings')}</button>
         </div>
       </footer>
 
@@ -246,9 +248,9 @@ class SharedToolbar extends HTMLElement {
               <div class="trait-xp-header">
                 <span class="trait-xp-title">XP-status</span>
                 <div class="xp-control trait-xp-buttons">
-                  <button id="xpMinus" class="char-btn icon" type="button" aria-label="Minska XP" title="Minska XP">➖</button>
+                  <button id="xpMinus" class="char-btn icon icon-only" type="button" aria-label="Minska XP" title="Minska XP">${icon('minus')}</button>
                   <input id="xpInput" type="number" min="0" value="0" aria-label="Totala erfarenhetspoäng">
-                  <button id="xpPlus" class="char-btn icon" type="button" aria-label="Öka XP" title="Öka XP">➕</button>
+                  <button id="xpPlus" class="char-btn icon icon-only" type="button" aria-label="Öka XP" title="Öka XP">${icon('plus')}</button>
                 </div>
               </div>
               <div class="trait-xp-row">
@@ -347,7 +349,7 @@ class SharedToolbar extends HTMLElement {
                     <span class="toggle-desc">
                       <span class="toggle-question">Smed i partyt?</span>
                     </span>
-                    <button id="partySmith" class="party-toggle">⚒️</button>
+                    <button id="partySmith" class="party-toggle icon-only">${icon('smithing')}</button>
                   </li>
                   <li>
                     <span class="toggle-desc">
@@ -411,7 +413,7 @@ class SharedToolbar extends HTMLElement {
                   <span class="toggle-desc">
                     <span class="toggle-question">Behöver du hjälp?</span>
                   </span>
-                  <button id="infoToggle" class="party-toggle" title="Visa hjälp">ℹ️</button>
+                  <button id="infoToggle" class="party-toggle icon-only" title="Visa hjälp">${icon('info')}</button>
                 </li>
               </ul>
             </div>
@@ -437,7 +439,7 @@ class SharedToolbar extends HTMLElement {
             <label for="customType">Typ</label>
             <div class="custom-type-row">
               <select id="customType"></select>
-              <button id="customTypeAdd" class="char-btn" type="button" aria-label="Lägg till typ" title="Lägg till typ">➕</button>
+              <button id="customTypeAdd" class="char-btn icon icon-only" type="button" aria-label="Lägg till typ" title="Lägg till typ">${icon('plus')}</button>
             </div>
             <div id="customTypeTags" class="tags"></div>
           </div>
@@ -472,7 +474,7 @@ class SharedToolbar extends HTMLElement {
           <div id="customPowerFields" class="filter-group" style="display:none">
             <label>Förmågor</label>
             <div id="customPowerList"></div>
-            <button id="customPowerAdd" class="char-btn" type="button" aria-label="Lägg till förmåga" title="Lägg till förmåga">➕</button>
+            <button id="customPowerAdd" class="char-btn icon icon-only" type="button" aria-label="Lägg till förmåga" title="Lägg till förmåga">${icon('plus')}</button>
           </div>
           <div id="customBoundFields" class="filter-group" style="display:none">
             <label for="customBoundType">Bundet till</label>
@@ -777,7 +779,7 @@ class SharedToolbar extends HTMLElement {
               <label for="newFolderName">+ Ny mapp:</label>
               <div class="inline-controls">
                 <input id="newFolderName" placeholder="Mappnamn">
-                <button id="addFolderBtn" class="char-btn" aria-label="Lägg till mapp" title="Lägg till mapp">➕</button>
+                <button id="addFolderBtn" class="char-btn icon icon-only" aria-label="Lägg till mapp" title="Lägg till mapp">${icon('plus')}</button>
               </div>
             </div>
           </section>

--- a/js/utils.js
+++ b/js/utils.js
@@ -24,6 +24,31 @@
   ];
   const SBASE = 10, OBASE = 10;
 
+  const ICON_SOURCES = Object.freeze({
+    character : 'icons/character.svg',
+    egenskaper: 'icons/egenskaper.svg',
+    index     : 'icons/index.svg',
+    info      : 'icons/info.svg',
+    inventarie: 'icons/inventarie.svg',
+    minus     : 'icons/minus.svg',
+    plus      : 'icons/plus.svg',
+    remove    : 'icons/remove.svg',
+    settings  : 'icons/settings.svg',
+    smithing  : 'icons/smithing.svg'
+  });
+
+  function iconHtml(name, opts = {}) {
+    if (!name) return '';
+    const src = ICON_SOURCES[name] || `icons/${name}.svg`;
+    const extraClass = opts.className ? ` ${opts.className}` : '';
+    const alt = typeof opts.alt === 'string' ? opts.alt : '';
+    const attrs = [];
+    if (opts.loading) attrs.push(`loading="${opts.loading}"`);
+    if (opts.decoding) attrs.push(`decoding="${opts.decoding}"`);
+    const attrStr = attrs.length ? ` ${attrs.join(' ')}` : '';
+    return `<img src="${src}" alt="${alt}" class="btn-icon${extraClass}"${attrStr}>`;
+  }
+
   // Konvertera ett penningobjekt till totalt antal örtegar
   function moneyToO(m) {
     m = m || {};
@@ -419,4 +444,5 @@
   window.catComparator = catComparator;
   window.catName = catName;
   window.lookupEntry = lookupEntry;
+  window.iconHtml = iconHtml;
 })(window);

--- a/notes.html
+++ b/notes.html
@@ -40,7 +40,7 @@
     <div class="panel-header">
       <h2 id="charName" style="margin:0;"></h2>
       <div class="header-actions">
-        <a href="character.html" id="charLink" class="char-btn icon" title="Till rollperson">🧝</a>
+        <a href="character.html" id="charLink" class="char-btn icon icon-only" title="Till rollperson"><img src="icons/character.svg" alt="" class="btn-icon"></a>
         <button id="editBtn" class="char-btn icon" title="Redigera">✏️</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add a shared `iconHtml` helper and CSS utilities for SVG-based toolbar and action buttons
- swap emoji content for SVG icons across the shared toolbar, dynamic entry/action buttons, and folder manager controls
- update notes header link to use the character SVG so the character button matches the new styling

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d53710d7b48323bf5f893be349f7fb