### PR TITLE
Add manual PWA update trigger and fix dismissal caching

### DIFF
--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,85 +1,183 @@
 if ('serviceWorker' in navigator) {
   let reloadOnControllerChange = false;
-  window.addEventListener('load', () => {
-    const storageKeyPrefix = 'pwa-dismissed:';
-    const buildStorageKey = scriptURL => `${storageKeyPrefix}${scriptURL}`;
+  let latestRegistration = null;
+  const storageKeyPrefix = 'pwa-dismissed:';
 
-    const getStorages = () => {
-      const storages = [];
-      try {
-        if (window.sessionStorage) {
-          storages.push(window.sessionStorage);
-        }
-      } catch (error) {
-        // Access to sessionStorage may be blocked; ignore.
-      }
-      try {
-        if (window.localStorage) {
-          storages.push(window.localStorage);
-        }
-      } catch (error) {
-        // Access to localStorage may be blocked; ignore.
-      }
-      return storages;
-    };
+  const buildStorageKey = id => (id ? `${storageKeyPrefix}${id}` : null);
 
-    const clearDismissalsExcept = scriptURL => {
-      const keyToKeep = scriptURL ? buildStorageKey(scriptURL) : null;
-      getStorages().forEach(storage => {
-        try {
-          for (let i = storage.length - 1; i >= 0; i -= 1) {
-            const key = storage.key(i);
-            if (key && key.startsWith(storageKeyPrefix) && key !== keyToKeep) {
-              storage.removeItem(key);
-            }
+  const getStorages = () => {
+    const storages = [];
+    try {
+      if (window.sessionStorage) {
+        storages.push(window.sessionStorage);
+      }
+    } catch (error) {
+      // Access to sessionStorage may be blocked; ignore.
+    }
+    try {
+      if (window.localStorage) {
+        storages.push(window.localStorage);
+      }
+    } catch (error) {
+      // Access to localStorage may be blocked; ignore.
+    }
+    return storages;
+  };
+
+  const getLatestWorkerVersion = async () => {
+    try {
+      const response = await fetch('sw.js', { cache: 'no-store' });
+      const text = await response.text();
+      const match = text.match(/CACHE_NAME\s*=\s*['"]([^'"]+)['"]/);
+      if (match) return match[1];
+    } catch (error) {
+      // Ignore version lookup errors.
+    }
+    return null;
+  };
+
+  const clearDismissalsExcept = id => {
+    const keyToKeep = buildStorageKey(id);
+    getStorages().forEach(storage => {
+      try {
+        for (let i = storage.length - 1; i >= 0; i -= 1) {
+          const key = storage.key(i);
+          if (key && key.startsWith(storageKeyPrefix) && key !== keyToKeep) {
+            storage.removeItem(key);
           }
-        } catch (error) {
-          // Ignore storage errors.
         }
-      });
-    };
+      } catch (error) {
+        // Ignore storage errors.
+      }
+    });
+  };
 
-    const clearWorkerDismissal = scriptURL => {
-      if (!scriptURL) return;
-      const key = buildStorageKey(scriptURL);
-      getStorages().forEach(storage => {
-        try {
-          storage.removeItem(key);
-        } catch (error) {
-          // Ignore storage errors.
+  const clearWorkerDismissal = id => {
+    if (!id) return;
+    const key = buildStorageKey(id);
+    getStorages().forEach(storage => {
+      try {
+        storage.removeItem(key);
+      } catch (error) {
+        // Ignore storage errors.
+      }
+    });
+  };
+
+  const markWorkerDismissed = id => {
+    if (!id) return;
+    const key = buildStorageKey(id);
+    getStorages().forEach(storage => {
+      try {
+        storage.setItem(key, '1');
+      } catch (error) {
+        // Ignore storage errors.
+      }
+    });
+  };
+
+  const isWorkerDismissed = id => {
+    if (!id) return false;
+    const key = buildStorageKey(id);
+    return getStorages().some(storage => {
+      try {
+        return storage.getItem(key) === '1';
+      } catch (error) {
+        return false;
+      }
+    });
+  };
+
+  const clearAllWorkerDismissals = () => {
+    clearDismissalsExcept(null);
+  };
+
+  const applyWaitingWorker = registration => {
+    if (!registration?.waiting) return false;
+    reloadOnControllerChange = true;
+    registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+    return true;
+  };
+
+  const waitForInstallingWorker = registration =>
+    new Promise(resolve => {
+      const installing = registration.installing;
+      if (!installing) {
+        resolve(registration.waiting || null);
+        return;
+      }
+
+      let settled = false;
+      let timeoutId;
+      const finish = value => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      };
+
+      const onStateChange = () => {
+        if (installing.state === 'installed' || installing.state === 'redundant') {
+          finish(registration.waiting || null);
         }
-      });
-    };
+      };
 
-    const clearAllWorkerDismissals = () => {
-      clearDismissalsExcept(null);
-    };
+      const onUpdateFound = () => {
+        const newWorker = registration.installing;
+        if (!newWorker || newWorker === installing) return;
+        newWorker.addEventListener('statechange', onStateChange);
+      };
 
-    const isWorkerDismissed = scriptURL => {
-      if (!scriptURL) return false;
-      const key = buildStorageKey(scriptURL);
-      return getStorages().some(storage => {
-        try {
-          return storage.getItem(key) === '1';
-        } catch (error) {
-          return false;
-        }
-      });
-    };
+      const cleanup = () => {
+        installing.removeEventListener('statechange', onStateChange);
+        registration.removeEventListener('updatefound', onUpdateFound);
+        if (timeoutId) clearTimeout(timeoutId);
+      };
 
-    const markWorkerDismissed = scriptURL => {
-      if (!scriptURL) return;
-      const key = buildStorageKey(scriptURL);
-      getStorages().forEach(storage => {
-        try {
-          storage.setItem(key, '1');
-        } catch (error) {
-          // Ignore storage errors.
-        }
-      });
-    };
+      registration.addEventListener('updatefound', onUpdateFound);
+      installing.addEventListener('statechange', onStateChange);
+
+      timeoutId = setTimeout(() => {
+        finish(registration.waiting || null);
+      }, 10000);
+
+      if (installing.state === 'installed') {
+        finish(registration.waiting || null);
+      }
+    });
+
+  const triggerManualUpdate = async () => {
+    try {
+      const registration = latestRegistration || (await navigator.serviceWorker.getRegistration());
+      if (!registration) {
+        return { status: 'missing' };
+      }
+      latestRegistration = registration;
+
+      if (registration.waiting) {
+        applyWaitingWorker(registration);
+        return { status: 'applied' };
+      }
+
+      await registration.update();
+      const waiting = await waitForInstallingWorker(registration);
+      if (waiting) {
+        applyWaitingWorker(registration);
+        return { status: 'applied' };
+      }
+
+      return { status: 'up-to-date' };
+    } catch (error) {
+      return { status: 'error', error };
+    }
+  };
+
+  window.requestPwaUpdate = triggerManualUpdate;
+
+  window.addEventListener('load', () => {
 
     navigator.serviceWorker.register('sw.js').then(registration => {
+      latestRegistration = registration;
       // Proactively check for updates
       registration.update();
       document.addEventListener('visibilitychange', () => {
@@ -89,33 +187,31 @@ if ('serviceWorker' in navigator) {
       });
 
       // If there's already a waiting worker, prompt immediately
-      const promptUserToRefresh = reg => {
+      const promptUserToRefresh = async reg => {
         if (!reg) return;
         const waitingWorker = reg.waiting;
         if (!waitingWorker) return;
-        const { scriptURL } = waitingWorker;
+        const version = await getLatestWorkerVersion();
+        const dismissId = version || waitingWorker.scriptURL;
 
-        clearDismissalsExcept(scriptURL);
+        clearDismissalsExcept(dismissId);
 
         if (!navigator.serviceWorker.controller) {
           return;
         }
 
-        if (scriptURL && isWorkerDismissed(scriptURL)) {
+        if (dismissId && isWorkerDismissed(dismissId)) {
           return;
         }
 
         const shouldReload = window.confirm('Ny version tillgänglig – Ladda om?');
         if (shouldReload) {
-          if (scriptURL) {
-            clearWorkerDismissal(scriptURL);
+          if (dismissId) {
+            clearWorkerDismissal(dismissId);
           }
-          reloadOnControllerChange = true;
-          if (reg.waiting) {
-            reg.waiting.postMessage({ type: 'SKIP_WAITING' });
-          }
-        } else if (scriptURL) {
-          markWorkerDismissed(scriptURL);
+          applyWaitingWorker(reg);
+        } else if (dismissId) {
+          markWorkerDismissed(dismissId);
         }
       };
 
@@ -129,7 +225,7 @@ if ('serviceWorker' in navigator) {
         reg.addEventListener('updatefound', () => {
           const newWorker = reg.installing;
           if (!newWorker) return;
-          newWorker.addEventListener('statechange', () => {
+          newWorker.addEventListener('statechange', async () => {
             if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
               // New update installed and waiting
               promptUserToRefresh(reg);

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -383,6 +383,9 @@ class SharedToolbar extends HTMLElement {
                   </li>
                 </ul>
               </div>
+              <div class="char-btn-row">
+                <button id="checkForUpdates" class="char-btn">Uppdatera appen</button>
+              </div>
             </div>
           </li>
         </ul>
@@ -1114,6 +1117,46 @@ class SharedToolbar extends HTMLElement {
     if (btn.id === 'infoToggle')   return this.toggle('infoPanel');
     /* stäng */
     if (btn.dataset.close) return this.close(btn.dataset.close);
+
+    if (btn.id === 'checkForUpdates') {
+      if (typeof window.requestPwaUpdate !== 'function') {
+        window.toast?.('Uppdateringsfunktionen är inte tillgänglig.');
+        return;
+      }
+      const originalText = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = 'Kontrollerar…';
+      Promise.resolve()
+        .then(() => window.requestPwaUpdate())
+        .then(result => {
+          switch (result?.status) {
+            case 'applied':
+              window.toast?.('Uppdaterar appen…');
+              break;
+            case 'up-to-date':
+              window.toast?.('Appen är redan uppdaterad.');
+              break;
+            case 'missing':
+              window.toast?.('Ingen installerad webapp hittades.');
+              break;
+            case 'error':
+              window.toast?.('Kunde inte söka efter uppdatering.');
+              break;
+            default:
+              window.toast?.('Kunde inte söka efter uppdatering.');
+              break;
+          }
+        })
+        .catch(error => {
+          console.error('PWA update failed', error);
+          window.toast?.('Kunde inte söka efter uppdatering.');
+        })
+        .finally(() => {
+          btn.disabled = false;
+          btn.textContent = originalText;
+        });
+      return;
+    }
 
     if (btn.id === 'collapseAllFilters') {
       const cards = [...this.shadowRoot.querySelectorAll('#filterPanel .card:not(#searchFiltersCard):not(.help-card)')];


### PR DESCRIPTION
## Summary
- fix the service worker dismissal cache so new versions are prompted again by version keying
- expose a manual PWA update helper that re-checks the service worker and applies it when available
- surface the helper in the filter settings as an "Uppdatera appen" button with user feedback

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d53f448f748323ae33c90838a87222