### PR TITLE
Replace SVG icons with PNG versions

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -25,21 +25,21 @@
   const SBASE = 10, OBASE = 10;
 
   const ICON_SOURCES = Object.freeze({
-    character : 'icons/character.svg',
-    egenskaper: 'icons/egenskaper.svg',
-    index     : 'icons/index.svg',
-    info      : 'icons/info.svg',
-    inventarie: 'icons/inventarie.svg',
-    minus     : 'icons/minus.svg',
-    plus      : 'icons/plus.svg',
-    remove    : 'icons/remove.svg',
-    settings  : 'icons/settings.svg',
-    smithing  : 'icons/smithing.svg'
+    character : 'icons/character.png',
+    egenskaper: 'icons/egenskaper.png',
+    index     : 'icons/index.png',
+    info      : 'icons/info.png',
+    inventarie: 'icons/inventarie.png',
+    minus     : 'icons/minus.png',
+    plus      : 'icons/plus.png',
+    remove    : 'icons/remove.png',
+    settings  : 'icons/settings.png',
+    smithing  : 'icons/smithing.png'
   });
 
   function iconHtml(name, opts = {}) {
     if (!name) return '';
-    const src = ICON_SOURCES[name] || `icons/${name}.svg`;
+    const src = ICON_SOURCES[name] || `icons/${name}.png`;
     const extraClass = opts.className ? ` ${opts.className}` : '';
     const alt = typeof opts.alt === 'string' ? opts.alt : '';
     const attrs = [];

--- a/notes.html
+++ b/notes.html
@@ -40,7 +40,7 @@
     <div class="panel-header">
       <h2 id="charName" style="margin:0;"></h2>
       <div class="header-actions">
-        <a href="character.html" id="charLink" class="char-btn icon icon-only" title="Till rollperson"><img src="icons/character.svg" alt="" class="btn-icon"></a>
+        <a href="character.html" id="charLink" class="char-btn icon icon-only" title="Till rollperson"><img src="icons/character.png" alt="" class="btn-icon"></a>
         <button id="editBtn" class="char-btn icon" title="Redigera">✏️</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- switch toolbar image reference in `notes.html` from SVG to PNG to match available assets
- update shared icon source mappings in `js/utils.js` to point to PNG files and default to PNG fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5436b3cec8323bfcb5f6649adfccb