### PR TITLE
Cap advantage XP cost at 15

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -1516,7 +1516,9 @@ function defaultTraits() {
   function advantageTotalCost(count) {
     const qty = Number(count) || 0;
     if (qty <= 0) return 0;
-    return qty * ADVANTAGE_STEP_COST;
+    if (qty <= 1) return ADVANTAGE_STEP_COST;
+    if (qty === 2) return ADVANTAGE_STEP_COST * 2;
+    return ADVANTAGE_STEP_COST * 3;
   }
 
   function resolveAdvantageCount(entry, list, types) {


### PR DESCRIPTION
## Summary
- cap the calculated XP cost for repeatedly purchased advantages at 15 to keep the counter consistent

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d546c1a60c8323bf6f7e52f94c52ad