### PR TITLE
Fix mobile back navigation for info panel

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -92,7 +92,17 @@
   }
 
   window.addEventListener('popstate', (ev) => {
-    if (manualCloseCount > 0) { manualCloseCount--; return; }
+    if (manualCloseCount > 0) {
+      manualCloseCount--;
+      const topOverlay = overlayStack[overlayStack.length - 1];
+      // Om popstate kommer från en historiknavigering vi själva triggat
+      // (t.ex. när en annan panel stängts manuellt) så motsvarar eventets
+      // state den nu öppna panelen. I det fallet ska vi inte stänga något
+      // ytterligare, men en användarinitierad back ska fortfarande fungera.
+      if (!topOverlay || ev?.state?.overlay === topOverlay.id) {
+        return;
+      }
+    }
     const el = overlayStack[overlayStack.length - 1];
     if (el) {
       isPop = true;


### PR DESCRIPTION
## Summary
- adjust overlay popstate handler to ignore only programmatic history changes that match the currently open panel
- ensure user initiated back navigation still closes the info offcanvas panel on mobile

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d548a4e9248323b94b92f5164f2026