### PR TITLE
Remove inventory badge counter from toolbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1664,10 +1664,6 @@ input:focus, select:focus, textarea:focus {
   min-width: 0;
 }
 
-/* Badge för inventarie­knapp */
-#invBadge { background: var(--danger); border-radius: 50%;
-            padding: 0 .45rem; font-size: .75rem; margin-left: .25rem; }
-
 /* animation when inventory items change */
 .inv-flash { animation: invFlash .6s ease-out; }
 .rm-flash { animation: rmFlash .6s ease-out; }
@@ -1678,14 +1674,6 @@ input:focus, select:focus, textarea:focus {
 @keyframes rmFlash {
   0% { background: rgba(255, 61, 61, 0.1); }
   100% { background: var(--card); }
-}
-
-/* pulse effect for inventory badge */
-#invBadge.badge-pulse { animation: invBadgePulse .6s ease; }
-@keyframes invBadgePulse {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.3); }
-  100% { transform: scale(1); }
 }
 
 /* XP-räknare i verktygsrad */

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -2589,9 +2589,6 @@ function openVehiclePopup(preselectId, precheckedPaths) {
 
     if (dom.wtOut) dom.wtOut.textContent = formatWeight(usedWeight);
     if (dom.slOut) dom.slOut.textContent = formatWeight(maxCapacity);
-    dom.invBadge.textContent = flatInv.reduce((s, r) => s + r.qty, 0);
-    dom.invBadge.classList.add('badge-pulse');
-    setTimeout(() => dom.invBadge.classList.remove('badge-pulse'), 600);
     dom.unusedOut = getEl('unusedOut');
     dom.dragToggle = getEl('dragToggle');
     if (dom.unusedOut) dom.unusedOut.textContent = diffText;

--- a/js/main.js
+++ b/js/main.js
@@ -245,7 +245,7 @@ const dom  = {
   xpTotal : getDom('xpTotal'),      xpUsed : getDom('xpUsed'),       xpFree : getDom('xpFree'),
 
   /* inventarie */
-  invFormal: getDom('invFormal'),   invList : getDom('invList'),      invBadge  : getDom('invBadge'),
+  invFormal: getDom('invFormal'),   invList : getDom('invList'),
   wtOut   : getDom('weightOut'),    slOut     : getDom('slotOut'),
   moneyD  : getDom('moneyDaler'),
   moneyS  : getDom('moneySkilling'),

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -162,13 +162,6 @@ class SharedToolbar extends HTMLElement {
         .button-row .nav-link.active:hover {
           opacity: 1;
         }
-        #invBadge {
-          background: var(--danger);
-          border-radius: 50%;
-          padding: 0 .45rem;
-          font-size: .75rem;
-          margin-left: .25rem;
-        }
         .toolbar .exp-counter {
           display: flex;
           align-items: center;
@@ -223,9 +216,7 @@ class SharedToolbar extends HTMLElement {
         </div>
         <div class="button-row">
           <button  id="traitsToggle" class="char-btn icon icon-only" title="Egenskaper">${icon('egenskaper')}</button>
-          <a       id="inventoryLink" class="char-btn icon nav-link" title="Inventarievy" href="inventory.html">
-            ${icon('inventarie')}<span id="invBadge">0</span>
-          </a>
+          <a       id="inventoryLink" class="char-btn icon nav-link" title="Inventarievy" href="inventory.html">${icon('inventarie')}</a>
           <a       id="indexLink" class="char-btn icon icon-only nav-link" title="Index" href="index.html">${icon('index')}</a>
           <a       id="characterLink" class="char-btn icon icon-only nav-link" title="Rollperson" href="character.html">${icon('character')}</a>
           <button  id="filterToggle" class="char-btn icon icon-only" title="Filter">${icon('settings')}</button>


### PR DESCRIPTION
## Summary
- remove the inventory badge markup and styles from the shared toolbar
- drop JavaScript references that updated the badge count

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d63b7cb6a8832382fa4c0c10bf79ed