### PR TITLE
Remove inventory drag-and-drop functionality

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1186,20 +1186,6 @@ input:focus, select:focus, textarea:focus {
   background: var(--danger-bg);
 }
 
-#invList li.card {
-  cursor: grab;
-  touch-action: pan-y;
-  user-select: none;
-}
-#invList.drag-mode li.card {
-  touch-action: none;
-}
-#invList li.card.dragging {
-  cursor: grabbing;
-  outline: 3px solid var(--accent);
-  outline-offset: 2px;
-}
-
 /* särställ "Formaliteter"-kort (inkl. uppdelade) */
 .card[data-special="__formal__"],
 .card[data-special="__tools__"],

--- a/js/main.js
+++ b/js/main.js
@@ -253,7 +253,6 @@ const dom  = {
   moneySetBtn: getDom('moneySetBtn'),
   moneyAddBtn: getDom('moneyAddBtn'),
   collapseAllBtn: getDom('collapseAllInv'),
-  dragToggle: getDom('dragToggle'),
   unusedOut: getDom('unusedOut'),
 
   /* smith filter */
@@ -433,7 +432,6 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
     { id: 'inv-multi',   label: 'Multiplicera pris',    sel: '#multiPriceBtn',  panel: 'filterPanel', emoji: '💸', syn: ['multiplicera pris','pris'] },
     { id: 'inv-qty',     label: 'Lägg till antal',      sel: '#squareBtn',      panel: 'filterPanel', emoji: 'x²', syn: ['antal','lägg till antal'] },
     { id: 'inv-vehicle', label: 'Lasta i',              sel: '[id^="vehicleBtn-"]', panel: 'filterPanel', emoji: '🛞', syn: ['lasta','lasta i','färdmedel','fordon'] },
-    { id: 'inv-drag',    label: 'Dra & Släpp',          sel: '#dragToggle',     panel: 'filterPanel', emoji: '🔀', syn: ['dra och släpp','drag','drag & drop'] },
     { id: 'inv-free',    label: 'Spara & gratismarkera',sel: '#saveFreeBtn',    panel: 'filterPanel', emoji: '🔒', syn: ['gratismarkera','spara gratis','gratis'] },
     { id: 'inv-clear',   label: 'Rensa inventarie',     sel: '#clearInvBtn',    panel: 'filterPanel', emoji: '🧹', syn: ['töm inventarie','rensa','töm'] },
 


### PR DESCRIPTION
## Summary
- remove the drag-and-drop toggle and handlers from the inventory view
- clean up toolbar configuration and styling that referenced drag mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d63bfef7488323bb5dfe905e74b0ee