### PR TITLE
Adjust scroll locking for off-canvas panels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2097,6 +2097,7 @@ select.level {
   transition: right .25s ease;
   z-index: 1000;
   overflow-y: auto;
+  overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
   padding: 1.2rem 1rem 2rem;
   font-size: 1rem;

--- a/js/main.js
+++ b/js/main.js
@@ -34,6 +34,15 @@
     scrollLocked = false;
   }
 
+  function updateScrollLock() {
+    const requiresLock = overlayStack.some(el => el && !el.classList.contains('offcanvas'));
+    if (requiresLock) {
+      lockScroll();
+    } else {
+      unlockScroll();
+    }
+  }
+
   const overlayTargets = new Set();
   const overlayObserver = new MutationObserver(muts => {
     for (const m of muts) {
@@ -54,11 +63,7 @@
         }
       }
     }
-    if (overlayStack.length > 0) {
-      lockScroll();
-    } else {
-      unlockScroll();
-    }
+    updateScrollLock();
   });
 
   const OVERLAY_SELECTOR = '.popup, .offcanvas';


### PR DESCRIPTION
## Summary
- allow the page to remain scrollable when only off-canvas panels are open by refining the shared scroll-lock logic
- ensure slide-in panels contain their own scroll momentum to keep background scrolling isolated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d63c37e9e083239c07581732462a7a