### PR TITLE
Move reset traits button beside trait total

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1908,6 +1908,26 @@ select.level {
   gap: .6rem;
 }
 
+.traits-total-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .55rem;
+  margin: 0 auto;
+}
+
+.traits-total-row .traits-total {
+  margin: 0;
+}
+
+.traits-reset-btn {
+  width: 2.4rem;
+  height: 2.4rem;
+  padding: .45rem;
+  border-radius: .55rem;
+  flex-shrink: 0;
+}
+
 .traits-total {
   margin: 0 auto;
   font-weight: 600;

--- a/traits.html
+++ b/traits.html
@@ -48,11 +48,7 @@
   <div class="panel traits-panel">
     <div class="panel-header">
       <h2 id="charName" style="margin:0;"></h2>
-      <div class="header-actions">
-        <button id="resetTraits" class="char-btn icon danger" title="Återställ basegenskaper">
-          <img src="icons/broom.svg" alt="" class="btn-icon">
-        </button>
-      </div>
+      <div class="header-actions"></div>
     </div>
 
     <div class="traits-content summary-content">
@@ -89,8 +85,13 @@
 
       <section class="summary-section trait-list-section">
         <div class="trait-meta">
-          <div class="traits-total" role="status">
-            Karaktärsdrag: <span id="traitsTotal">0</span> / <span id="traitsMax">0</span>
+          <div class="traits-total-row">
+            <div class="traits-total" role="status">
+              Karaktärsdrag: <span id="traitsTotal">0</span> / <span id="traitsMax">0</span>
+            </div>
+            <button id="resetTraits" class="char-btn icon icon-only danger traits-reset-btn" title="Återställ basegenskaper" aria-label="Återställ basegenskaper">
+              <img src="icons/broom.svg" alt="" class="btn-icon">
+            </button>
           </div>
           <div id="traitStats" class="trait-extra-meta" aria-live="polite"></div>
         </div>


### PR DESCRIPTION
## Summary
- relocate the reset traits button into the trait summary meta area next to the total counter
- style the new layout so the button fits alongside the status badge without breaking alignment

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d64d208b908323b3089c59351f08e6