### PR TITLE
Fix summary key spacing and expose defense value

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -388,6 +388,14 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   line-height: 1.2;
 }
 
+.summary-pairs .summary-key::after {
+  content: ': ';
+}
+
+.summary-pairs .summary-key:empty::after {
+  content: '';
+}
+
 .summary-value {
   grid-column: 2;
   min-width: 0;

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -878,11 +878,35 @@ function initCharacter() {
     const economyRows = [{ text: `Oanvänt: ${unusedText}` }];
     summarySections.push({ title: 'Ekonomi', rows: economyRows, listClass: 'summary-text' });
 
-    const defenseRows = defenseList.map(d => ({
-      label: d.name ? `Försvar (${d.name})` : 'Försvar',
-      value: String(d.value),
-      align: 'right'
-    }));
+    const normalizedDefense = defenseList
+      .map(d => ({
+        name: d?.name ? String(d.name).trim() : '',
+        value: Number(d?.value)
+      }))
+      .filter(d => Number.isFinite(d.value));
+
+    const defenseRows = [];
+    if (normalizedDefense.length) {
+      const highestDefense = normalizedDefense
+        .reduce((max, d) => Math.max(max, d.value), Number.NEGATIVE_INFINITY);
+      if (Number.isFinite(highestDefense)) {
+        defenseRows.push({
+          label: 'Försvarsvärde',
+          value: String(highestDefense),
+          align: 'right'
+        });
+      }
+
+      normalizedDefense.forEach(d => {
+        const label = d.name ? `Försvar (${d.name})` : 'Försvar';
+        defenseRows.push({
+          label,
+          value: String(d.value),
+          align: 'right'
+        });
+      });
+    }
+
     if (defenseRows.length) {
       summarySections.push({ title: 'Försvar', rows: defenseRows, listClass: 'summary-pairs' });
     }


### PR DESCRIPTION
## Summary
- add spacing after summary keys to improve readability in overview lists
- surface the highest defense value in the overview alongside detailed entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d64da6d93c83238e42bbff12bbcf96