### PR TITLE
Link trait ability counts to character view

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -36,6 +36,40 @@ function initCharacter() {
     catState = saved.cats || {};
   }
 
+  const applyQueryFilters = () => {
+    if (typeof URLSearchParams !== 'function') return;
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const rawValues = params.getAll('test') || [];
+      const collected = [];
+      rawValues.forEach(val => {
+        String(val || '')
+          .split(',')
+          .map(v => v.trim())
+          .filter(Boolean)
+          .forEach(v => collected.push(v));
+      });
+      if (!collected.length) return;
+
+      const deduped = [];
+      const seen = new Set();
+      collected.forEach(val => {
+        if (seen.has(val)) return;
+        seen.add(val);
+        deduped.push(val);
+      });
+
+      F.search = [];
+      F.typ = [];
+      F.ark = [];
+      F.test = deduped;
+      storeHelper.setOnlySelected(store, true);
+      openCatsOnce.add('Förmåga');
+      saveState();
+    } catch {}
+  };
+  applyQueryFilters();
+
   let catsMinimized = false;
   const updateCatToggle = () => {
     catsMinimized = [...document.querySelectorAll('.cat-group > details')]

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -312,12 +312,20 @@
       const countBtn = e.target.closest('.trait-count');
       if (countBtn) {
         const trait = countBtn.dataset.trait;
-        if (dom.tstSel) {
-          dom.tstSel.value = trait;
-          dom.tstSel.dispatchEvent(new Event('change'));
-        }
         storeHelper.setOnlySelected(store, true);
-        if (typeof indexViewUpdate === 'function') indexViewUpdate();
+        if (trait) {
+          let target = 'character.html';
+          try {
+            const params = new URLSearchParams();
+            params.set('test', trait);
+            target = `character.html?${params.toString()}`;
+          } catch {
+            target = `character.html?test=${encodeURIComponent(trait)}`;
+          }
+          window.location.href = target;
+        } else {
+          window.location.href = 'character.html';
+        }
         return;
       }
       const btn = e.target.closest('.trait-btn');


### PR DESCRIPTION
## Summary
- update the Förmågor buttons on the traits page to open the character view with the matching Test filter
- allow the character view to pick up Test filters from URL query parameters and focus the Förmåga category

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64e7a856c8323bc2a4565d99b3342