### PR TITLE
Add buy-multiple controls for inventory stacks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2772,8 +2772,9 @@ select.level {
   width: auto;
 }
 
-/* ---------- Popup för antal ---------- */
-#qtyPopup {
+/* ---------- Popup för antal / köp flera ---------- */
+#qtyPopup,
+#buyMultiplePopup {
   position: fixed;
   inset: 0;
   width: 100%;
@@ -2784,8 +2785,10 @@ select.level {
   background: rgba(0,0,0,.6);
   z-index: 3000;
 }
-#qtyPopup.open { display: flex; }
-#qtyPopup .popup-inner {
+#qtyPopup.open,
+#buyMultiplePopup.open { display: flex; }
+#qtyPopup .popup-inner,
+#buyMultiplePopup .popup-inner {
   background: var(--panel);
   border: 1.5px solid var(--border);
   border-radius: 1.2rem 1.2rem 0 0;
@@ -2800,12 +2803,19 @@ select.level {
   flex-direction: column;
   gap: .8rem;
 }
-#qtyPopup.open .popup-inner { transform: translateY(0); }
-#qtyPopup .popup-inner button { width: 100%; }
+#qtyPopup.open .popup-inner,
+#buyMultiplePopup.open .popup-inner { transform: translateY(0); }
+#qtyPopup .popup-inner button,
+#buyMultiplePopup .popup-inner button { width: 100%; }
 #qtyItemList {
   display: flex;
   flex-direction: column;
   gap: .4rem;
+}
+
+#buyMultiplePopup .popup-item-name {
+  font-weight: 600;
+  margin: 0;
 }
 
 /* ---------- Popup för pris ---------- */

--- a/js/entry-card.js
+++ b/js/entry-card.js
@@ -28,12 +28,13 @@
 
   const splitButtons = (buttonParts) => {
     const dynamic = [];
-    const standardBuckets = { remove: [], minus: [], plus: [] };
+    const standardBuckets = { remove: [], minus: [], plus: [], multi: [] };
     const ACT_MAP = new Map([
       ['del', 'remove'],
       ['rem', 'remove'],
       ['sub', 'minus'],
-      ['add', 'plus']
+      ['add', 'plus'],
+      ['buyMulti', 'multi']
     ]);
 
     buttonParts.forEach(part => {
@@ -49,7 +50,7 @@
       dynamic.push(part);
     });
 
-    const standardOrder = ['remove', 'minus', 'plus'];
+    const standardOrder = ['remove', 'minus', 'plus', 'multi'];
     const standard = standardOrder.reduce((acc, key) => acc.concat(standardBuckets[key]), []);
     return {
       dynamic,

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -499,6 +499,19 @@ class SharedToolbar extends HTMLElement {
         </div>
       </div>
 
+      <!-- ---------- Popup Köp Flera ---------- -->
+      <div id="buyMultiplePopup" class="popup popup-bottom">
+        <div class="popup-inner">
+          <h3>Köp flera</h3>
+          <p id="buyMultipleItemName" class="popup-item-name" hidden></p>
+          <input id="buyMultipleInput" type="number" min="1" step="1" placeholder="Antal" aria-label="Antal att köpa">
+          <div class="confirm-row">
+            <button id="buyMultipleConfirm" class="char-btn">Lägg till</button>
+            <button id="buyMultipleCancel" class="char-btn danger">Avbryt</button>
+          </div>
+        </div>
+      </div>
+
       <!-- ---------- Popup Pris ---------- -->
       <div id="pricePopup" class="popup popup-bottom">
         <div class="popup-inner">
@@ -1145,7 +1158,7 @@ class SharedToolbar extends HTMLElement {
     }
 
     // ignore clicks inside popups so panels stay open
-      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','pricePopup','rowPricePopup','vehiclePopup','vehicleRemovePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','importPopup','pdfPopup','nilasPopup','tabellPopup','dialogPopup','folderManagerPopup','newCharPopup','dupCharPopup','renameCharPopup','artifactPaymentPopup'];
+      const popups = ['qualPopup','customPopup','moneyPopup','saveFreePopup','advMoneyPopup','qtyPopup','buyMultiplePopup','pricePopup','rowPricePopup','vehiclePopup','vehicleRemovePopup','masterPopup','alcPopup','smithPopup','artPopup','defensePopup','exportPopup','importPopup','pdfPopup','nilasPopup','tabellPopup','dialogPopup','folderManagerPopup','newCharPopup','dupCharPopup','renameCharPopup','artifactPaymentPopup'];
     if (path.some(el => popups.includes(el.id))) return;
 
     const openPanel = Object.values(this.panels).find(p => p.classList.contains('open'));


### PR DESCRIPTION
## Summary
- add a buy-multiple button to stackable inventory entries and wire it to a new handler for bulk quantity changes
- introduce a dedicated buy-multiple popup in the shared toolbar so users can enter exact counts
- share popup styling for the existing quantity dialog and include the new action in standard button layouts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d652c7dd188323b94ebd64b0e7d992