### PR TITLE
Add buy-multiple control to index view

### DIFF
--- a/js/entry-card.js
+++ b/js/entry-card.js
@@ -50,7 +50,7 @@
       dynamic.push(part);
     });
 
-    const standardOrder = ['remove', 'minus', 'plus', 'multi'];
+    const standardOrder = ['remove', 'multi', 'minus', 'plus'];
     const standard = standardOrder.reduce((acc, key) => acc.concat(standardBuckets[key]), []);
     return {
       dynamic,

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1018,6 +1018,7 @@ function initIndex() {
             if (count > 0) {
               actionButtons.push(`<button data-act="del" class="char-btn danger icon icon-only" data-name="${p.namn}">${icon('remove')}</button>`);
               actionButtons.push(`<button data-act="sub" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Minska">${icon('minus')}</button>`);
+              actionButtons.push(`<button data-act="buyMulti" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Köp flera">${icon('buymultiple')}</button>`);
               if (count < limit) actionButtons.push(`<button data-act="add" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`);
             } else {
               actionButtons.push(`<button data-act="add" class="char-btn icon icon-only add-btn" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`);
@@ -2060,6 +2061,27 @@ function initIndex() {
         await finishAdd(added);
       }
       needsFullRefresh = true;
+    } else if (act==='buyMulti') {
+      if (!isInv(p)) return;
+      if (!window.invUtil || typeof window.invUtil.openBuyMultiplePopup !== 'function') return;
+      const inv = storeHelper.getInventory(store);
+      const idxInv = inv.findIndex(x => x.id === p.id);
+      if (idxInv < 0) return;
+      const row = inv[idxInv];
+      const safeName = escapeSelectorValue(p.namn);
+      let invLi = null;
+      if (safeName) {
+        invLi = dom.invList?.querySelector(`li[data-name="${safeName}"][data-idx="${idxInv}"]`) || null;
+      }
+      window.invUtil.openBuyMultiplePopup({
+        row,
+        entry: p,
+        inv,
+        li: invLi,
+        parentArr: inv,
+        idx: idxInv
+      });
+      return;
     } else if (act==='sub' || act==='del' || act==='rem') {
       if (isInv(p)) {
         const inv = storeHelper.getInventory(store);

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -3421,6 +3421,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     openVehicleRemovePopup,
     openRowPricePopup,
     openSaveFreePopup,
+    openBuyMultiplePopup,
     massFreeAndSave,
     recalcArtifactEffects,
     addWellEquippedItems,

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -506,8 +506,8 @@ class SharedToolbar extends HTMLElement {
           <p id="buyMultipleItemName" class="popup-item-name" hidden></p>
           <input id="buyMultipleInput" type="number" min="1" step="1" placeholder="Antal" aria-label="Antal att köpa">
           <div class="confirm-row">
-            <button id="buyMultipleConfirm" class="char-btn">Lägg till</button>
             <button id="buyMultipleCancel" class="char-btn danger">Avbryt</button>
+            <button id="buyMultipleConfirm" class="char-btn">Lägg till</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show the buy-multiple button on index entry cards when the item is already in the inventory and connect it to the existing popup
- export the shared buy-multiple popup and reorder standard button layout so "Köp flera" sits between minus and delete with "Lägg till" on the far right
- swap the popup button order so "Avbryt" renders on the left and "Lägg till" on the right

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6584e3f5c83238de85653db4661af