### PR TITLE
Use SVG icons for toolbar toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 - **Ta bort rollperson** raderar den aktuella karaktären.
 - **Export** öppnar en meny där du kan ladda ner alla rollpersoner eller välja en specifik att exportera som JSON-fil.
 - **Import** återställer en eller flera karaktärer från sparade filer.
-- **⚒️**, **⚗️** och **🏺** anger nivå på smed, alkemist och artefaktmakare i ditt sällskap. Dessa nivåer används för att räkna ut rabatter på priser.
-- **🔭** gör att flera filter kombineras med OR i stället för AND, vilket ger en bredare sökning.
-- **↕️ Expandera vy** växlar till vanliga vyn.
+- **<img src="icons/smithing.svg" alt="Smed" width="18">**, **<img src="icons/alkemi.svg" alt="Alkemist" width="18">** och **<img src="icons/artefakt.svg" alt="Artefakt" width="18">** anger nivå på smed, alkemist och artefaktmakare i ditt sällskap. Dessa nivåer används för att räkna ut rabatter på priser.
+- **<img src="icons/extend.svg" alt="Utvidga sökning" width="18">** gör att flera filter kombineras med OR i stället för AND, vilket ger en bredare sökning.
+- **<img src="icons/expand.svg" alt="Expandera vy" width="18"> Expandera vy** växlar till vanliga vyn.
 - **ℹ️** visar en snabböversikt av alla knappar.
 
 ### 5. Inventariepanelen

--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1349,8 +1349,11 @@ function initCharacter() {
         const badge = g.count>1 ? ` <span class="count-badge">×${g.count}</span>` : '';
         const activeKeys = getActiveHandlingKeys(p);
         const activeNames = activeKeys.map(k => handlingName(p, k));
+        const conflictIcon = icon('active');
         const conflictBtn = activeKeys.length
-          ? `<button class="char-btn icon conflict-btn" data-name="${p.namn}" title="Aktiva nivåer: ${activeNames.join(', ')}">💔</button>`
+          ? (conflictIcon
+            ? `<button class="char-btn icon icon-only conflict-btn" data-name="${p.namn}" title="Aktiva nivåer: ${activeNames.join(', ')}">${conflictIcon}</button>`
+            : `<button class="char-btn icon conflict-btn" data-name="${p.namn}" title="Aktiva nivåer: ${activeNames.join(', ')}">💔</button>`)
           : '';
         const showInfo = compact || hideDetails;
         const hasCustomEdit = typesList.includes('Hemmagjort');
@@ -1482,7 +1485,18 @@ function initCharacter() {
         const cmds = window.getUICommandSuggestions(q) || [];
         if (cmds.length) {
           const escTxt = v => v.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/\"/g,'&quot;');
-          uiHtml = cmds.map((c,i)=>`<div class="item" data-ui="${escTxt(c.id)}" data-idx="ui-${i}">${escTxt((c.emoji||'') + ' ' + c.label)}</div>`).join('');
+          uiHtml = cmds.map((c,i)=>{
+            const iconPart = (() => {
+              if (c.icon) {
+                const html = icon(c.icon, { className: 'suggest-icon-img' });
+                if (html) return `<span class="suggest-icon">${html}</span>`;
+              }
+              const emoji = (c.emoji || '').trim();
+              return emoji ? `<span class="suggest-emoji">${escTxt(emoji)}</span>` : '';
+            })();
+            const label = `<span class="suggest-label">${escTxt(c.label || '')}</span>`;
+            return `<div class="item" data-ui="${escTxt(c.id)}" data-idx="ui-${i}">${iconPart}${label}</div>`;
+          }).join('');
         }
       }
     } catch {}

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -510,7 +510,18 @@ function initIndex() {
         const cmds = window.getUICommandSuggestions(q) || [];
         if (cmds.length) {
           const escTxt = v => v.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/\"/g,'&quot;');
-          uiHtml = cmds.map((c,i)=>`<div class="item" data-ui="${escTxt(c.id)}" data-idx="ui-${i}">${escTxt((c.emoji||'') + ' ' + c.label)}</div>`).join('');
+          uiHtml = cmds.map((c,i)=>{
+            const iconPart = (() => {
+              if (c.icon) {
+                const html = icon(c.icon, { className: 'suggest-icon-img' });
+                if (html) return `<span class="suggest-icon">${html}</span>`;
+              }
+              const emoji = (c.emoji || '').trim();
+              return emoji ? `<span class="suggest-emoji">${escTxt(emoji)}</span>` : '';
+            })();
+            const label = `<span class="suggest-label">${escTxt(c.label || '')}</span>`;
+            return `<div class="item" data-ui="${escTxt(c.id)}" data-idx="ui-${i}">${iconPart}${label}</div>`;
+          }).join('');
         }
       }
     } catch {}

--- a/js/inventory-view.js
+++ b/js/inventory-view.js
@@ -119,7 +119,18 @@
         const cmds = window.getUICommandSuggestions(q) || [];
         if (cmds.length) {
           const escTxt = v => v.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/\"/g,'&quot;');
-          uiHtml = cmds.map((c,i)=>`<div class="item" data-ui="${escTxt(c.id)}" data-idx="ui-${i}">${escTxt((c.emoji||'') + ' ' + c.label)}</div>`).join('');
+          uiHtml = cmds.map((c,i)=>{
+            const iconPart = (() => {
+              if (c.icon && window.iconHtml) {
+                const html = window.iconHtml(c.icon, { className: 'suggest-icon-img' });
+                if (html) return `<span class="suggest-icon">${html}</span>`;
+              }
+              const emoji = (c.emoji || '').trim();
+              return emoji ? `<span class="suggest-emoji">${escTxt(emoji)}</span>` : '';
+            })();
+            const label = `<span class="suggest-label">${escTxt(c.label || '')}</span>`;
+            return `<div class="item" data-ui="${escTxt(c.id)}" data-idx="ui-${i}">${iconPart}${label}</div>`;
+          }).join('');
         }
       }
     } catch {}

--- a/js/main.js
+++ b/js/main.js
@@ -429,10 +429,10 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
     // Inställningar 💡 (Filter → Inställningar)
     { id: 'settings-smith',   label: 'Smed i partyt',        sel: '#partySmith',      panel: 'filterPanel', emoji: '⚒️', syn: ['smed','smed i partyt','smed nivå'] },
     { id: 'settings-alch',    label: 'Alkemist i partyt',    sel: '#partyAlchemist',  panel: 'filterPanel', emoji: '⚗️', syn: ['alkemist','alkemist i partyt'] },
-    { id: 'settings-art',     label: 'Artefaktmakare i partyt', sel: '#partyArtefacter', panel: 'filterPanel', emoji: '🏺', syn: ['artefaktmakare','artefaktare'] },
-    { id: 'settings-union',   label: 'Utvidgad sökning',     sel: '#filterUnion',     panel: 'filterPanel', emoji: '🔭', syn: ['utvidga sökning','or-sökning','union','OR'] },
-    { id: 'settings-expand',  label: 'Expandera vy',         sel: '#entryViewToggle', panel: 'filterPanel', emoji: '↕️', syn: ['expandera vy','vy','detaljer','expand'] },
-    { id: 'settings-defense', label: 'Tvinga försvar',       sel: '#forceDefense',    panel: 'filterPanel', emoji: '🏃', syn: ['försvar','tvinga försvar','försvarskaraktärsdrag'] },
+    { id: 'settings-art',     label: 'Artefaktmakare i partyt', sel: '#partyArtefacter', panel: 'filterPanel', emoji: '🏺', icon: 'artefakt', syn: ['artefaktmakare','artefaktare'] },
+    { id: 'settings-union',   label: 'Utvidgad sökning',     sel: '#filterUnion',     panel: 'filterPanel', emoji: '🔭', icon: 'extend', syn: ['utvidga sökning','or-sökning','union','OR'] },
+    { id: 'settings-expand',  label: 'Expandera vy',         sel: '#entryViewToggle', panel: 'filterPanel', emoji: '↕️', icon: 'expand', syn: ['expandera vy','vy','detaljer','expand'] },
+    { id: 'settings-defense', label: 'Tvinga försvar',       sel: '#forceDefense',    panel: 'filterPanel', emoji: '🏃', icon: 'forsvar', syn: ['försvar','tvinga försvar','försvarskaraktärsdrag'] },
     { id: 'settings-help',    label: 'Hjälp',                sel: '#infoToggle',      panel: 'filterPanel', emoji: 'ℹ️',
       syn: ['hjälp','info','information','behöver du hjälp','behover du hjalp'] },
 
@@ -523,9 +523,9 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
       return UI_CMDS
         .slice()
         .sort((a,b)=> String(a.label||'').localeCompare(String(b.label||''), 'sv'))
-        .map(c => ({ id: c.id, label: c.label, emoji: c.emoji || '' }));
+        .map(c => ({ id: c.id, label: c.label, emoji: c.emoji || '', icon: c.icon || '' }));
     }
-    return searchUICommands(q).map(c => ({ id: c.id, label: c.label, emoji: c.emoji || '' }));
+    return searchUICommands(q).map(c => ({ id: c.id, label: c.label, emoji: c.emoji || '', icon: c.icon || '' }));
   };
   window.executeUICommand = executeUICommand;
   window.tryUICommand = tryUICommand;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -140,6 +140,25 @@ class SharedToolbar extends HTMLElement {
           padding: .4rem .6rem;
           border-radius: .4rem;
           cursor: pointer;
+          display: flex;
+          align-items: center;
+          gap: .45rem;
+        }
+        .toolbar-top .suggestions .item .suggest-icon .btn-icon {
+          width: 1.1rem;
+          height: 1.1rem;
+        }
+        .toolbar-top .suggestions .item .suggest-emoji {
+          font-size: 1.1rem;
+          line-height: 1;
+        }
+        .toolbar-top .suggestions .item .suggest-label {
+          flex: 1;
+        }
+        .emoji-fallback {
+          display: inline-block;
+          font-size: 1.2rem;
+          line-height: 1;
         }
         .toolbar-top .suggestions .item:hover,
         .toolbar-top .suggestions .item.active {
@@ -305,25 +324,25 @@ class SharedToolbar extends HTMLElement {
                     <span class="toggle-desc">
                       <span class="toggle-question">Artefaktmakare i partyt?</span>
                     </span>
-                    <button id="partyArtefacter" class="party-toggle">🏺</button>
+                    <button id="partyArtefacter" class="party-toggle icon-only">${icon('artefakt') || '<span class="emoji-fallback">🏺</span>'}</button>
                   </li>
                   <li>
                     <span class="toggle-desc">
                       <span class="toggle-question">Utvidgad sökning?</span>
                     </span>
-                    <button id="filterUnion" class="party-toggle" title="Matcha någon tag (OR)">🔭</button>
+                    <button id="filterUnion" class="party-toggle icon-only" title="Matcha någon tag (OR)">${icon('extend') || '<span class="emoji-fallback">🔭</span>'}</button>
                   </li>
                   <li>
                     <span class="toggle-desc">
                       <span class="toggle-question">Expandera vy?</span>
                     </span>
-                    <button id="entryViewToggle" class="party-toggle" title="Expandera vy">↕️</button>
+                    <button id="entryViewToggle" class="party-toggle icon-only" title="Expandera vy">${icon('expand') || '<span class="emoji-fallback">↕️</span>'}</button>
                   </li>
                   <li>
                     <span class="toggle-desc">
                       <span class="toggle-question">Tvinga försvar?</span>
                     </span>
-                    <button id="forceDefense" class="party-toggle" title="Välj försvarskaraktärsdrag">🏃</button>
+                    <button id="forceDefense" class="party-toggle icon-only" title="Välj försvarskaraktärsdrag">${icon('forsvar') || '<span class="emoji-fallback">🏃</span>'}</button>
                   </li>
                 </ul>
               </div>
@@ -905,10 +924,10 @@ class SharedToolbar extends HTMLElement {
               <li>Ny/Kopiera/Byt namn/Ta bort: Hanterar karaktärer.</li>
               <li>Mapphantering: Skapa mappar och flytta rollpersoner mellan mappar.</li>
               <li>Export/Import: Säkerhetskopiera eller hämta karaktärer som JSON.</li>
-              <li>${icon('smithing')}/${icon('alkemi')}/🏺: Välj nivå för smed, alkemist och artefaktmakare (påverkar pris och åtkomst).</li>
-              <li>🔭 Utvidga sökning: Växla till OR-filter (matcha någon tag).</li>
-              <li>↕️ Expandera vy: Visar fler detaljer i kort (alla utom Ras, Yrken och Elityrken).</li>
-              <li>🏃 Försvar: Välj försvarskaraktärsdrag manuellt.</li>
+              <li>${icon('smithing')}/${icon('alkemi')}/${icon('artefakt') || '🏺'}: Välj nivå för smed, alkemist och artefaktmakare (påverkar pris och åtkomst).</li>
+              <li>${icon('extend') || '🔭'} Utvidga sökning: Växla till OR-filter (matcha någon tag).</li>
+              <li>${icon('expand') || '↕️'} Expandera vy: Visar fler detaljer i kort (alla utom Ras, Yrken och Elityrken).</li>
+              <li>${icon('forsvar') || '🏃'} Försvar: Välj försvarskaraktärsdrag manuellt.</li>
               <li>${icon('info')} Hjälp: Visar denna panel.</li>
             </ul>
           </section>
@@ -962,7 +981,7 @@ class SharedToolbar extends HTMLElement {
               <li>Info: Visa detaljer.</li>
               <li>🏋🏻‍♂️ Elityrke: Lägg till elityrket med dess krav på förmågor.</li>
               <li>${icon('addqual')} Lägg till kvalitet. ${icon('qualfree')} Markera kostsam kvalitet som gratis.</li>
-              <li>${icon('free')} Gör föremål gratis. 💔 Visa konflikter.</li>
+              <li>${icon('free')} Gör föremål gratis. ${(icon('active') || '💔')} Visa konflikter.</li>
               <li>↔ Växla artefaktens kostnad mellan XP och permanent korruption.</li>
               <li>⬇️/⬆️ Lasta på/av föremål till/från färdmedel.</li>
               <li>${icon('remove')} Ta bort posten helt.</li>


### PR DESCRIPTION
## Summary
- replace toolbar toggles for artefaktmakare, utvidgad sökning, expandera vy och tvinga försvar with SVG icons and fallbacks
- show the new icons in UI command suggestions and update the entry conflict button to use the active icon
- refresh documentation/help text to reference the SVG icons

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d657f097548323a89746f2a40d1bc8