### PR TITLE
Refactor buy multi button placement in index view

### DIFF
--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1026,13 +1026,15 @@ function initIndex() {
         if (editBtn) actionButtons.push(editBtn);
         if (allowAdd) {
           if (multi) {
+            const buyMultiButton = `<button data-act="buyMulti" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Köp flera">${icon('buymultiple')}</button>`;
             if (count > 0) {
               actionButtons.push(`<button data-act="del" class="char-btn danger icon icon-only" data-name="${p.namn}">${icon('remove')}</button>`);
               actionButtons.push(`<button data-act="sub" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Minska">${icon('minus')}</button>`);
-              actionButtons.push(`<button data-act="buyMulti" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Köp flera">${icon('buymultiple')}</button>`);
+              actionButtons.push(buyMultiButton);
               if (count < limit) actionButtons.push(`<button data-act="add" class="char-btn icon icon-only" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`);
             } else {
-              actionButtons.push(`<button data-act="add" class="char-btn icon icon-only add-btn" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`);
+              if (count < limit) actionButtons.push(`<button data-act="add" class="char-btn icon icon-only add-btn" data-name="${p.namn}" aria-label="Lägg till">${icon('plus')}</button>`);
+              actionButtons.push(buyMultiButton);
             }
           } else {
             const mainBtn = inChar


### PR DESCRIPTION
## Summary
- reuse a single buy multi button instance for stackable entries
- show the buy multi button alongside add when no copies exist while keeping limits intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d65dce1f348323aaf296192cf50869