### PR TITLE
Adjust summary key/value spacing

### DIFF
--- a/summary.html
+++ b/summary.html
@@ -9,6 +9,11 @@
   <title>Symbapedia - Översikt</title>
 
   <link rel="stylesheet" href="css/style.css">
+  <style>
+    body[data-role="summary"] .summary-pairs li {
+      column-gap: 8px;
+    }
+  </style>
   <script src="js/text-format.js" defer></script>
   <script src="js/utils.js" defer></script>
   <script src="js/store.js" defer></script>


### PR DESCRIPTION
## Summary
- add a summary-page-specific style override to reduce the spacing between summary keys and values to 8px

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d66fb90f888323ada3571674d58838