### PR TITLE
Move inventory actions into the inventory view

### DIFF
--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -2161,11 +2161,20 @@ function openVehiclePopup(preselectId, precheckedPaths) {
         }
       };
 
-      dom.invFormal.addEventListener('entry-card-toggle', e => {
-        updateCollapseBtnState();
-        const expanded = Boolean(e.detail?.expanded);
-        localStorage.setItem(INV_INFO_KEY, expanded ? '1' : '0');
-      });
+      if (!dom.invFormal.dataset.toggleBound) {
+        dom.invFormal.addEventListener('entry-card-toggle', e => {
+          updateCollapseBtnState();
+          const card = e.detail?.card;
+          if (!card) return;
+          const expanded = Boolean(e.detail?.expanded);
+          if (card.dataset.special === '__info__') {
+            localStorage.setItem(INV_INFO_KEY, expanded ? '1' : '0');
+          } else if (card.dataset.special === '__invfunc__') {
+            localStorage.setItem(INV_TOOLS_KEY, expanded ? '1' : '0');
+          }
+        });
+        dom.invFormal.dataset.toggleBound = '1';
+      }
     }
 
     const allInv = storeHelper.getInventory(store);
@@ -2303,11 +2312,16 @@ function openVehiclePopup(preselectId, precheckedPaths) {
       '<button id="clearInvBtn" class="char-btn danger">Rensa inventarie</button>'
     ];
     const allFunctionButtons = [...baseFunctionButtons, ...vehicleButtons, ...trailingFunctionButtons];
-    const invFunctionsContainer = getEl('filterInventoryFunctionsInner');
-    if (invFunctionsContainer) {
-      invFunctionsContainer.innerHTML = `<div class="inv-buttons">${allFunctionButtons.join('')}</div>`;
-      if (localStorage.getItem(INV_TOOLS_KEY) === null) localStorage.setItem(INV_TOOLS_KEY, '1');
-    }
+    const functionsState = localStorage.getItem(INV_TOOLS_KEY);
+    const functionsOpen = functionsState === null ? true : functionsState === '1';
+    if (functionsState === null) localStorage.setItem(INV_TOOLS_KEY, '1');
+    const functionsCard = createEntryCard({
+      compact: !functionsOpen,
+      dataset: { special: '__invfunc__' },
+      nameHtml: 'Inventarie 💰',
+      descHtml: `<div class="card-desc"><div class="inv-buttons">${allFunctionButtons.join('')}</div></div>`,
+      collapsible: true
+    });
 
     const infoKey  = '__info__';
     const infoState = localStorage.getItem(INV_INFO_KEY);
@@ -2616,6 +2630,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     };
     if (dom.invFormal) {
       dom.invFormal.innerHTML = '';
+      dom.invFormal.appendChild(functionsCard);
       dom.invFormal.appendChild(infoCard);
     }
 
@@ -2782,7 +2797,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
         cards.forEach(li => {
           li.classList.toggle('compact', anyOpen);
           window.entryCardFactory?.syncCollapse?.(li);
-          if (li.dataset.special === '__functions__') {
+          if (li.dataset.special === '__invfunc__') {
             localStorage.setItem(INV_TOOLS_KEY, anyOpen ? '0' : '1');
           } else if (li.dataset.special === '__info__') {
             localStorage.setItem(INV_INFO_KEY, anyOpen ? '0' : '1');
@@ -2797,7 +2812,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
         const card = detail.card;
         if (!card) return;
         const expanded = Boolean(detail.expanded);
-        if (card.dataset.special === '__functions__') {
+        if (card.dataset.special === '__invfunc__') {
           localStorage.setItem(INV_TOOLS_KEY, expanded ? '1' : '0');
         } else if (card.dataset.special === '__info__') {
           localStorage.setItem(INV_INFO_KEY, expanded ? '1' : '0');

--- a/js/main.js
+++ b/js/main.js
@@ -396,6 +396,10 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
         }
       }
       if (!el) return false;
+      const card = el.closest('li.entry-card');
+      if (card && card.dataset.collapsible === '1' && card.classList.contains('compact')) {
+        window.entryCardFactory?.toggle?.(card, true);
+      }
       // Blink-animera, fokusera och scrolla in elementet
       el.classList.remove('focus-highlight');
       scheduleHighlight(el);
@@ -437,13 +441,13 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
       syn: ['hjälp','info','information','behöver du hjälp','behover du hjalp'] },
 
     // Inventarie → Verktyg 🧰
-    { id: 'inv-new',     label: 'Nytt föremål',         sel: '#addCustomBtn',   panel: 'filterPanel', emoji: '🆕', syn: ['nytt föremål','eget föremål','skapa föremål'] },
-    { id: 'inv-money',   label: 'Hantera pengar',       sel: '#manageMoneyBtn', panel: 'filterPanel', emoji: '💰', syn: ['pengar','hantera pengar','money'] },
-    { id: 'inv-multi',   label: 'Multiplicera pris',    sel: '#multiPriceBtn',  panel: 'filterPanel', emoji: '💸', syn: ['multiplicera pris','pris'] },
-    { id: 'inv-qty',     label: 'Lägg till antal',      sel: '#squareBtn',      panel: 'filterPanel', emoji: 'x²', syn: ['antal','lägg till antal'] },
-    { id: 'inv-vehicle', label: 'Lasta i',              sel: '[id^="vehicleBtn-"]', panel: 'filterPanel', emoji: '🛞', syn: ['lasta','lasta i','färdmedel','fordon'] },
-    { id: 'inv-free',    label: 'Spara & gratismarkera',sel: '#saveFreeBtn',    panel: 'filterPanel', emoji: '🔒', syn: ['gratismarkera','spara gratis','gratis'] },
-    { id: 'inv-clear',   label: 'Rensa inventarie',     sel: '#clearInvBtn',    panel: 'filterPanel', emoji: '🧹', syn: ['töm inventarie','rensa','töm'] },
+    { id: 'inv-new',     label: 'Nytt föremål',         sel: '#addCustomBtn',   panel: null, emoji: '🆕', syn: ['nytt föremål','eget föremål','skapa föremål'] },
+    { id: 'inv-money',   label: 'Hantera pengar',       sel: '#manageMoneyBtn', panel: null, emoji: '💰', syn: ['pengar','hantera pengar','money'] },
+    { id: 'inv-multi',   label: 'Multiplicera pris',    sel: '#multiPriceBtn',  panel: null, emoji: '💸', syn: ['multiplicera pris','pris'] },
+    { id: 'inv-qty',     label: 'Lägg till antal',      sel: '#squareBtn',      panel: null, emoji: 'x²', syn: ['antal','lägg till antal'] },
+    { id: 'inv-vehicle', label: 'Lasta i',              sel: '[id^="vehicleBtn-"]', panel: null, emoji: '🛞', syn: ['lasta','lasta i','färdmedel','fordon'] },
+    { id: 'inv-free',    label: 'Spara & gratismarkera',sel: '#saveFreeBtn',    panel: null, emoji: '🔒', syn: ['gratismarkera','spara gratis','gratis'] },
+    { id: 'inv-clear',   label: 'Rensa inventarie',     sel: '#clearInvBtn',    panel: null, emoji: '🧹', syn: ['töm inventarie','rensa','töm'] },
 
     // Verktyg inne i Filter → Verktyg
     { id: 'new-character',   label: 'Ny rollperson',       sel: '#newCharBtn',      panel: 'filterPanel', emoji: '➕',
@@ -490,6 +494,11 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
     const cmd = UI_CMDS.find(c => c.id === id);
     if (!cmd) return false;
     if (cmd.id === 'open-inventory' && ROLE !== 'inventory') {
+      try { sessionStorage.setItem('__pendingUICommand', cmd.id); } catch {}
+      try { window.location.href = 'inventory.html'; } catch {}
+      return true;
+    }
+    if (cmd.id.startsWith('inv-') && ROLE !== 'inventory') {
       try { sessionStorage.setItem('__pendingUICommand', cmd.id); } catch {}
       try { window.location.href = 'inventory.html'; } catch {}
       return true;

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -7,10 +7,8 @@
    =========================================================== */
 const FILTER_TOOLS_KEY = 'filterToolsOpen';
 const FILTER_SETTINGS_KEY = 'filterSettingsOpen';
-const FILTER_INV_FUNCS_KEY = 'invToolsOpen';
 const FILTER_CARD_KEY_MAP = Object.freeze({
   filterFormalCard: FILTER_TOOLS_KEY,
-  filterInventoryFunctions: FILTER_INV_FUNCS_KEY,
   filterSettingsCard: FILTER_SETTINGS_KEY
 });
 
@@ -301,12 +299,6 @@ class SharedToolbar extends HTMLElement {
               <div class="char-btn-row">
                 <button id="deleteChar" class="char-btn danger">Radera rollperson</button>
               </div>
-            </div>
-          </li>
-          <li class="card" data-special="__invfunc__" id="filterInventoryFunctions">
-            <div class="card-title"><span><span class="collapse-btn"></span>Inventarie 💰</span></div>
-            <div class="card-desc">
-              <div class="inv-buttons" id="filterInventoryFunctionsInner"></div>
             </div>
           </li>
           <li class="card" data-special="__formal__" id="filterSettingsCard">
@@ -1049,9 +1041,8 @@ class SharedToolbar extends HTMLElement {
 
   restoreFilterCollapse() {
     const cards = [
-      { el: this.shadowRoot.getElementById('filterFormalCard'),    key: FILTER_TOOLS_KEY },
-      { el: this.shadowRoot.getElementById('filterInventoryFunctions'), key: FILTER_INV_FUNCS_KEY },
-      { el: this.shadowRoot.getElementById('filterSettingsCard'),  key: FILTER_SETTINGS_KEY }
+      { el: this.shadowRoot.getElementById('filterFormalCard'), key: FILTER_TOOLS_KEY },
+      { el: this.shadowRoot.getElementById('filterSettingsCard'), key: FILTER_SETTINGS_KEY }
     ];
     cards.forEach(({ el, key }) => {
       if (!el) return;


### PR DESCRIPTION
## Summary
- move the inventory tools card out of the filter off-canvas and render it above the information card inside the inventory view
- persist the new card's open state and ensure collapse-all logic handles it together with the information panel
- remap UI command search entries to the new location and auto-expand cards when highlighting results

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d67062ccf083238a41b5a48dca415a