### PR TITLE
Fix toolbar outside click fallback path

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -1169,9 +1169,51 @@ class SharedToolbar extends HTMLElement {
   }
 
   handleOutsideClick(e) {
+    const buildFallbackPath = start => {
+      if (!start) return [];
+      const path = [];
+      let current = start;
+      const seen = new Set();
+
+      while (current && !seen.has(current)) {
+        path.push(current);
+        seen.add(current);
+
+        if (current === document) {
+          path.push(window);
+          break;
+        }
+
+        if (current instanceof Element) {
+          const slot = current.assignedSlot;
+          if (slot) {
+            current = slot;
+            continue;
+          }
+        }
+
+        if (current.parentNode) {
+          current = current.parentNode;
+          continue;
+        }
+
+        if (current.host) {
+          current = current.host;
+          continue;
+        }
+
+        if (current.defaultView) {
+          path.push(current.defaultView);
+        }
+        break;
+      }
+
+      return path;
+    };
+
     const rawPath = typeof e.composedPath === 'function'
       ? e.composedPath()
-      : (e.path || []);
+      : (e.path || buildFallbackPath(e.target));
     const path = Array.isArray(rawPath) ? [...rawPath] : [];
     if (!path.length && e.target) path.push(e.target);
 


### PR DESCRIPTION
## Summary
- add a composedPath fallback that walks parent, slot, and host relationships when Safari does not expose the native API
- ensure outside-click detection keeps filter/info toggle buttons in the path so their panels stay open in browsers without composedPath

## Testing
- not run (Safari-specific issue)

------
https://chatgpt.com/codex/tasks/task_e_68d67338ce5c83238ef97336761fd8a1