### PR TITLE
Ensure summary sections use summary-pairs layout

### DIFF
--- a/js/summary-effects.js
+++ b/js/summary-effects.js
@@ -621,7 +621,7 @@
     });
 
     const sectionsHtml = summarySections.map(section => {
-      const listClasses = ['summary-list'];
+      const listClasses = ['summary-list', 'summary-pairs'];
       if (section.layout) listClasses.push(`layout-${section.layout}`);
       const items = (section.items || []).map(row => {
         if (row.text) {


### PR DESCRIPTION
## Summary
- ensure summary summary lists include the summary-pairs class so existing layout rules apply

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d685ceaeb08323862c65f90308fd36