### PR TITLE
Align summary keys and values on overview page

### DIFF
--- a/summary.html
+++ b/summary.html
@@ -11,7 +11,21 @@
   <link rel="stylesheet" href="css/style.css">
   <style>
     body[data-role="summary"] .summary-pairs li {
-      column-gap: 8px;
+      display: flex;
+      align-items: flex-start;
+      gap: .5rem;
+    }
+
+    body[data-role="summary"] .summary-key {
+      flex: 0 0 auto;
+    }
+
+    body[data-role="summary"] .summary-value {
+      flex: 1 1 auto;
+    }
+
+    body[data-role="summary"] .summary-values {
+      flex: 1 1 auto;
     }
   </style>
   <script src="js/text-format.js" defer></script>


### PR DESCRIPTION
## Summary
- adjust the summary page list styling so keys and values sit side-by-side with consistent spacing
- ensure summary values flex to fill remaining space for improved readability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d68c4b8b688323afbded4df3c89877