### PR TITLE
Align entry header controls vertically

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1055,6 +1055,17 @@ input:focus, select:focus, textarea:focus {
   min-width: 0;
 }
 
+.entry-header-main .card-title > span {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  min-width: 0;
+}
+
+.entry-header-main .card-title > span .count-badge {
+  align-self: center;
+}
+
 .entry-header-xp,
 .entry-header-actions {
   display: flex;


### PR DESCRIPTION
## Summary
- ensure entry card headers keep the title, collapse toggle, info button, and count badge vertically aligned
- add inline-flex layout to the title span so badges and controls sit on the same vertical center

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d690bea05c8323b1e28247c647896b