### PR TITLE
Enable auto-resize for custom popup textareas

### DIFF
--- a/character.html
+++ b/character.html
@@ -9,6 +9,7 @@
   <title>Symbapedia - Rollperson</title>
 
   <link rel="stylesheet" href="css/style.css">
+  <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>
   <script src="js/utils.js"          defer></script>
   <script src="js/store.js"          defer></script>

--- a/effects.html
+++ b/effects.html
@@ -9,6 +9,7 @@
   <title>Symbapedia - Effekter</title>
 
   <link rel="stylesheet" href="css/style.css">
+  <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>
   <script src="js/utils.js" defer></script>
   <script src="js/store.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <title>Symbapedia</title>
 
   <link rel="stylesheet" href="css/style.css">
+  <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>
   <script src="js/utils.js"        defer></script>
   <script src="js/store.js"        defer></script>

--- a/inventory.html
+++ b/inventory.html
@@ -9,6 +9,7 @@
   <title>Symbapedia - Inventarie</title>
 
   <link rel="stylesheet" href="css/style.css">
+  <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>
   <script src="js/utils.js"          defer></script>
   <script src="js/store.js"          defer></script>

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -417,6 +417,7 @@
     const popInner = pop.querySelector('.popup-inner');
 
     pop.classList.add('open');
+    window.autoResizeAll?.(pop);
     if (popInner) popInner.scrollTop = 0;
 
     /* local helpers */
@@ -712,15 +713,17 @@
             const row = document.createElement('div');
             row.className = 'power-row';
             row.innerHTML = `
-              <input class=\"power-name\" placeholder=\"Förmågans namn\" value=\"${k.replace(/\"/g,'&quot;')}\">\n              <textarea class=\"power-desc\" placeholder=\"Beskrivning\">${existing.niv\u00e5er[k] ? String(existing.niv\u00e5er[k]) : ''}</textarea>\n              <button class=\"char-btn danger power-del\" type=\"button\">✕</button>
+              <input class=\"power-name\" placeholder=\"Förmågans namn\" value=\"${k.replace(/\"/g,'&quot;')}\">\n              <textarea class=\"power-desc auto-resize\" placeholder=\"Beskrivning\">${existing.niv\u00e5er[k] ? String(existing.niv\u00e5er[k]) : ''}</textarea>\n              <button class=\"char-btn danger power-del\" type=\"button\">✕</button>
             `;
             powerList.appendChild(row);
-          row.querySelector('.power-del').addEventListener('click', ev => {
-            ev.preventDefault();
-            ev.stopPropagation();
-            row.remove();
+            const descField = row.querySelector('.power-desc');
+            if (descField) window.autoResize?.(descField);
+            row.querySelector('.power-del').addEventListener('click', ev => {
+              ev.preventDefault();
+              ev.stopPropagation();
+              row.remove();
+            });
           });
-        });
         powerBox.style.display = '';
       }
       }
@@ -892,6 +895,7 @@
     }
 
     pop.classList.add('open');
+    window.autoResizeAll?.(pop);
     if (popInner) popInner.scrollTop = 0;
     if (typeAdd) typeAdd.addEventListener('click', onAddType);
     if (typeTags) typeTags.addEventListener('click', onTagsClick);
@@ -914,10 +918,12 @@
       row.className = 'power-row';
       row.innerHTML = `
         <input class="power-name" placeholder="Förmågans namn">
-        <textarea class="power-desc" placeholder="Beskrivning"></textarea>
+        <textarea class="power-desc auto-resize" placeholder="Beskrivning"></textarea>
         <button class="char-btn danger power-del" type="button">✕</button>
       `;
       powerList.appendChild(row);
+      const descField = row.querySelector('.power-desc');
+      if (descField) window.autoResize?.(descField);
       row.querySelector('.power-del').addEventListener('click', ev => {
         ev.preventDefault();
         ev.stopPropagation();

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -25,6 +25,7 @@ class SharedToolbar extends HTMLElement {
   /* ------------------------------------------------------- */
   connectedCallback() {
     this.render();
+    window.autoResizeAll?.(this.shadowRoot);
     this.dispatchEvent(new CustomEvent('toolbar-rendered'));
 
     const toolbar = this.shadowRoot.querySelector('.toolbar');
@@ -429,9 +430,9 @@ class SharedToolbar extends HTMLElement {
               <option value="mastare">Mästare</option>
               <option value="triple">Novis/Gesäll/Mästare</option>
             </select>
-            <textarea id="customLevelNovis" placeholder="Novis"></textarea>
-            <textarea id="customLevelGesall" placeholder="Gesäll"></textarea>
-            <textarea id="customLevelMastare" placeholder="Mästare"></textarea>
+            <textarea id="customLevelNovis" class="auto-resize" placeholder="Novis"></textarea>
+            <textarea id="customLevelGesall" class="auto-resize" placeholder="Gesäll"></textarea>
+            <textarea id="customLevelMastare" class="auto-resize" placeholder="Mästare"></textarea>
           </div>
           <div id="customPowerFields" class="filter-group" style="display:none">
             <label>Förmågor</label>
@@ -462,7 +463,7 @@ class SharedToolbar extends HTMLElement {
             <input id="customSkilling" type="number" min="0" placeholder="Skilling">
             <input id="customOrtegar" type="number" min="0" placeholder="Örtegar">
           </div>
-          <textarea id="customDesc" placeholder="Beskrivning"></textarea>
+          <textarea id="customDesc" class="auto-resize" placeholder="Beskrivning"></textarea>
           <button id="customAdd" class="char-btn" type="button">Spara</button>
           <button id="customDelete" class="char-btn danger" type="button" style="display:none">Radera</button>
           <button id="customCancel" class="char-btn danger" type="button">Avbryt</button>

--- a/summary.html
+++ b/summary.html
@@ -28,6 +28,7 @@
       flex: 1 1 auto;
     }
   </style>
+  <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>
   <script src="js/utils.js" defer></script>
   <script src="js/store.js" defer></script>

--- a/traits.html
+++ b/traits.html
@@ -9,6 +9,7 @@
   <title>Symbapedia - Egenskaper</title>
 
   <link rel="stylesheet" href="css/style.css">
+  <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>
   <script src="js/utils.js" defer></script>
   <script src="js/store.js" defer></script>


### PR DESCRIPTION
## Summary
- load the auto-resize helper on each page that embeds the shared toolbar
- mark shared-toolbar popup textareas for automatic resizing and initialize them after render
- trigger auto-resize when opening the custom item popup and when adding power description rows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d78a453754832380b23a58911539c6