### PR TITLE
Add shadow DOM icon sizing styles for shared toolbar

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -179,6 +179,27 @@ class SharedToolbar extends HTMLElement {
         .button-row .char-btn.icon-only {
           padding: .55rem 1.1rem;
         }
+        .btn-icon {
+          width: 1.8rem;
+          height: 1.8rem;
+          max-width: 100%;
+          max-height: 100%;
+          display: block;
+          pointer-events: none;
+          object-fit: contain;
+        }
+        .char-btn.icon .btn-icon {
+          width: 1.8rem;
+          height: 1.8rem;
+        }
+        .char-btn.icon-only .btn-icon {
+          width: 2rem;
+          height: 2rem;
+        }
+        .party-toggle .btn-icon {
+          width: 1.85rem;
+          height: 1.85rem;
+        }
         .button-row .nav-link.active {
           background: var(--neutral);
           color: #1d2118;


### PR DESCRIPTION
## Summary
- add icon sizing rules to the shared toolbar shadow DOM so icons match global stylesheet values
- ensure icons use block display and object-fit containment before the main CSS loads

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8eca65e9883239180d35c5b415899