### PR TITLE
Set default icon dimensions for toolbar buttons

### DIFF
--- a/character.html
+++ b/character.html
@@ -44,10 +44,10 @@
     <div class="panel-header">
       <h2 id="charName" style="margin:0;"></h2>
       <div class="header-actions">
-        <button id="clearNonInv" class="char-btn icon danger" title="Rensa allt utom inventariet"><img src="icons/broom.svg" alt="" class="btn-icon"></button>
-        <a href="notes.html" id="notesLink" class="char-btn icon" title="Anteckningar"><img src="icons/anteckningar.svg" alt="" class="btn-icon"></a>
-        <a id="effectsToggle" class="char-btn icon" href="effects.html" title="Visa effekter"><img src="icons/effects.svg" alt="" class="btn-icon"></a>
-        <a id="summaryToggle" class="char-btn icon summary-btn" href="summary.html" title="Visa översikt"><img src="icons/overview.svg" alt="" class="btn-icon"></a>
+        <button id="clearNonInv" class="char-btn icon danger" title="Rensa allt utom inventariet"><img src="icons/broom.svg" alt="" class="btn-icon" width="32" height="32"></button>
+        <a href="notes.html" id="notesLink" class="char-btn icon" title="Anteckningar"><img src="icons/anteckningar.svg" alt="" class="btn-icon" width="32" height="32"></a>
+        <a id="effectsToggle" class="char-btn icon" href="effects.html" title="Visa effekter"><img src="icons/effects.svg" alt="" class="btn-icon" width="32" height="32"></a>
+        <a id="summaryToggle" class="char-btn icon summary-btn" href="summary.html" title="Visa översikt"><img src="icons/overview.svg" alt="" class="btn-icon" width="32" height="32"></a>
       </div>
     </div>
     <ul id="valda" class="card-list entry-card-list" data-entry-page="character"></ul>

--- a/js/utils.js
+++ b/js/utils.js
@@ -123,6 +123,14 @@
     const extraClass = opts.className ? ` ${opts.className}` : '';
     const alt = typeof opts.alt === 'string' ? opts.alt : '';
     const attrs = [];
+    const widthAttr = Object.prototype.hasOwnProperty.call(opts, 'width') ? opts.width : 32;
+    const heightAttr = Object.prototype.hasOwnProperty.call(opts, 'height') ? opts.height : 32;
+    if (widthAttr !== undefined && widthAttr !== null && widthAttr !== '') {
+      attrs.push(`width="${widthAttr}"`);
+    }
+    if (heightAttr !== undefined && heightAttr !== null && heightAttr !== '') {
+      attrs.push(`height="${heightAttr}"`);
+    }
     if (opts.loading) attrs.push(`loading="${opts.loading}"`);
     if (opts.decoding) attrs.push(`decoding="${opts.decoding}"`);
     const attrStr = attrs.length ? ` ${attrs.join(' ')}` : '';

--- a/notes.html
+++ b/notes.html
@@ -40,7 +40,7 @@
     <div class="panel-header">
       <h2 id="charName" style="margin:0;"></h2>
       <div class="header-actions">
-        <a href="character.html" id="charLink" class="char-btn icon icon-only" title="Till rollperson"><img src="icons/character.svg" alt="" class="btn-icon" data-icon-name="character"></a>
+        <a href="character.html" id="charLink" class="char-btn icon icon-only" title="Till rollperson"><img src="icons/character.svg" alt="" class="btn-icon" data-icon-name="character" width="32" height="32"></a>
         <button id="editBtn" class="char-btn icon" title="Redigera">✏️</button>
       </div>
     </div>

--- a/traits.html
+++ b/traits.html
@@ -59,11 +59,11 @@
             <span class="trait-xp-title">Erfarenhet</span>
             <div class="xp-control trait-xp-buttons">
               <button id="xpMinus" class="char-btn icon icon-only" type="button" aria-label="Minska XP" title="Minska XP">
-                <img src="icons/minus.svg" alt="" class="btn-icon">
+                <img src="icons/minus.svg" alt="" class="btn-icon" width="32" height="32">
               </button>
               <input id="xpInput" type="number" min="0" value="0" aria-label="Totala erfarenhetspoäng">
               <button id="xpPlus" class="char-btn icon icon-only" type="button" aria-label="Öka XP" title="Öka XP">
-                <img src="icons/plus.svg" alt="" class="btn-icon">
+                <img src="icons/plus.svg" alt="" class="btn-icon" width="32" height="32">
               </button>
             </div>
           </div>
@@ -91,7 +91,7 @@
               Karaktärsdrag: <span id="traitsTotal">0</span> / <span id="traitsMax">0</span>
             </div>
             <button id="resetTraits" class="char-btn icon icon-only danger traits-reset-btn" title="Återställ basegenskaper" aria-label="Återställ basegenskaper">
-              <img src="icons/broom.svg" alt="" class="btn-icon">
+              <img src="icons/broom.svg" alt="" class="btn-icon" width="32" height="32">
             </button>
           </div>
           <div id="traitStats" class="trait-extra-meta" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- add default width and height attributes to icons emitted by iconHtml with override support
- add matching dimensions to existing static btn-icon markup so buttons render consistently while styles load

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9085b87b48323b300c6cc5d69f77a