### PR TITLE
Update summary page styling to match theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -691,7 +691,7 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
 }
 
 body[data-role="summary"] {
-  background: #19130f;
+  background: var(--bg);
 }
 
 body[data-role="summary"] .app-title {
@@ -707,10 +707,10 @@ body[data-role="summary"] .app-title {
 body[data-role="summary"] .summary-panel {
   max-width: 440px;
   padding: 1.8rem 1.5rem 2rem;
-  background: #211a16;
+  background: var(--panel);
   border-radius: 1.55rem;
-  border: 1px solid rgba(255, 255, 255, .08);
-  box-shadow: 0 18px 48px rgba(0, 0, 0, .55);
+  border: 1.5px solid var(--border);
+  box-shadow: var(--shadow);
 }
 
 body[data-role="summary"] .summary-panel .panel-header {
@@ -729,11 +729,11 @@ body[data-role="summary"] .summary-content {
 }
 
 body[data-role="summary"] .summary-section {
-  background: rgba(26, 20, 16, .95);
-  border: 1px solid rgba(255, 255, 255, .08);
+  background: var(--card);
+  border: 1px solid var(--card-border);
   border-radius: 1.15rem;
   padding: 1.2rem 1.15rem 1.3rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .04), 0 14px 28px rgba(0, 0, 0, .32);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .04);
 }
 
 body[data-role="summary"] .summary-section h3 {
@@ -742,7 +742,7 @@ body[data-role="summary"] .summary-section h3 {
   font-weight: 600;
   letter-spacing: .18em;
   text-transform: uppercase;
-  color: rgba(235, 221, 200, .82);
+  color: var(--subtxt);
 }
 
 body[data-role="summary"] .summary-pairs {
@@ -758,13 +758,21 @@ body[data-role="summary"] .summary-pairs li {
   gap: .85rem;
   padding: .85rem 1rem;
   border-radius: 1rem;
-  border: 1px solid rgba(255, 255, 255, .08);
-  background: linear-gradient(140deg, rgba(35, 27, 22, .95), rgba(24, 18, 14, .92));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .05), 0 10px 22px rgba(0, 0, 0, .32);
+  border: 1px solid var(--card-border);
+  background: var(--card);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .04);
 }
 
 body[data-role="summary"] .summary-pairs li::before {
-  content: none;
+  content: '';
+  position: absolute;
+  top: .55rem;
+  bottom: .55rem;
+  left: .6rem;
+  width: .22rem;
+  border-radius: 1rem;
+  background: linear-gradient(90deg, rgba(185, 122, 82, .9), rgba(185, 122, 82, .45));
+  opacity: .95;
 }
 
 body[data-role="summary"] .summary-key {
@@ -773,13 +781,13 @@ body[data-role="summary"] .summary-key {
   text-transform: uppercase;
   letter-spacing: .16em;
   font-size: .7rem;
-  color: rgba(235, 221, 200, .72);
+  color: var(--subtxt);
 }
 
 body[data-role="summary"] .summary-value {
   flex: 0 0 auto;
   min-width: 0;
-  font-size: 1.35rem;
+  font-size: 1.2rem;
   font-weight: 700;
   letter-spacing: .04em;
   color: var(--txt);
@@ -809,13 +817,13 @@ body[data-role="summary"] .summary-pairs.layout-grid li {
 
 body[data-role="summary"] .summary-pairs.layout-grid .summary-key {
   flex: 0 0 auto;
-  color: rgba(235, 221, 200, .64);
+  color: var(--subtxt);
   letter-spacing: .18em;
 }
 
 body[data-role="summary"] .summary-pairs.layout-grid .summary-value {
   text-align: left;
-  font-size: 1.45rem;
+  font-size: 1.3rem;
 }
 
 body[data-role="summary"] .summary-pairs.layout-stack li {


### PR DESCRIPTION
## Summary
- use global palette variables on the summary page to match the rest of the site
- reduce the summary value font sizes for better visual balance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d97cee11248323b8303d64f12deef4