### PR TITLE
Adjust summary quick overview layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -771,8 +771,8 @@ body[data-role="summary"] .summary-pairs li::before {
   left: .6rem;
   width: .22rem;
   border-radius: 1rem;
-  background: linear-gradient(90deg, rgba(185, 122, 82, .9), rgba(185, 122, 82, .45));
-  opacity: .95;
+  background: rgba(185, 122, 82, .85);
+  opacity: 1;
 }
 
 body[data-role="summary"] .summary-key {
@@ -847,6 +847,14 @@ body[data-role="summary"] .summary-pairs.layout-block li {
   padding: .95rem 1.05rem;
   font-size: .95rem;
   line-height: 1.45;
+}
+
+body[data-role="summary"] .summary-section.quick-overview .summary-pairs {
+  gap: .55rem;
+}
+
+body[data-role="summary"] .summary-section.quick-overview .summary-pairs li {
+  padding: .75rem .9rem;
 }
 
 body[data-role="summary"] .summary-chip {

--- a/js/summary-effects.js
+++ b/js/summary-effects.js
@@ -583,6 +583,21 @@
 
     const summarySections = [];
 
+    const quickOverviewRows = [
+      createListRow('Raser', gatherEntries('Ras'), { max: Infinity }),
+      createListRow('Yrken', gatherEntries('Yrke'), { max: Infinity }),
+      createListRow('Elityrken', gatherEntries('Elityrke'), { max: Infinity })
+    ].filter(Boolean);
+
+    if (quickOverviewRows.length) {
+      summarySections.push({
+        title: 'Snabböversikt',
+        layout: 'stack',
+        items: quickOverviewRows,
+        sectionClass: 'quick-overview'
+      });
+    }
+
     summarySections.push({
       title: 'Karaktärsdrag',
       items: KEYS.map(key => ({
@@ -637,20 +652,6 @@
       ]
     });
 
-    const quickOverviewRows = [
-      createListRow('Raser', gatherEntries('Ras'), { max: Infinity }),
-      createListRow('Yrken', gatherEntries('Yrke'), { max: Infinity }),
-      createListRow('Elityrken', gatherEntries('Elityrke'), { max: Infinity })
-    ].filter(Boolean);
-
-    if (quickOverviewRows.length) {
-      summarySections.push({
-        title: 'Snabböversikt',
-        layout: 'stack',
-        items: quickOverviewRows
-      });
-    }
-
     const categorySections = [
       { title: 'Förmågor', types: 'Förmåga' },
       { title: 'Mystiska krafter', types: 'Mystisk kraft' },
@@ -684,6 +685,17 @@
       const listClasses = ['summary-list', 'summary-pairs'];
       if (section.layout) listClasses.push(`layout-${section.layout}`);
       const showColon = section.layout !== 'grid';
+      const sectionClasses = ['summary-section'];
+      if (section.sectionClass) {
+        if (Array.isArray(section.sectionClass)) {
+          section.sectionClass.filter(Boolean).forEach(cls => sectionClasses.push(cls));
+        } else {
+          sectionClasses.push(section.sectionClass);
+        }
+      }
+      if (Array.isArray(section.sectionClasses)) {
+        section.sectionClasses.filter(Boolean).forEach(cls => sectionClasses.push(cls));
+      }
       const items = (section.items || []).map(row => {
         if (row.text) {
           return `<li>${escapeHtml(row.text)}</li>`;
@@ -717,7 +729,7 @@
         const valueText = row.value === null || row.value === undefined ? '–' : String(row.value);
         return `<li><span class="summary-key">${escapeHtml(labelText)}</span><span class="${classNames.join(' ')}">${escapeHtml(valueText)}</span></li>`;
       }).join('');
-      return `<section class="summary-section"><h3>${escapeHtml(section.title)}</h3><ul class="${listClasses.join(' ')}">${items}</ul></section>`;
+      return `<section class="${sectionClasses.join(' ')}"><h3>${escapeHtml(section.title)}</h3><ul class="${listClasses.join(' ')}">${items}</ul></section>`;
     }).join('');
 
     return sectionsHtml;


### PR DESCRIPTION
## Summary
- Move the quick overview section to render before other summary groups and support targeted styling hooks.
- Refresh summary card visuals by replacing the side gradient with a solid accent and tightening spacing in the quick overview stack.

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d987f46f9c8323a4c8ee0079f7c7b1