### PR TITLE
Replace emoji indicators with SVG icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ I panelen som öppnas med `⚙️` finns flera viktiga knappar:
 ### 5. Inventariepanelen
 Via `🎒` kommer du åt allt du har samlat på dig.
 - **Kategori** låter dig filtrera inventarielistan på typ av utrustning.
-- Under **Verktyg** hittar du knappar för **🆕**, **💰**, **🧹** och **x²** för att lägga till flera av samma föremål. Om föremålet inte kan staplas skapas nya fält.
+- Under **Verktyg** hittar du knappar för **🆕**, **<img src="icons/basket.svg" alt="Pengar" width="18" height="18">**, **🧹** och **x²** för att lägga till flera av samma föremål. Om föremålet inte kan staplas skapas nya fält.
 I listan för varje föremål finns knappar för att öka/minska antal, markera som gratis, redigera kvaliteter och mer.
 
 ### 6. Egenskapssidorna

--- a/css/style.css
+++ b/css/style.css
@@ -235,6 +235,13 @@ h1, h2, h3 { margin: 0 0 .8rem; font-weight: 700; }
   height: 1.55rem;
 }
 
+.btn-icon.title-icon {
+  width: 1.35rem;
+  height: 1.35rem;
+  display: inline-block;
+  vertical-align: middle;
+}
+
 .icon-only {
   font-size: 0 !important;
   line-height: 0;

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -2407,7 +2407,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     const functionsCard = createEntryCard({
       compact: !functionsOpen,
       dataset: { special: '__invfunc__' },
-      nameHtml: 'Inventarie 💰',
+      nameHtml: `Inventarie ${icon('basket', { className: 'title-icon', alt: 'Inventarie' })}`,
       descHtml: `<div class="card-desc"><div class="inv-buttons">${allFunctionButtons.join('')}</div></div>`,
       collapsible: true
     });
@@ -2438,7 +2438,7 @@ function openVehiclePopup(preselectId, precheckedPaths) {
     const infoCard = createEntryCard({
       compact: !infoOpen,
       dataset: { special: infoKey },
-      nameHtml: 'Information 🔎',
+      nameHtml: `Information ${icon('money-bag', { className: 'title-icon', alt: 'Information' })}`,
       descHtml: `<div class="card-desc">${infoCardDesc}</div>`,
       collapsible: true
     });

--- a/js/main.js
+++ b/js/main.js
@@ -430,7 +430,7 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
     { id: 'open-effects',    label: 'Effekter',     sel: '#effectsToggle, #traitsTabEffects', panel: null,         emoji: '📚',
       syn: ['effekter','visa effekter','sammanställning effekter','sammanstallning effekter'] },
 
-    // Inställningar 💡 (Filter → Inställningar)
+    // Inställningar (Filter → Inställningar, lamp-ikon)
     { id: 'settings-smith',   label: 'Smed i partyt',        sel: '#partySmith',      panel: 'filterPanel', emoji: '⚒️', syn: ['smed','smed i partyt','smed nivå'] },
     { id: 'settings-alch',    label: 'Alkemist i partyt',    sel: '#partyAlchemist',  panel: 'filterPanel', emoji: '⚗️', syn: ['alkemist','alkemist i partyt'] },
     { id: 'settings-art',     label: 'Artefaktmakare i partyt', sel: '#partyArtefacter', panel: 'filterPanel', emoji: '🏺', icon: 'artefakt', syn: ['artefaktmakare','artefaktare'] },
@@ -440,9 +440,9 @@ const shouldBypassShowOpenFilePickerMulti = (() => {
     { id: 'settings-help',    label: 'Hjälp',                sel: '#infoToggle',      panel: 'filterPanel', emoji: 'ℹ️',
       syn: ['hjälp','info','information','behöver du hjälp','behover du hjalp'] },
 
-    // Inventarie → Verktyg 🧰
+    // Inventarie → Verktyg (verktygslåda-ikon)
     { id: 'inv-new',     label: 'Nytt föremål',         sel: '#addCustomBtn',   panel: null, emoji: '🆕', syn: ['nytt föremål','eget föremål','skapa föremål'] },
-    { id: 'inv-money',   label: 'Hantera pengar',       sel: '#manageMoneyBtn', panel: null, emoji: '💰', syn: ['pengar','hantera pengar','money'] },
+    { id: 'inv-money',   label: 'Hantera pengar',       sel: '#manageMoneyBtn', panel: null, emoji: '', icon: 'basket', syn: ['pengar','hantera pengar','money'] },
     { id: 'inv-multi',   label: 'Multiplicera pris',    sel: '#multiPriceBtn',  panel: null, emoji: '💸', syn: ['multiplicera pris','pris'] },
     { id: 'inv-qty',     label: 'Lägg till antal',      sel: '#squareBtn',      panel: null, emoji: 'x²', syn: ['antal','lägg till antal'] },
     { id: 'inv-vehicle', label: 'Lasta i',              sel: '[id^="vehicleBtn-"]', panel: null, emoji: '🛞', syn: ['lasta','lasta i','färdmedel','fordon'] },

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -309,7 +309,7 @@ class SharedToolbar extends HTMLElement {
 
         <ul class="card-list">
           <li class="card" data-special="__formal__" id="filterFormalCard">
-            <div class="card-title"><span><span class="collapse-btn"></span>Verktyg 🧰</span></div>
+            <div class="card-title"><span><span class="collapse-btn"></span>Verktyg ${icon('tool-box', { className: 'title-icon', alt: 'Verktyg' })}</span></div>
             <div class="card-desc">
               <!-- Välj rollperson och Aktiv mapp -->
               <div class="filter-group">
@@ -352,7 +352,7 @@ class SharedToolbar extends HTMLElement {
             </div>
           </li>
           <li class="card" data-special="__formal__" id="filterSettingsCard">
-            <div class="card-title"><span><span class="collapse-btn"></span>Inställningar 💡</span></div>
+            <div class="card-title"><span><span class="collapse-btn"></span>Inställningar ${icon('lamp', { className: 'title-icon', alt: 'Inställningar' })}</span></div>
             <div class="card-desc">
               <!-- Grupp med partymedlemmar och vy-knappar -->
               <div class="filter-group party-toggles">
@@ -987,7 +987,7 @@ class SharedToolbar extends HTMLElement {
               <li>Sök i inventarie: Filtrerar föremål i realtid.</li>
               <li>▶/▼ Öppna eller kollapsa alla.</li>
               <li>🔀 Dra-och-släpp-läge för att ändra ordning.</li>
-              <li>🆕 Eget föremål. 💰 Pengar (Spara/Addera/Nollställ; ${icon('minus')}/${icon('plus')} justerar 1 daler).</li>
+              <li>🆕 Eget föremål. ${icon('basket', { className: 'title-icon', alt: 'Pengar' })} Pengar (Spara/Addera/Nollställ; ${icon('minus')}/${icon('plus')} justerar 1 daler).</li>
               <li>💸 Multiplicera pris på markerade rader; klick på pris öppnar snabbmeny (×0.5, ×1, ×1.5, ×2).</li>
               <li>🔒 Spara inventarie och markera alla befintliga föremål som gratis. ${icon('broom')} Töm inventariet.</li>
               <li>x² Lägg till flera av samma. Icke-staplingsbara får egna fält.</li>


### PR DESCRIPTION
## Summary
- replace the filter panel headings and inventory help text emojis with dedicated SVG icons
- swap the inventory functions and info cards to use basket and money-bag icons via iconHtml helpers
- adjust button icon styling and documentation to reflect the new SVG usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d98eec457483238f53ad006f2d7e5f