### PR TITLE
Add iOS web app meta tags to HTML pages

### DIFF
--- a/character.html
+++ b/character.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Symbapedia">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">

--- a/effects.html
+++ b/effects.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Symbapedia">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">

--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Symbapedia">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">

--- a/inventory.html
+++ b/inventory.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Symbapedia">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">

--- a/notes.html
+++ b/notes.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Symbapedia">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">

--- a/summary.html
+++ b/summary.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Symbapedia">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">

--- a/traits.html
+++ b/traits.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Symbapedia">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">

--- a/webapp.html
+++ b/webapp.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Symbapedia">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">


### PR DESCRIPTION
## Summary
- add the iOS standalone web app meta tags to every HTML entry point
- define the apple-mobile-web-app title so the installed icon is labeled "Symbapedia"

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dab0994ee88323b2cfa756879f195f