### PR TITLE
Add preload visibility guard for main pages

### DIFF
--- a/character.html
+++ b/character.html
@@ -11,6 +11,8 @@
   <meta name="theme-color" content="#121416">
   <title>Symbapedia - Rollperson</title>
 
+  <style>html[data-preload] body { visibility:hidden; opacity:0; } html.is-ready body { visibility:visible; opacity:1; transition:opacity .2s; }</style>
+  <script>document.documentElement.dataset.preload = "true";</script>
   <link rel="stylesheet" href="css/style.css">
   <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>

--- a/effects.html
+++ b/effects.html
@@ -11,6 +11,8 @@
   <meta name="theme-color" content="#121416">
   <title>Symbapedia - Effekter</title>
 
+  <style>html[data-preload] body { visibility:hidden; opacity:0; } html.is-ready body { visibility:visible; opacity:1; transition:opacity .2s; }</style>
+  <script>document.documentElement.dataset.preload = "true";</script>
   <link rel="stylesheet" href="css/style.css">
   <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
   <meta name="theme-color" content="#121416">
   <title>Symbapedia</title>
 
+  <style>html[data-preload] body { visibility:hidden; opacity:0; } html.is-ready body { visibility:visible; opacity:1; transition:opacity .2s; }</style>
+  <script>document.documentElement.dataset.preload = "true";</script>
   <link rel="stylesheet" href="css/style.css">
   <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>

--- a/inventory.html
+++ b/inventory.html
@@ -11,6 +11,8 @@
   <meta name="theme-color" content="#121416">
   <title>Symbapedia - Inventarie</title>
 
+  <style>html[data-preload] body { visibility:hidden; opacity:0; } html.is-ready body { visibility:visible; opacity:1; transition:opacity .2s; }</style>
+  <script>document.documentElement.dataset.preload = "true";</script>
   <link rel="stylesheet" href="css/style.css">
   <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,11 @@
    2025-06-20
    =========================================================== */
 
+window.addEventListener('load', () => {
+  document.documentElement.classList.add('is-ready');
+  document.documentElement.removeAttribute('data-preload');
+});
+
 /* ---------- Back-navigering för menyer & popups ---------- */
 (function() {
   const overlayStack = [];

--- a/notes.html
+++ b/notes.html
@@ -11,6 +11,8 @@
   <meta name="theme-color" content="#121416">
   <title>Symbapedia - Anteckningar</title>
 
+  <style>html[data-preload] body { visibility:hidden; opacity:0; } html.is-ready body { visibility:visible; opacity:1; transition:opacity .2s; }</style>
+  <script>document.documentElement.dataset.preload = "true";</script>
   <link rel="stylesheet" href="css/style.css">
   <script src="js/text-format.js" defer></script>
   <script src="js/utils.js"          defer></script>

--- a/summary.html
+++ b/summary.html
@@ -11,6 +11,8 @@
   <meta name="theme-color" content="#121416">
   <title>Symbapedia - Översikt</title>
 
+  <style>html[data-preload] body { visibility:hidden; opacity:0; } html.is-ready body { visibility:visible; opacity:1; transition:opacity .2s; }</style>
+  <script>document.documentElement.dataset.preload = "true";</script>
   <link rel="stylesheet" href="css/style.css">
   <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>

--- a/traits.html
+++ b/traits.html
@@ -11,6 +11,8 @@
   <meta name="theme-color" content="#121416">
   <title>Symbapedia - Egenskaper</title>
 
+  <style>html[data-preload] body { visibility:hidden; opacity:0; } html.is-ready body { visibility:visible; opacity:1; transition:opacity .2s; }</style>
+  <script>document.documentElement.dataset.preload = "true";</script>
   <link rel="stylesheet" href="css/style.css">
   <script src="js/auto-resize.js" defer></script>
   <script src="js/text-format.js" defer></script>

--- a/webapp.html
+++ b/webapp.html
@@ -10,6 +10,8 @@
   <link rel="icon" href="icons/icon_DA">
   <meta name="theme-color" content="#121416">
   <title>Symbapedia - Installera som webapp</title>
+  <style>html[data-preload] body { visibility:hidden; opacity:0; } html.is-ready body { visibility:visible; opacity:1; transition:opacity .2s; }</style>
+  <script>document.documentElement.dataset.preload = "true";</script>
   <link rel="stylesheet" href="css/style.css">
   <style>
     main { max-width: 40rem; margin: 2rem auto; padding: 0 1rem; }


### PR DESCRIPTION
## Summary
- add a preload visibility guard style/script to each HTML entry point so pages stay hidden until the app is ready
- mark the document as ready on window load to fade in content after assets finish loading

## Testing
- not run (Safari/iOS environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db99d4df1c83239002583cce10bd81