### PR TITLE
Fix toolbar lift recalculation for iOS Safari

### DIFF
--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -61,11 +61,17 @@ class SharedToolbar extends HTMLElement {
         if (!lift) {
           const vvHeight = vv.height ?? 0;
           const vvPageTop = vv.pageTop ?? 0;
-          const layoutViewportHeight = this._largeViewportHeight ?? measureLayoutViewport();
+          let layoutViewportHeight = this._largeViewportHeight ?? measureLayoutViewport();
           lift = Math.max(0, layoutViewportHeight - (vvHeight + vvPageTop));
+          const offsetTop = vv.offsetTop ?? 0;
+
+          if (lift > 0 && offsetTop === 0) {
+            refreshLargeViewportHeight(true);
+            layoutViewportHeight = this._largeViewportHeight ?? measureLayoutViewport();
+            lift = Math.max(0, layoutViewportHeight - (vvHeight + vvPageTop));
+          }
 
           if (!lift) {
-            const offsetTop = vv.offsetTop ?? 0;
             lift = offsetTop > 0 ? offsetTop : 0;
           }
         }


### PR DESCRIPTION
## Summary
- refresh the cached large viewport height when visual viewport changes indicate Safari UI controls adjusting
- recompute the toolbar lift so the toolbar reattaches to the bottom when the lift resolves to zero

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db9a6429788323abe9323677d2b1a0