### PR TITLE
Ensure XP display uses per-purchase calculation

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1251,7 +1251,7 @@ function initCharacter() {
           traitInfo = `<p><strong>${label}:</strong> ${value}</p>`;
         }
         const curList = storeHelper.getCurrentList(store);
-        const xpVal = storeHelper.calcEntryXP(p, curList);
+        const xpVal = storeHelper.calcEntryDisplayXP(p, curList);
         let xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
         if (isElityrke(p)) xpText = `Minst ${eliteReq.minXP ? eliteReq.minXP(p, curList) : 50}`;
         const xpTag = `<span class="tag xp-cost">Erf: ${xpText}</span>`;

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -881,8 +881,9 @@ function initIndex() {
         }
         let infoBodyHtml = desc;
         if (infoBodyExtras.length) infoBodyHtml += infoBodyExtras.join('');
-        const xpSource = charEntry ? charEntry : { ...p, nivå: curLvl };
-        const xpVal = (isInv(p) || isEmployment(p) || isService(p)) ? null : storeHelper.calcEntryXP(xpSource, charList);
+        const xpVal = (isInv(p) || isEmployment(p) || isService(p))
+          ? null
+          : storeHelper.calcEntryDisplayXP(p, charList, { xpSource: charEntry, level: curLvl });
         let xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
         if (isElityrke(p)) xpText = `Minst ${eliteReq.minXP ? eliteReq.minXP(p, charList) : 50}`;
         const xpTag = (xpVal != null || isElityrke(p)) ? `<span class="tag xp-cost">Erf: ${xpText}</span>` : '';
@@ -1238,8 +1239,7 @@ function initIndex() {
       }
       let xpVal = null;
       if (!isInventory && !isEmployment(entry) && !isService(entry)) {
-        const xpSource = cardCharEntry ? cardCharEntry : { ...entry, nivå: curLvl };
-        xpVal = storeHelper.calcEntryXP(xpSource, charList);
+        xpVal = storeHelper.calcEntryDisplayXP(entry, charList, { xpSource: cardCharEntry, level: curLvl });
       }
       const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
       if (xpVal != null) card.dataset.xp = xpVal;
@@ -2360,7 +2360,7 @@ function initIndex() {
     const lvl = select.value;
     const xpVal = (isInv(p) || isEmployment(p) || isService(p))
       ? null
-      : storeHelper.calcEntryXP({ ...p, nivå:lvl }, list);
+      : storeHelper.calcEntryDisplayXP(p, list, { level: lvl });
     const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
     const liEl = select.closest('li');
     if (xpVal != null) liEl.dataset.xp = xpVal; else delete liEl.dataset.xp;


### PR DESCRIPTION
## Summary
- add a shared `calcEntryDisplayXP` helper that filters stacked entries before deferring to `calcEntryXP`
- update index view rendering and level-change paths to use the helper for consistent XP tags
- switch the character view to the helper so stacked cards show per-purchase XP values

## Testing
- Manual: Verified Arkivarie ×2 shows matching Erf: 5 in index and character views

------
https://chatgpt.com/codex/tasks/task_e_68dba528b998832385bbd575c4b078d4