### PR TITLE
Add entry card script to notes page

### DIFF
--- a/notes.html
+++ b/notes.html
@@ -24,6 +24,7 @@
   <script src="js/elite-req.js"   defer></script>
   <script src="js/pdf-library.js" defer></script>
   <script src="js/auto-resize.js" defer></script>
+  <script src="js/entry-card.js" defer></script>
   <script src="js/notes-view.js"  defer></script>
   <script src="js/jszip.min.js"   defer></script>
   <script src="js/main.js"        defer></script>


### PR DESCRIPTION
## Summary
- load the entry card factory script on notes.html before notes-view initialization

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbffb62f4c832384a97cfeb03fe6b7