### PR TITLE
Keep Hoppsan category pinned open

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1177,6 +1177,11 @@ input:focus, select:focus, textarea:focus {
   cursor: pointer;
 }
 
+.cat-group > details.hoppsan-group > summary {
+  cursor: default;
+  pointer-events: none;
+}
+
 .cat-group .card-list {
   margin-top: .6rem;
 }

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1092,9 +1092,8 @@ function initIndex() {
     {
       const hopLi = document.createElement('li');
       hopLi.className = 'cat-group';
-      const hopOpen = catState['Hoppsan'] !== undefined ? catState['Hoppsan'] : openCats.has('Hoppsan');
       hopLi.innerHTML = `
-        <details data-cat="Hoppsan"${hopOpen ? ' open' : ''}>
+        <details class="hoppsan-group" data-cat="Hoppsan" open>
           <summary>Hoppsan</summary>
           <ul class="card-list entry-card-list" data-entry-page="hoppsan"></ul>
         </details>`;
@@ -1111,10 +1110,15 @@ function initIndex() {
       const detailsEl = hopLi.querySelector('details');
       detailsEl.addEventListener('toggle', (ev) => {
         updateCatToggle();
+        if (!detailsEl.open) {
+          detailsEl.open = true;
+          return;
+        }
         if (!ev.isTrusted) return;
-        catState['Hoppsan'] = detailsEl.open;
+        catState['Hoppsan'] = true;
         saveState();
       });
+      catState['Hoppsan'] = true;
       fragment.appendChild(hopLi);
     }
     dom.lista.replaceChildren(fragment);
@@ -1559,7 +1563,10 @@ function initIndex() {
     if (catsMinimized) {
       details.forEach(d => { d.open = true; });
     } else {
-      details.forEach(d => { d.open = false; });
+      details.forEach(d => {
+        if (d.dataset.cat === 'Hoppsan') return;
+        d.open = false;
+      });
     }
     updateCatToggle();
   });


### PR DESCRIPTION
## Summary
- render the Hoppsan details panel with a dedicated class that always stays open and keeps its saved state true
- guard the global category toggle from collapsing Hoppsan and disable pointer interactions on its summary so it cannot close

## Testing
- playwright script verifying Hoppsan remains open

------
https://chatgpt.com/codex/tasks/task_e_68dccb8779188323b07319690141c9c1