### PR TITLE
Prevent Enter command activation when suggestions visible

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1604,7 +1604,8 @@ function initCharacter() {
       dom.sIn.blur();
       const termTry = (sTemp || '').trim();
       const term = sTemp.toLowerCase();
-      if (termTry && window.tryUICommand && window.tryUICommand(termTry)) {
+      const suggestionsActive = Boolean(sugEl && !sugEl.hidden && items.length);
+      if (!suggestionsActive && termTry && window.tryUICommand && window.tryUICommand(termTry)) {
         dom.sIn.value = '';
         sTemp = '';
         updateSearchDatalist();

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -1433,7 +1433,8 @@ function initIndex() {
       dom.sIn.blur();
       const termTry = (sTemp || '').trim();
       const term = sTemp.toLowerCase();
-      if (termTry && window.tryUICommand && window.tryUICommand(termTry)) {
+      const suggestionsActive = Boolean(sugEl && !sugEl.hidden && items.length);
+      if (!suggestionsActive && termTry && window.tryUICommand && window.tryUICommand(termTry)) {
         dom.sIn.value = '';
         sTemp = '';
         updateSearchDatalist();

--- a/js/inventory-view.js
+++ b/js/inventory-view.js
@@ -219,7 +219,8 @@
         input.blur();
         const termTry = (sTemp || '').trim();
         const term = termTry.toLowerCase();
-        if (termTry && window.tryUICommand && window.tryUICommand(termTry)) {
+        const suggestionsActive = Boolean(sugEl && !sugEl.hidden && items.length);
+        if (!suggestionsActive && termTry && window.tryUICommand && window.tryUICommand(termTry)) {
           if (input) input.value = '';
           sTemp = '';
           updateSearchDatalist();


### PR DESCRIPTION
## Summary
- guard the index view Enter handler so UI commands only trigger when no suggestions are visible
- apply the same suggestion-aware guard to the inventory and character search handlers for consistent behavior

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dccd4564d08323ae30ef5c3e7e5dd1