### PR TITLE
Ensure single-pick perks always show base XP

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -1252,7 +1252,7 @@ function initCharacter() {
         }
         const curList = storeHelper.getCurrentList(store);
         const xpVal = storeHelper.calcEntryDisplayXP(p, curList);
-        let xpText = xpVal < 0 ? `+${-xpVal}` : xpVal;
+        let xpText = storeHelper.formatEntryXPText(p, xpVal);
         if (isElityrke(p)) xpText = `Minst ${eliteReq.minXP ? eliteReq.minXP(p, curList) : 50}`;
         const xpTag = `<span class="tag xp-cost">Erf: ${xpText}</span>`;
         const typesList = Array.isArray(p.taggar?.typ) ? p.taggar.typ : [];

--- a/js/index-view.js
+++ b/js/index-view.js
@@ -884,7 +884,10 @@ function initIndex() {
         const xpVal = (isInv(p) || isEmployment(p) || isService(p))
           ? null
           : storeHelper.calcEntryDisplayXP(p, charList, { xpSource: charEntry, level: curLvl });
-        let xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
+        let xpText = '';
+        if (xpVal != null) {
+          xpText = storeHelper.formatEntryXPText(p, xpVal);
+        }
         if (isElityrke(p)) xpText = `Minst ${eliteReq.minXP ? eliteReq.minXP(p, charList) : 50}`;
         const xpTag = (xpVal != null || isElityrke(p)) ? `<span class="tag xp-cost">Erf: ${xpText}</span>` : '';
         const renderFilterTag = (tag, extra = '') => `<span class="tag filter-tag" data-section="${tag.section}" data-val="${tag.value}"${extra}>${tag.label}</span>`;
@@ -1245,7 +1248,10 @@ function initIndex() {
       if (!isInventory && !isEmployment(entry) && !isService(entry)) {
         xpVal = storeHelper.calcEntryDisplayXP(entry, charList, { xpSource: cardCharEntry, level: curLvl });
       }
-      const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
+      let xpText = '';
+      if (xpVal != null) {
+        xpText = storeHelper.formatEntryXPText(entry, xpVal);
+      }
       if (xpVal != null) card.dataset.xp = xpVal;
       else delete card.dataset.xp;
       const xpSpan = card.querySelector('.entry-header-xp .entry-xp-value');
@@ -2369,7 +2375,10 @@ function initIndex() {
     const xpVal = (isInv(p) || isEmployment(p) || isService(p))
       ? null
       : storeHelper.calcEntryDisplayXP(p, list, { level: lvl });
-    const xpText = xpVal != null ? (xpVal < 0 ? `+${-xpVal}` : xpVal) : '';
+    let xpText = '';
+    if (xpVal != null) {
+      xpText = storeHelper.formatEntryXPText(p, xpVal);
+    }
     const liEl = select.closest('li');
     if (xpVal != null) liEl.dataset.xp = xpVal; else delete liEl.dataset.xp;
     const xpSpan = liEl.querySelector('.entry-header-xp .entry-xp-value');

--- a/js/store.js
+++ b/js/store.js
@@ -1648,6 +1648,31 @@ function defaultTraits() {
     return calcEntryXP(xpSource, workingList);
   }
 
+  function singlePickAdvantageInfo(entry) {
+    if (!entry || typeof entry !== 'object') return null;
+    if (entry.kan_införskaffas_flera_gånger) return null;
+    const types = Array.isArray(entry?.taggar?.typ)
+      ? entry.taggar.typ.map(t => String(t).trim().toLowerCase())
+      : [];
+    if (!types.length) return null;
+    const isAdv = types.includes('fördel');
+    const isDis = types.includes('nackdel');
+    if (!isAdv && !isDis) return null;
+    return { isAdv, isDis };
+  }
+
+  function formatEntryXPText(entry, xpVal) {
+    if (xpVal === undefined || xpVal === null) return '';
+    if (typeof xpVal === 'number') {
+      const singleInfo = singlePickAdvantageInfo(entry);
+      if (singleInfo) {
+        return singleInfo.isDis ? '+5' : '5';
+      }
+      return xpVal < 0 ? `+${-xpVal}` : String(xpVal);
+    }
+    return String(xpVal);
+  }
+
   function calcTotalXP(baseXp, list) {
     return Number(baseXp || 0) + disadvantagesWithXP(list).length * 5;
   }
@@ -2235,6 +2260,7 @@ function defaultTraits() {
     calcUsedXP,
     calcEntryXP,
     calcEntryDisplayXP,
+    formatEntryXPText,
     calcTotalXP,
     countDisadvantages,
     calcPermanentCorruption,

--- a/js/summary-effects.js
+++ b/js/summary-effects.js
@@ -790,7 +790,7 @@
     if (window.isElityrke?.(entry) && window.eliteReq?.minXP) {
       xpText = `Minst ${window.eliteReq.minXP(entry, list)}`;
     } else if (typeof xpRaw === 'number') {
-      xpText = xpRaw < 0 ? `+${-xpRaw}` : xpRaw;
+      xpText = storeHelper.formatEntryXPText(entry, xpRaw);
     } else if (entry.xp !== undefined && entry.xp !== null) {
       xpText = entry.xp;
     }


### PR DESCRIPTION
## Summary
- add a shared helper that formats XP text so single-pick advantages and disadvantages always show 5/+5
- update index, character, and summary views to use the helper for XP tags

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcce2465008323a904c9ac29dea877