### PR TITLE
Fix manual adjustment increments and hide summary outputs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1095,12 +1095,6 @@ body[data-role="summary"] .summary-value.neg {
   word-break: break-word;
 }
 
-#filterSettingsCard .manual-adjust-summary {
-  font-size: .9rem;
-  color: var(--subtxt);
-  margin: .2rem 0 .8rem;
-}
-
 /* Grupp för partytillhörighet */
 .party-toggles {
   padding: 0;

--- a/js/main.js
+++ b/js/main.js
@@ -292,7 +292,6 @@ const dom  = {
   entryViewToggle: getDom('entryViewToggle'),
   infoToggle: getDom('infoToggle'),
   manualBtn: getDom('manualAdjustBtn'),
-  manualSummary: getDom('manualAdjustSummary'),
 
   /* element i main-DOM */
   active : getDom('activeFilters'),
@@ -2218,12 +2217,12 @@ function openManualAdjustPopup() {
   }
 
   function onAction(e) {
-    const btn = e.target.closest('button[data-type][data-delta]');
+    const btn = e.target.closest('button[data-type][data-direction]');
     if (!btn) return;
     e.preventDefault();
     const type = btn.dataset.type;
-    const rawDelta = Number(btn.dataset.delta);
-    const delta = Number.isFinite(rawDelta) ? (rawDelta > 0 ? 1 : rawDelta < 0 ? -1 : 0) : 0;
+    const dir = btn.dataset.direction;
+    const delta = dir === 'increase' ? 1 : dir === 'decrease' ? -1 : 0;
     if (!type || delta === 0 || !store || !store.current) return;
     applyUpdate(next => {
       if (type === 'corruption') {
@@ -3232,34 +3231,17 @@ function manualAdjustmentSummaryText(manual) {
 
 function syncManualAdjustButton() {
   const baseTitle = 'Hantera manuella justeringar för korruption och erfarenhet';
-  if (!dom.manualBtn && !dom.manualSummary) return;
+  if (!dom.manualBtn) return;
   if (!store || !store.current) {
-    if (dom.manualBtn) {
-      dom.manualBtn.classList.remove('active');
-      dom.manualBtn.title = baseTitle;
-    }
-    if (dom.manualSummary) {
-      dom.manualSummary.textContent = '';
-      dom.manualSummary.hidden = true;
-    }
+    dom.manualBtn.classList.remove('active');
+    dom.manualBtn.title = baseTitle;
     return;
   }
   const manual = getManualAdjustmentsSafe();
   const hasAdjustments = Boolean((manual.corruption || 0) || (manual.xp || 0));
   const summary = hasAdjustments ? manualAdjustmentSummaryText(manual) : '';
-  if (dom.manualBtn) {
-    dom.manualBtn.classList.toggle('active', hasAdjustments);
-    dom.manualBtn.title = summary ? `${baseTitle} (${summary})` : baseTitle;
-  }
-  if (dom.manualSummary) {
-    if (summary) {
-      dom.manualSummary.textContent = summary;
-      dom.manualSummary.hidden = false;
-    } else {
-      dom.manualSummary.textContent = '';
-      dom.manualSummary.hidden = true;
-    }
-  }
+  dom.manualBtn.classList.toggle('active', hasAdjustments);
+  dom.manualBtn.title = summary ? `${baseTitle} (${summary})` : baseTitle;
 }
 
 function updateXP() {

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -543,7 +543,6 @@ class SharedToolbar extends HTMLElement {
                   </li>
                 </ul>
               </div>
-              <div id="manualAdjustSummary" class="manual-adjust-summary" hidden></div>
             </div>
           </li>
         </ul>
@@ -696,8 +695,8 @@ class SharedToolbar extends HTMLElement {
                 <span id="manualCorruptionDisplay" class="manual-adjust-current">0</span>
               </div>
               <div class="manual-adjust-buttons manual-adjust-buttons--even">
-                <button class="char-btn" type="button" data-type="corruption" data-delta="-1">-1</button>
-                <button class="char-btn" type="button" data-type="corruption" data-delta="1">+1</button>
+                <button class="char-btn" type="button" data-type="corruption" data-direction="decrease">-1</button>
+                <button class="char-btn" type="button" data-type="corruption" data-direction="increase">+1</button>
               </div>
             </div>
             <div class="manual-adjust-row">
@@ -706,7 +705,7 @@ class SharedToolbar extends HTMLElement {
                 <span id="manualXpDisplay" class="manual-adjust-current">0</span>
               </div>
               <div class="manual-adjust-buttons manual-adjust-buttons--single">
-                <button class="char-btn" type="button" data-type="xp" data-delta="1">-1</button>
+                <button class="char-btn" type="button" data-type="xp" data-direction="decrease">-1</button>
               </div>
             </div>
           </div>

--- a/js/summary-effects.js
+++ b/js/summary-effects.js
@@ -621,19 +621,11 @@
       layout: 'grid'
     });
 
-    const manualXp = manualAdjust.xp || 0;
     const xpItems = [
       { label: 'Total XP', value: totalXPText },
       { label: 'Använt XP', value: usedXPText },
       { label: 'XP kvar', value: freeXPText, valueClass: freeXP < 0 ? 'neg' : '' }
     ];
-    if (manualXp) {
-      xpItems.splice(2, 0, {
-        label: 'Manuell justering',
-        value: formatSigned(-manualXp),
-        valueClass: manualXp > 0 ? 'neg' : manualXp < 0 ? 'pos' : ''
-      });
-    }
     summarySections.push({
       title: 'Erfarenhet',
       layout: 'grid',
@@ -658,19 +650,11 @@
       ]
     });
 
-    const manualCor = manualAdjust.corruption || 0;
     const corruptionItems = [
       { label: 'Maximal korruption', value: formatNumber(maxCor) },
       { label: 'Permanent korruption', value: formatNumber(perm) },
       { label: 'Korruptionströskel', value: formatNumber(thresh) }
     ];
-    if (manualCor) {
-      corruptionItems.splice(1, 0, {
-        label: 'Manuell justering',
-        value: formatSigned(manualCor),
-        valueClass: manualCor > 0 ? 'neg' : 'pos'
-      });
-    }
     summarySections.push({
       title: 'Korruption',
       items: corruptionItems


### PR DESCRIPTION
## Summary
- ensure manual adjustment buttons always change values by a single step and simplify the popup controls
- remove manual adjustment readouts from settings and summary views to keep them confined to the popup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de37ed2ca48323a13a144eedfbff77