### PR TITLE
Avoid stacking manual adjust popup listeners

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2184,6 +2184,12 @@ function openManualAdjustPopup() {
     if (xpOut)  xpOut.textContent  = formatSignedNumber(-manual.xp);
   };
 
+  refresh();
+
+  if (pop.classList.contains('open')) {
+    return;
+  }
+
   const applyUpdate = (updater) => {
     if (!store || !store.current) return;
     const manual = getManualAdjustmentsSafe();
@@ -2248,7 +2254,6 @@ function openManualAdjustPopup() {
     }
   }
 
-  refresh();
   pop.classList.add('open');
   if (inner) inner.scrollTop = 0;
   groups?.addEventListener('click', onAction);


### PR DESCRIPTION
## Summary
- refresh the manual adjustment popup values immediately before handling updates
- bail out when the popup is already open to prevent stacking duplicate event listeners

## Testing
- Manual Playwright script to open the manual adjustment popup repeatedly and exercise the ±1 controls

------
https://chatgpt.com/codex/tasks/task_e_68de3e1117648323a9cb6c2b047fcec4