### PR TITLE
Handle Reningskraft permanent corruption costs

### DIFF
--- a/data/formaga.json
+++ b/data/formaga.json
@@ -2028,9 +2028,9 @@
       }
     },
     "nivåer": {
-      "Novis": "Handling: Aktiv. Rollpersonen kan med ett lyckat Stark bli av med 1T4 temporär Korruption. Upprepade försök får göras, men endast ett lyckat försök per scen räknas.",
-      "Gesäll": "Handling: Aktiv. Som Novis men rensningen tar bort 1T6 temporär Korruption.",
-      "Mästare": "Handling: Aktiv. Som Gesäll men rollpersonens rensning tar bort 1T8 temporär Korruption."
+      "Novis": "Handling: Aktiv. Rollpersonen kan med ett lyckat Stark bli av med 1T4 temporär Korruption. Upprepade försök får göras, men endast ett lyckat försök per scen räknas. Kostnad: 1 permanent Korruption.",
+      "Gesäll": "Handling: Aktiv. Som Novis men rensningen tar bort 1T6 temporär Korruption. Kostnad: 2 permanent Korruption.",
+      "Mästare": "Handling: Aktiv. Som Gesäll men rollpersonens rensning tar bort 1T8 temporär Korruption. Kostnad: 3 permanent Korruption."
     }
   },
   {

--- a/js/store.js
+++ b/js/store.js
@@ -1452,6 +1452,11 @@ function defaultTraits() {
     let cor = 0;
     const isDwarf = list.some(x => x.namn === 'Dvärg' && (x.taggar?.typ || []).includes('Ras'));
     list.forEach(it => {
+      const levelValue = LEVEL_IDX[it.nivå || 'Novis'] || 0;
+      if (it.namn === 'Reningskraft') {
+        cor += levelValue;
+        return;
+      }
       const types = it.taggar?.typ || [];
       if (!['Mystisk kraft', 'Ritual'].some(t => types.includes(t))) return;
       if (isDwarf && types.includes('Mystisk kraft') && it.namn === 'Vedergällning') return;
@@ -1465,7 +1470,7 @@ function defaultTraits() {
         }
       });
       if (types.includes('Mystisk kraft')) {
-        const plvl = LEVEL_IDX[it.nivå || 'Novis'] || 1;
+        const plvl = levelValue || 1;
         if (plvl > lvl) cor += (plvl - lvl);
       } else if (types.includes('Ritual')) {
         if (lvl < 1) cor++;


### PR DESCRIPTION
## Summary
- ensure Reningskraft adds its level to permanent corruption and exits early in the calculator
- describe the permanent corruption cost per level in Reningskraft's ability text

## Testing
- Playwright verification script for Reningskraft corruption values

------
https://chatgpt.com/codex/tasks/task_e_68de4d0d0c988323bacf5016aa84f1ec