### PR TITLE
Add manual adjustments for toughness, pain, and capacity

### DIFF
--- a/js/character-view.js
+++ b/js/character-view.js
@@ -674,6 +674,9 @@ function initCharacter() {
       xp: (artifactEffects?.xp || 0) + (manualAdjust?.xp || 0),
       corruption: (artifactEffects?.corruption || 0) + (manualAdjust?.corruption || 0)
     };
+    const manualToughness = Number(manualAdjust?.toughness || 0);
+    const manualPain = Number(manualAdjust?.pain || 0);
+    const manualCapacity = Number(manualAdjust?.capacity || 0);
     const bonus = window.exceptionSkill ? exceptionSkill.getBonuses(list) : {};
     const maskBonus = window.maskSkill ? maskSkill.getBonuses(inv) : {};
     const KEYS = ['Diskret','Kvick','Listig','Stark','Träffsäker','Vaksam','Viljestark','Övertygande'];
@@ -704,11 +707,11 @@ function initCharacter() {
 
     const hasHardnackad = list.some(p=>p.namn==='Hårdnackad');
     const hasKraftprov = list.some(p=>p.namn==='Kraftprov');
-    const capacity = storeHelper.calcCarryCapacity(valStark, list);
+    const capacity = storeHelper.calcCarryCapacity(valStark, list) + manualCapacity;
     const hardy = hasHardnackad ? 1 : 0;
     const talBase = hasKraftprov ? valStark + 5 : Math.max(10, valStark);
-    const tal = talBase + hardy;
-    const pain = storeHelper.calcPainThreshold(valStark, list, effectsWithDark);
+    const tal = talBase + hardy + manualToughness;
+    const pain = storeHelper.calcPainThreshold(valStark, list, effectsWithDark) + manualPain;
 
     const defTrait = getDefenseTraitName(list);
     const kvickForDef = vals[defTrait];

--- a/js/inventory-utils.js
+++ b/js/inventory-utils.js
@@ -2316,11 +2316,13 @@ function openVehiclePopup(preselectId, precheckedPaths) {
       return s + (isVeh ? 0 : calcRowWeight(r));
     }, 0) + moneyWeight;
     const traits = storeHelper.getTraits(store);
+    const manualAdjust = storeHelper.getManualAdjustments(store) || {};
     const bonus = window.exceptionSkill ? exceptionSkill.getBonuses(list) : {};
     const maskBonus = window.maskSkill ? maskSkill.getBonuses(allInv) : {};
     const valStark = (traits['Stark']||0) + (bonus['Stark']||0) + (maskBonus['Stark']||0);
+    const manualCapacity = Number(manualAdjust.capacity || 0);
     const baseCap = storeHelper.calcCarryCapacity(valStark, list);
-    const maxCapacity = baseCap;
+    const maxCapacity = baseCap + manualCapacity;
     const remainingCap = maxCapacity - usedWeight;
 
     const capClassOf = (used, max) => {

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -708,6 +708,36 @@ class SharedToolbar extends HTMLElement {
                 <button class="char-btn" type="button" data-type="xp" data-direction="decrease">-1</button>
               </div>
             </div>
+            <div class="manual-adjust-row">
+              <div class="manual-adjust-label">
+                <span>Tålighet</span>
+                <span id="manualToughnessDisplay" class="manual-adjust-current">0</span>
+              </div>
+              <div class="manual-adjust-buttons manual-adjust-buttons--even">
+                <button class="char-btn" type="button" data-type="toughness" data-direction="decrease">-1</button>
+                <button class="char-btn" type="button" data-type="toughness" data-direction="increase">+1</button>
+              </div>
+            </div>
+            <div class="manual-adjust-row">
+              <div class="manual-adjust-label">
+                <span>Smärtgräns</span>
+                <span id="manualPainDisplay" class="manual-adjust-current">0</span>
+              </div>
+              <div class="manual-adjust-buttons manual-adjust-buttons--even">
+                <button class="char-btn" type="button" data-type="pain" data-direction="decrease">-1</button>
+                <button class="char-btn" type="button" data-type="pain" data-direction="increase">+1</button>
+              </div>
+            </div>
+            <div class="manual-adjust-row">
+              <div class="manual-adjust-label">
+                <span>Bärkapacitet</span>
+                <span id="manualCapacityDisplay" class="manual-adjust-current">0</span>
+              </div>
+              <div class="manual-adjust-buttons manual-adjust-buttons--even">
+                <button class="char-btn" type="button" data-type="capacity" data-direction="decrease">-1</button>
+                <button class="char-btn" type="button" data-type="capacity" data-direction="increase">+1</button>
+              </div>
+            </div>
           </div>
           <div class="manual-adjust-footer">
             <button id="manualAdjustReset" class="char-btn danger" type="button">Återställ</button>

--- a/js/store.js
+++ b/js/store.js
@@ -888,7 +888,13 @@
   }
 
   function defaultManualAdjustments() {
-    return { xp: 0, corruption: 0 };
+    return {
+      xp: 0,
+      corruption: 0,
+      toughness: 0,
+      pain: 0,
+      capacity: 0
+    };
   }
 
   function getMoney(store) {
@@ -1156,7 +1162,10 @@
     const manual = { ...defaultManualAdjustments(), ...(data.manualAdjustments || {}) };
     return {
       xp: Number(manual.xp || 0),
-      corruption: Number(manual.corruption || 0)
+      corruption: Number(manual.corruption || 0),
+      toughness: Number(manual.toughness || 0),
+      pain: Number(manual.pain || 0),
+      capacity: Number(manual.capacity || 0)
     };
   }
 
@@ -1166,6 +1175,9 @@
     const next = { ...defaultManualAdjustments(), ...(adj || {}) };
     next.xp = Number(next.xp || 0);
     next.corruption = Number(next.corruption || 0);
+    next.toughness = Number(next.toughness || 0);
+    next.pain = Number(next.pain || 0);
+    next.capacity = Number(next.capacity || 0);
     store.data[store.current].manualAdjustments = next;
     persistCurrentCharacter(store);
   }

--- a/js/summary-effects.js
+++ b/js/summary-effects.js
@@ -436,6 +436,9 @@
       xp: (artifactEffects.xp || 0) + (manualAdjust.xp || 0),
       corruption: (artifactEffects.corruption || 0) + (manualAdjust.corruption || 0)
     };
+    const manualToughness = Number(manualAdjust.toughness || 0);
+    const manualPain = Number(manualAdjust.pain || 0);
+    const manualCapacity = Number(manualAdjust.capacity || 0);
     const bonus = window.exceptionSkill ? exceptionSkill.getBonuses(list) : {};
     const maskBonus = window.maskSkill ? maskSkill.getBonuses(inv) : {};
     const formatNumber = (value, options = {}) => {
@@ -486,11 +489,11 @@
 
     const hasHardnackad = list.some(p=>p.namn==='Hårdnackad');
     const hasKraftprov = list.some(p=>p.namn==='Kraftprov');
-    const capacity = storeHelper.calcCarryCapacity(valStark, list);
+    const capacity = storeHelper.calcCarryCapacity(valStark, list) + manualCapacity;
     const hardy = hasHardnackad ? 1 : 0;
     const talBase = hasKraftprov ? valStark + 5 : Math.max(10, valStark);
-    const tal = talBase + hardy;
-    const pain = storeHelper.calcPainThreshold(valStark, list, effectsWithDark);
+    const tal = talBase + hardy + manualToughness;
+    const pain = storeHelper.calcPainThreshold(valStark, list, effectsWithDark) + manualPain;
 
     const defTrait = window.getDefenseTraitName ? getDefenseTraitName(list) : 'Kvick';
     const kvickForDef = vals[defTrait];

--- a/js/traits-utils.js
+++ b/js/traits-utils.js
@@ -157,6 +157,9 @@
       xp: (artifactEffects?.xp || 0) + (manualAdjust?.xp || 0),
       corruption: (artifactEffects?.corruption || 0) + (manualAdjust?.corruption || 0)
     };
+    const manualToughness = Number(manualAdjust?.toughness || 0);
+    const manualPain = Number(manualAdjust?.pain || 0);
+    const manualCapacity = Number(manualAdjust?.capacity || 0);
     const permBase = storeHelper.calcPermanentCorruption(list, combinedEffects);
     const hasEarth = list.some(p => p.namn === 'Jordnära');
     const bonus = window.exceptionSkill ? exceptionSkill.getBonuses(list) : {};
@@ -199,14 +202,15 @@
       if (k === 'Stark') {
         const hardy = hasHardnackad ? 1 : 0;
         const base = storeHelper.calcCarryCapacity(val, list);
+        const capacity = base + manualCapacity;
         const talBase = hasKraftprov ? val + 5 : Math.max(10, val);
-        const tal = talBase + hardy;
-        const pain = storeHelper.calcPainThreshold(val, list, effectsWithDark);
+        const tal = talBase + hardy + manualToughness;
+        const pain = storeHelper.calcPainThreshold(val, list, effectsWithDark) + manualPain;
 
-        
+
         extras.push(`Tålighet: ${tal}`)
         extras.push(` Smärtgräns: ${pain}`);
-        extras.push(`Bärkapacitet: ${formatWeight(base)}`);
+        extras.push(`Bärkapacitet: ${formatWeight(capacity)}`);
       } else if (k === 'Viljestark') {
         let perm = hasEarth ? (permBase % 2) : permBase;
         perm += darkPerm;


### PR DESCRIPTION
## Summary
- extend manual adjustment storage to include toughness, pain, and carry capacity offsets
- update the manual adjustment popup and summary tooltip to expose the new controls
- apply the new offsets when rendering character summaries, traits, effects, and inventory capacity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de57577e0483238321f41be25fc524