### PR TITLE
Improve manual adjustments popup styling and controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3007,10 +3007,9 @@ select.level {
   flex-direction: column;
   gap: 1rem;
 }
-#manualAdjustPopup .manual-adjust-row {
-  display: flex;
-  flex-direction: column;
-  gap: .4rem;
+#manualAdjustPopup .manual-adjust-card {
+  gap: .7rem;
+  padding: 1rem 1.2rem;
 }
 #manualAdjustPopup .manual-adjust-label {
   display: flex;
@@ -3024,22 +3023,12 @@ select.level {
   color: var(--accent);
 }
 #manualAdjustPopup .manual-adjust-buttons {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
   gap: .6rem;
-  flex-wrap: wrap;
-}
-#manualAdjustPopup .manual-adjust-buttons.manual-adjust-buttons--even button {
-  flex: 1 1 45%;
-}
-#manualAdjustPopup .manual-adjust-buttons.manual-adjust-buttons--single button {
-  flex: 0 0 auto;
-  min-width: 120px;
 }
 #manualAdjustPopup .manual-adjust-buttons button {
   width: 100%;
-}
-#manualAdjustPopup .manual-adjust-buttons.manual-adjust-buttons--single button {
-  width: auto;
 }
 #manualAdjustPopup .manual-adjust-footer {
   display: flex;

--- a/js/main.js
+++ b/js/main.js
@@ -2239,8 +2239,6 @@ function openManualAdjustPopup() {
     groups?.removeEventListener('click', onAction);
     closeBtn?.removeEventListener('click', onClose);
     resetBtn?.removeEventListener('click', onReset);
-    pop.removeEventListener('click', onOutside);
-    document.removeEventListener('keydown', onKey);
     window.registerOverlayCleanup?.(pop, null);
   }
 
@@ -2278,18 +2276,6 @@ function openManualAdjustPopup() {
     refresh();
   }
 
-  function onOutside(e) {
-    if (!inner || inner.contains(e.target)) return;
-    close();
-  }
-
-  function onKey(e) {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      close();
-    }
-  }
-
   window.registerOverlayCleanup?.(pop, close);
 
   pop.classList.add('open');
@@ -2297,8 +2283,6 @@ function openManualAdjustPopup() {
   groups?.addEventListener('click', onAction);
   closeBtn?.addEventListener('click', onClose);
   resetBtn?.addEventListener('click', onReset);
-  pop.addEventListener('click', onOutside);
-  document.addEventListener('keydown', onKey);
 }
 
 async function saveJsonFile(jsonText, suggested) {

--- a/js/shared-toolbar.js
+++ b/js/shared-toolbar.js
@@ -689,51 +689,52 @@ class SharedToolbar extends HTMLElement {
           <h3>Manuella justeringar</h3>
           <p class="manual-adjust-hint">Använd knapparna för att lägga till eller ta bort manuella ändringar. Erf påverkar endast spenderad erfarenhet.</p>
           <div class="manual-adjust-groups" id="manualAdjustGroups">
-            <div class="manual-adjust-row">
+            <div class="manual-adjust-card card">
               <div class="manual-adjust-label">
                 <span>Korruption</span>
                 <span id="manualCorruptionDisplay" class="manual-adjust-current">0</span>
               </div>
-              <div class="manual-adjust-buttons manual-adjust-buttons--even">
+              <div class="manual-adjust-buttons">
                 <button class="char-btn" type="button" data-type="corruption" data-direction="decrease">-1</button>
                 <button class="char-btn" type="button" data-type="corruption" data-direction="increase">+1</button>
               </div>
             </div>
-            <div class="manual-adjust-row">
+            <div class="manual-adjust-card card">
               <div class="manual-adjust-label">
                 <span>Erf</span>
                 <span id="manualXpDisplay" class="manual-adjust-current">0</span>
               </div>
-              <div class="manual-adjust-buttons manual-adjust-buttons--single">
+              <div class="manual-adjust-buttons">
                 <button class="char-btn" type="button" data-type="xp" data-direction="decrease">-1</button>
+                <button class="char-btn" type="button" data-type="xp" data-direction="increase">+1</button>
               </div>
             </div>
-            <div class="manual-adjust-row">
+            <div class="manual-adjust-card card">
               <div class="manual-adjust-label">
                 <span>Tålighet</span>
                 <span id="manualToughnessDisplay" class="manual-adjust-current">0</span>
               </div>
-              <div class="manual-adjust-buttons manual-adjust-buttons--even">
+              <div class="manual-adjust-buttons">
                 <button class="char-btn" type="button" data-type="toughness" data-direction="decrease">-1</button>
                 <button class="char-btn" type="button" data-type="toughness" data-direction="increase">+1</button>
               </div>
             </div>
-            <div class="manual-adjust-row">
+            <div class="manual-adjust-card card">
               <div class="manual-adjust-label">
                 <span>Smärtgräns</span>
                 <span id="manualPainDisplay" class="manual-adjust-current">0</span>
               </div>
-              <div class="manual-adjust-buttons manual-adjust-buttons--even">
+              <div class="manual-adjust-buttons">
                 <button class="char-btn" type="button" data-type="pain" data-direction="decrease">-1</button>
                 <button class="char-btn" type="button" data-type="pain" data-direction="increase">+1</button>
               </div>
             </div>
-            <div class="manual-adjust-row">
+            <div class="manual-adjust-card card">
               <div class="manual-adjust-label">
                 <span>Bärkapacitet</span>
                 <span id="manualCapacityDisplay" class="manual-adjust-current">0</span>
               </div>
-              <div class="manual-adjust-buttons manual-adjust-buttons--even">
+              <div class="manual-adjust-buttons">
                 <button class="char-btn" type="button" data-type="capacity" data-direction="decrease">-1</button>
                 <button class="char-btn" type="button" data-type="capacity" data-direction="increase">+1</button>
               </div>


### PR DESCRIPTION
## Summary
- wrap each manual adjustment statistic in card-styled sections and add a +1 button for experience
- keep the manual adjustments popup open until the close button is pressed so in-panel buttons no longer dismiss it

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68de5d511ee883238787f021a02e44d7