### PR TITLE
Fix disadvantage XP display after five burdens

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -1804,7 +1804,11 @@ function defaultTraits() {
     if (typeof xpVal === 'number') {
       const singleInfo = singlePickAdvantageInfo(entry);
       if (singleInfo) {
-        return singleInfo.isDis ? '+5' : '5';
+        if (singleInfo.isDis) {
+          const disXp = Math.max(0, -xpVal);
+          return `+${disXp}`;
+        }
+        return `${Math.max(0, xpVal)}`;
       }
       return xpVal < 0 ? `+${-xpVal}` : String(xpVal);
     }


### PR DESCRIPTION
## Summary
- ensure the single-pick disadvantage XP label reflects the actual calculated value
- stop showing +5 XP for burdens beyond the fifth, matching the underlying XP calculation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f86fa96483239cae4e2d4d0ff334